### PR TITLE
Rename apiImpl to APIClient - fixes #11

### DIFF
--- a/dropbox/auth/client.go
+++ b/dropbox/auth/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	TokenRevoke() (err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //TokenFromOauth1APIError is an error-wrapper for the token/from_oauth1 route
 type TokenFromOauth1APIError struct {
@@ -47,7 +47,7 @@ type TokenFromOauth1APIError struct {
 	EndpointError *TokenFromOAuth1Error `json:"error"`
 }
 
-func (dbx *apiImpl) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error) {
+func (dbx *APIClient) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -127,7 +127,7 @@ type TokenRevokeAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) TokenRevoke() (err error) {
+func (dbx *APIClient) TokenRevoke() (err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -187,7 +187,7 @@ func (dbx *apiImpl) TokenRevoke() (err error) {
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/dropbox/files/client.go
+++ b/dropbox/files/client.go
@@ -230,7 +230,7 @@ type Client interface {
 	UploadSessionStart(arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //AlphaGetMetadataAPIError is an error-wrapper for the alpha/get_metadata route
 type AlphaGetMetadataAPIError struct {
@@ -238,7 +238,7 @@ type AlphaGetMetadataAPIError struct {
 	EndpointError *AlphaGetMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
+func (dbx *APIClient) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -329,7 +329,7 @@ type AlphaUploadAPIError struct {
 	EndpointError *UploadErrorWithProperties `json:"error"`
 }
 
-func (dbx *apiImpl) AlphaUpload(arg *CommitInfoWithProperties, content io.Reader) (res *FileMetadata, err error) {
+func (dbx *APIClient) AlphaUpload(arg *CommitInfoWithProperties, content io.Reader) (res *FileMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -410,7 +410,7 @@ type CopyAPIError struct {
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) Copy(arg *RelocationArg) (res IsMetadata, err error) {
+func (dbx *APIClient) Copy(arg *RelocationArg) (res IsMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -501,7 +501,7 @@ type CopyBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+func (dbx *APIClient) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -581,7 +581,7 @@ type CopyBatchCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+func (dbx *APIClient) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -661,7 +661,7 @@ type CopyReferenceGetAPIError struct {
 	EndpointError *GetCopyReferenceError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
+func (dbx *APIClient) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -741,7 +741,7 @@ type CopyReferenceSaveAPIError struct {
 	EndpointError *SaveCopyReferenceError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
+func (dbx *APIClient) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -821,7 +821,7 @@ type CreateFolderAPIError struct {
 	EndpointError *CreateFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err error) {
+func (dbx *APIClient) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -901,7 +901,7 @@ type DeleteAPIError struct {
 	EndpointError *DeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) Delete(arg *DeleteArg) (res IsMetadata, err error) {
+func (dbx *APIClient) Delete(arg *DeleteArg) (res IsMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -992,7 +992,7 @@ type DeleteBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
+func (dbx *APIClient) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1072,7 +1072,7 @@ type DeleteBatchCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobStatus, err error) {
+func (dbx *APIClient) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1152,7 +1152,7 @@ type DownloadAPIError struct {
 	EndpointError *DownloadError `json:"error"`
 }
 
-func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error) {
+func (dbx *APIClient) Download(arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1228,7 +1228,7 @@ type GetMetadataAPIError struct {
 	EndpointError *GetMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
+func (dbx *APIClient) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1319,7 +1319,7 @@ type GetPreviewAPIError struct {
 	EndpointError *PreviewError `json:"error"`
 }
 
-func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
+func (dbx *APIClient) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1395,7 +1395,7 @@ type GetTemporaryLinkAPIError struct {
 	EndpointError *GetTemporaryLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
+func (dbx *APIClient) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1475,7 +1475,7 @@ type GetThumbnailAPIError struct {
 	EndpointError *ThumbnailError `json:"error"`
 }
 
-func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
+func (dbx *APIClient) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1551,7 +1551,7 @@ type ListFolderAPIError struct {
 	EndpointError *ListFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err error) {
+func (dbx *APIClient) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1631,7 +1631,7 @@ type ListFolderContinueAPIError struct {
 	EndpointError *ListFolderContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
+func (dbx *APIClient) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1711,7 +1711,7 @@ type ListFolderGetLatestCursorAPIError struct {
 	EndpointError *ListFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
+func (dbx *APIClient) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1791,7 +1791,7 @@ type ListFolderLongpollAPIError struct {
 	EndpointError *ListFolderLongpollError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
+func (dbx *APIClient) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1868,7 +1868,7 @@ type ListRevisionsAPIError struct {
 	EndpointError *ListRevisionsError `json:"error"`
 }
 
-func (dbx *apiImpl) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
+func (dbx *APIClient) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1948,7 +1948,7 @@ type MoveAPIError struct {
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) Move(arg *RelocationArg) (res IsMetadata, err error) {
+func (dbx *APIClient) Move(arg *RelocationArg) (res IsMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2039,7 +2039,7 @@ type MoveBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+func (dbx *APIClient) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2119,7 +2119,7 @@ type MoveBatchCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+func (dbx *APIClient) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2199,7 +2199,7 @@ type PermanentlyDeleteAPIError struct {
 	EndpointError *DeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) PermanentlyDelete(arg *DeleteArg) (err error) {
+func (dbx *APIClient) PermanentlyDelete(arg *DeleteArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2274,7 +2274,7 @@ type PropertiesAddAPIError struct {
 	EndpointError *AddPropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesAdd(arg *PropertyGroupWithPath) (err error) {
+func (dbx *APIClient) PropertiesAdd(arg *PropertyGroupWithPath) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2349,7 +2349,7 @@ type PropertiesOverwriteAPIError struct {
 	EndpointError *InvalidPropertyGroupError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesOverwrite(arg *PropertyGroupWithPath) (err error) {
+func (dbx *APIClient) PropertiesOverwrite(arg *PropertyGroupWithPath) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2424,7 +2424,7 @@ type PropertiesRemoveAPIError struct {
 	EndpointError *RemovePropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
+func (dbx *APIClient) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2499,7 +2499,7 @@ type PropertiesTemplateGetAPIError struct {
 	EndpointError *properties.PropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateGet(arg *properties.GetPropertyTemplateArg) (res *properties.GetPropertyTemplateResult, err error) {
+func (dbx *APIClient) PropertiesTemplateGet(arg *properties.GetPropertyTemplateArg) (res *properties.GetPropertyTemplateResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2579,7 +2579,7 @@ type PropertiesTemplateListAPIError struct {
 	EndpointError *properties.PropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateList() (res *properties.ListPropertyTemplateIds, err error) {
+func (dbx *APIClient) PropertiesTemplateList() (res *properties.ListPropertyTemplateIds, err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -2649,7 +2649,7 @@ type PropertiesUpdateAPIError struct {
 	EndpointError *UpdatePropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesUpdate(arg *UpdatePropertyGroupArg) (err error) {
+func (dbx *APIClient) PropertiesUpdate(arg *UpdatePropertyGroupArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2724,7 +2724,7 @@ type RestoreAPIError struct {
 	EndpointError *RestoreError `json:"error"`
 }
 
-func (dbx *apiImpl) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
+func (dbx *APIClient) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2804,7 +2804,7 @@ type SaveUrlAPIError struct {
 	EndpointError *SaveUrlError `json:"error"`
 }
 
-func (dbx *apiImpl) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
+func (dbx *APIClient) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2884,7 +2884,7 @@ type SaveUrlCheckJobStatusAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobStatus, err error) {
+func (dbx *APIClient) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2964,7 +2964,7 @@ type SearchAPIError struct {
 	EndpointError *SearchError `json:"error"`
 }
 
-func (dbx *apiImpl) Search(arg *SearchArg) (res *SearchResult, err error) {
+func (dbx *APIClient) Search(arg *SearchArg) (res *SearchResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3044,7 +3044,7 @@ type UploadAPIError struct {
 	EndpointError *UploadError `json:"error"`
 }
 
-func (dbx *apiImpl) Upload(arg *CommitInfo, content io.Reader) (res *FileMetadata, err error) {
+func (dbx *APIClient) Upload(arg *CommitInfo, content io.Reader) (res *FileMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3125,7 +3125,7 @@ type UploadSessionAppendAPIError struct {
 	EndpointError *UploadSessionLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Reader) (err error) {
+func (dbx *APIClient) UploadSessionAppend(arg *UploadSessionCursor, content io.Reader) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3201,7 +3201,7 @@ type UploadSessionAppendV2APIError struct {
 	EndpointError *UploadSessionLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content io.Reader) (err error) {
+func (dbx *APIClient) UploadSessionAppendV2(arg *UploadSessionAppendArg, content io.Reader) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3277,7 +3277,7 @@ type UploadSessionFinishAPIError struct {
 	EndpointError *UploadSessionFinishError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
+func (dbx *APIClient) UploadSessionFinish(arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3358,7 +3358,7 @@ type UploadSessionFinishBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
+func (dbx *APIClient) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3438,7 +3438,7 @@ type UploadSessionFinishBatchCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
+func (dbx *APIClient) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3518,7 +3518,7 @@ type UploadSessionStartAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
+func (dbx *APIClient) UploadSessionStart(arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3594,7 +3594,7 @@ func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Re
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/dropbox/paper/client.go
+++ b/dropbox/paper/client.go
@@ -95,7 +95,7 @@ type Client interface {
 	DocsUsersRemove(arg *RemovePaperDocUser) (err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //DocsArchiveAPIError is an error-wrapper for the docs/archive route
 type DocsArchiveAPIError struct {
@@ -103,7 +103,7 @@ type DocsArchiveAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsArchive(arg *RefPaperDoc) (err error) {
+func (dbx *APIClient) DocsArchive(arg *RefPaperDoc) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -178,7 +178,7 @@ type DocsDownloadAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
+func (dbx *APIClient) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -254,7 +254,7 @@ type DocsFolderUsersListAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
+func (dbx *APIClient) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -334,7 +334,7 @@ type DocsFolderUsersListContinueAPIError struct {
 	EndpointError *ListUsersCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
+func (dbx *APIClient) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -414,7 +414,7 @@ type DocsGetFolderInfoAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
+func (dbx *APIClient) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -494,7 +494,7 @@ type DocsListAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
+func (dbx *APIClient) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -574,7 +574,7 @@ type DocsListContinueAPIError struct {
 	EndpointError *ListDocsCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
+func (dbx *APIClient) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -654,7 +654,7 @@ type DocsPermanentlyDeleteAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
+func (dbx *APIClient) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -729,7 +729,7 @@ type DocsSharingPolicyGetAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, err error) {
+func (dbx *APIClient) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -809,7 +809,7 @@ type DocsSharingPolicySetAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error) {
+func (dbx *APIClient) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -884,7 +884,7 @@ type DocsUsersAddAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
+func (dbx *APIClient) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -964,7 +964,7 @@ type DocsUsersListAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
+func (dbx *APIClient) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1044,7 +1044,7 @@ type DocsUsersListContinueAPIError struct {
 	EndpointError *ListUsersCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
+func (dbx *APIClient) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1124,7 +1124,7 @@ type DocsUsersRemoveAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
+func (dbx *APIClient) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1194,7 +1194,7 @@ func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/dropbox/sharing/client.go
+++ b/dropbox/sharing/client.go
@@ -219,7 +219,7 @@ type Client interface {
 	UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //AddFileMemberAPIError is an error-wrapper for the add_file_member route
 type AddFileMemberAPIError struct {
@@ -227,7 +227,7 @@ type AddFileMemberAPIError struct {
 	EndpointError *AddFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error) {
+func (dbx *APIClient) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -307,7 +307,7 @@ type AddFolderMemberAPIError struct {
 	EndpointError *AddFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) AddFolderMember(arg *AddFolderMemberArg) (err error) {
+func (dbx *APIClient) AddFolderMember(arg *AddFolderMemberArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -382,7 +382,7 @@ type ChangeFileMemberAccessAPIError struct {
 	EndpointError *FileMemberActionError `json:"error"`
 }
 
-func (dbx *apiImpl) ChangeFileMemberAccess(arg *ChangeFileMemberAccessArgs) (res *FileMemberActionResult, err error) {
+func (dbx *APIClient) ChangeFileMemberAccess(arg *ChangeFileMemberAccessArgs) (res *FileMemberActionResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -462,7 +462,7 @@ type CheckJobStatusAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err error) {
+func (dbx *APIClient) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -542,7 +542,7 @@ type CheckRemoveMemberJobStatusAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveMemberJobStatus, err error) {
+func (dbx *APIClient) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveMemberJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -622,7 +622,7 @@ type CheckShareJobStatusAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJobStatus, err error) {
+func (dbx *APIClient) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -702,7 +702,7 @@ type CreateSharedLinkAPIError struct {
 	EndpointError *CreateSharedLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
+func (dbx *APIClient) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -782,7 +782,7 @@ type CreateSharedLinkWithSettingsAPIError struct {
 	EndpointError *CreateSharedLinkWithSettingsError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
+func (dbx *APIClient) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -870,7 +870,7 @@ type GetFileMetadataAPIError struct {
 	EndpointError *GetFileMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMetadata, err error) {
+func (dbx *APIClient) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -950,7 +950,7 @@ type GetFileMetadataBatchAPIError struct {
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error) {
+func (dbx *APIClient) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1030,7 +1030,7 @@ type GetFolderMetadataAPIError struct {
 	EndpointError *SharedFolderAccessError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMetadata, err error) {
+func (dbx *APIClient) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1110,7 +1110,7 @@ type GetSharedLinkFileAPIError struct {
 	EndpointError *GetSharedLinkFileError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error) {
+func (dbx *APIClient) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1194,7 +1194,7 @@ type GetSharedLinkMetadataAPIError struct {
 	EndpointError *SharedLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error) {
+func (dbx *APIClient) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1282,7 +1282,7 @@ type GetSharedLinksAPIError struct {
 	EndpointError *GetSharedLinksError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
+func (dbx *APIClient) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1362,7 +1362,7 @@ type ListFileMembersAPIError struct {
 	EndpointError *ListFileMembersError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMembers, err error) {
+func (dbx *APIClient) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMembers, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1442,7 +1442,7 @@ type ListFileMembersBatchAPIError struct {
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
+func (dbx *APIClient) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1522,7 +1522,7 @@ type ListFileMembersContinueAPIError struct {
 	EndpointError *ListFileMembersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembersContinue(arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
+func (dbx *APIClient) ListFileMembersContinue(arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1602,7 +1602,7 @@ type ListFolderMembersAPIError struct {
 	EndpointError *SharedFolderAccessError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error) {
+func (dbx *APIClient) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1682,7 +1682,7 @@ type ListFolderMembersContinueAPIError struct {
 	EndpointError *ListFolderMembersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderMembersContinue(arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
+func (dbx *APIClient) ListFolderMembersContinue(arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1762,7 +1762,7 @@ type ListFoldersAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+func (dbx *APIClient) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1842,7 +1842,7 @@ type ListFoldersContinueAPIError struct {
 	EndpointError *ListFoldersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+func (dbx *APIClient) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1922,7 +1922,7 @@ type ListMountableFoldersAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) ListMountableFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+func (dbx *APIClient) ListMountableFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2002,7 +2002,7 @@ type ListMountableFoldersContinueAPIError struct {
 	EndpointError *ListFoldersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+func (dbx *APIClient) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2082,7 +2082,7 @@ type ListReceivedFilesAPIError struct {
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, err error) {
+func (dbx *APIClient) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2162,7 +2162,7 @@ type ListReceivedFilesContinueAPIError struct {
 	EndpointError *ListFilesContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *ListFilesResult, err error) {
+func (dbx *APIClient) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *ListFilesResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2242,7 +2242,7 @@ type ListSharedLinksAPIError struct {
 	EndpointError *ListSharedLinksError `json:"error"`
 }
 
-func (dbx *apiImpl) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
+func (dbx *APIClient) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2322,7 +2322,7 @@ type ModifySharedLinkSettingsAPIError struct {
 	EndpointError *ModifySharedLinkSettingsError `json:"error"`
 }
 
-func (dbx *apiImpl) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
+func (dbx *APIClient) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2410,7 +2410,7 @@ type MountFolderAPIError struct {
 	EndpointError *MountFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata, err error) {
+func (dbx *APIClient) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2490,7 +2490,7 @@ type RelinquishFileMembershipAPIError struct {
 	EndpointError *RelinquishFileMembershipError `json:"error"`
 }
 
-func (dbx *apiImpl) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (err error) {
+func (dbx *APIClient) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2565,7 +2565,7 @@ type RelinquishFolderMembershipAPIError struct {
 	EndpointError *RelinquishFolderMembershipError `json:"error"`
 }
 
-func (dbx *apiImpl) RelinquishFolderMembership(arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
+func (dbx *APIClient) RelinquishFolderMembership(arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2645,7 +2645,7 @@ type RemoveFileMemberAPIError struct {
 	EndpointError *RemoveFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error) {
+func (dbx *APIClient) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2725,7 +2725,7 @@ type RemoveFileMember2APIError struct {
 	EndpointError *RemoveFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error) {
+func (dbx *APIClient) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2805,7 +2805,7 @@ type RemoveFolderMemberAPIError struct {
 	EndpointError *RemoveFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
+func (dbx *APIClient) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2885,7 +2885,7 @@ type RevokeSharedLinkAPIError struct {
 	EndpointError *RevokeSharedLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
+func (dbx *APIClient) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2960,7 +2960,7 @@ type ShareFolderAPIError struct {
 	EndpointError *ShareFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
+func (dbx *APIClient) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3040,7 +3040,7 @@ type TransferFolderAPIError struct {
 	EndpointError *TransferFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) TransferFolder(arg *TransferFolderArg) (err error) {
+func (dbx *APIClient) TransferFolder(arg *TransferFolderArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3115,7 +3115,7 @@ type UnmountFolderAPIError struct {
 	EndpointError *UnmountFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) UnmountFolder(arg *UnmountFolderArg) (err error) {
+func (dbx *APIClient) UnmountFolder(arg *UnmountFolderArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3190,7 +3190,7 @@ type UnshareFileAPIError struct {
 	EndpointError *UnshareFileError `json:"error"`
 }
 
-func (dbx *apiImpl) UnshareFile(arg *UnshareFileArg) (err error) {
+func (dbx *APIClient) UnshareFile(arg *UnshareFileArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3265,7 +3265,7 @@ type UnshareFolderAPIError struct {
 	EndpointError *UnshareFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
+func (dbx *APIClient) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3345,7 +3345,7 @@ type UpdateFileMemberAPIError struct {
 	EndpointError *FileMemberActionError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error) {
+func (dbx *APIClient) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3425,7 +3425,7 @@ type UpdateFolderMemberAPIError struct {
 	EndpointError *UpdateFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error) {
+func (dbx *APIClient) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3505,7 +3505,7 @@ type UpdateFolderPolicyAPIError struct {
 	EndpointError *UpdateFolderPolicyError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
+func (dbx *APIClient) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3580,7 +3580,7 @@ func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedF
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/dropbox/team/client.go
+++ b/dropbox/team/client.go
@@ -226,7 +226,7 @@ type Client interface {
 	TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //DevicesListMemberDevicesAPIError is an error-wrapper for the devices/list_member_devices route
 type DevicesListMemberDevicesAPIError struct {
@@ -234,7 +234,7 @@ type DevicesListMemberDevicesAPIError struct {
 	EndpointError *ListMemberDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
+func (dbx *APIClient) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -311,7 +311,7 @@ type DevicesListMembersDevicesAPIError struct {
 	EndpointError *ListMembersDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error) {
+func (dbx *APIClient) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -388,7 +388,7 @@ type DevicesListTeamDevicesAPIError struct {
 	EndpointError *ListTeamDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
+func (dbx *APIClient) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -465,7 +465,7 @@ type DevicesRevokeDeviceSessionAPIError struct {
 	EndpointError *RevokeDeviceSessionError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err error) {
+func (dbx *APIClient) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -537,7 +537,7 @@ type DevicesRevokeDeviceSessionBatchAPIError struct {
 	EndpointError *RevokeDeviceSessionBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error) {
+func (dbx *APIClient) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -614,7 +614,7 @@ type GetInfoAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetInfo() (res *TeamGetInfoResult, err error) {
+func (dbx *APIClient) GetInfo() (res *TeamGetInfoResult, err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -681,7 +681,7 @@ type GroupsCreateAPIError struct {
 	EndpointError *GroupCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err error) {
+func (dbx *APIClient) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -758,7 +758,7 @@ type GroupsDeleteAPIError struct {
 	EndpointError *GroupDeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
+func (dbx *APIClient) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -835,7 +835,7 @@ type GroupsGetInfoAPIError struct {
 	EndpointError *GroupsGetInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
+func (dbx *APIClient) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -912,7 +912,7 @@ type GroupsJobStatusGetAPIError struct {
 	EndpointError *GroupsPollError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+func (dbx *APIClient) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -989,7 +989,7 @@ type GroupsListAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err error) {
+func (dbx *APIClient) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1066,7 +1066,7 @@ type GroupsListContinueAPIError struct {
 	EndpointError *GroupsListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
+func (dbx *APIClient) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1143,7 +1143,7 @@ type GroupsMembersAddAPIError struct {
 	EndpointError *GroupMembersAddError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error) {
+func (dbx *APIClient) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1220,7 +1220,7 @@ type GroupsMembersListAPIError struct {
 	EndpointError *GroupSelectorError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error) {
+func (dbx *APIClient) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1297,7 +1297,7 @@ type GroupsMembersListContinueAPIError struct {
 	EndpointError *GroupsMembersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersListContinue(arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
+func (dbx *APIClient) GroupsMembersListContinue(arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1374,7 +1374,7 @@ type GroupsMembersRemoveAPIError struct {
 	EndpointError *GroupMembersRemoveError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
+func (dbx *APIClient) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1451,7 +1451,7 @@ type GroupsMembersSetAccessTypeAPIError struct {
 	EndpointError *GroupMemberSetAccessTypeError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error) {
+func (dbx *APIClient) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1528,7 +1528,7 @@ type GroupsUpdateAPIError struct {
 	EndpointError *GroupUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err error) {
+func (dbx *APIClient) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1605,7 +1605,7 @@ type LinkedAppsListMemberLinkedAppsAPIError struct {
 	EndpointError *ListMemberAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
+func (dbx *APIClient) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1682,7 +1682,7 @@ type LinkedAppsListMembersLinkedAppsAPIError struct {
 	EndpointError *ListMembersAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error) {
+func (dbx *APIClient) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1759,7 +1759,7 @@ type LinkedAppsListTeamLinkedAppsAPIError struct {
 	EndpointError *ListTeamAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
+func (dbx *APIClient) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1836,7 +1836,7 @@ type LinkedAppsRevokeLinkedAppAPIError struct {
 	EndpointError *RevokeLinkedAppError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err error) {
+func (dbx *APIClient) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1908,7 +1908,7 @@ type LinkedAppsRevokeLinkedAppBatchAPIError struct {
 	EndpointError *RevokeLinkedAppBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
+func (dbx *APIClient) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -1985,7 +1985,7 @@ type MembersAddAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err error) {
+func (dbx *APIClient) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2062,7 +2062,7 @@ type MembersAddJobStatusGetAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJobStatus, err error) {
+func (dbx *APIClient) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2139,7 +2139,7 @@ type MembersGetInfoAPIError struct {
 	EndpointError *MembersGetInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
+func (dbx *APIClient) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2216,7 +2216,7 @@ type MembersListAPIError struct {
 	EndpointError *MembersListError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersList(arg *MembersListArg) (res *MembersListResult, err error) {
+func (dbx *APIClient) MembersList(arg *MembersListArg) (res *MembersListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2293,7 +2293,7 @@ type MembersListContinueAPIError struct {
 	EndpointError *MembersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersListContinue(arg *MembersListContinueArg) (res *MembersListResult, err error) {
+func (dbx *APIClient) MembersListContinue(arg *MembersListContinueArg) (res *MembersListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2370,7 +2370,7 @@ type MembersRecoverAPIError struct {
 	EndpointError *MembersRecoverError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRecover(arg *MembersRecoverArg) (err error) {
+func (dbx *APIClient) MembersRecover(arg *MembersRecoverArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2442,7 +2442,7 @@ type MembersRemoveAPIError struct {
 	EndpointError *MembersRemoveError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
+func (dbx *APIClient) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2519,7 +2519,7 @@ type MembersRemoveJobStatusGetAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+func (dbx *APIClient) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2596,7 +2596,7 @@ type MembersSendWelcomeEmailAPIError struct {
 	EndpointError *MembersSendWelcomeError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
+func (dbx *APIClient) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2668,7 +2668,7 @@ type MembersSetAdminPermissionsAPIError struct {
 	EndpointError *MembersSetPermissionsError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error) {
+func (dbx *APIClient) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2745,7 +2745,7 @@ type MembersSetProfileAPIError struct {
 	EndpointError *MembersSetProfileError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMemberInfo, err error) {
+func (dbx *APIClient) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMemberInfo, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2822,7 +2822,7 @@ type MembersSuspendAPIError struct {
 	EndpointError *MembersSuspendError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSuspend(arg *MembersDeactivateArg) (err error) {
+func (dbx *APIClient) MembersSuspend(arg *MembersDeactivateArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2894,7 +2894,7 @@ type MembersUnsuspendAPIError struct {
 	EndpointError *MembersUnsuspendError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
+func (dbx *APIClient) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -2966,7 +2966,7 @@ type PropertiesTemplateAddAPIError struct {
 	EndpointError *properties.ModifyPropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateAdd(arg *AddPropertyTemplateArg) (res *AddPropertyTemplateResult, err error) {
+func (dbx *APIClient) PropertiesTemplateAdd(arg *AddPropertyTemplateArg) (res *AddPropertyTemplateResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3043,7 +3043,7 @@ type PropertiesTemplateGetAPIError struct {
 	EndpointError *properties.PropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateGet(arg *properties.GetPropertyTemplateArg) (res *properties.GetPropertyTemplateResult, err error) {
+func (dbx *APIClient) PropertiesTemplateGet(arg *properties.GetPropertyTemplateArg) (res *properties.GetPropertyTemplateResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3120,7 +3120,7 @@ type PropertiesTemplateListAPIError struct {
 	EndpointError *properties.PropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateList() (res *properties.ListPropertyTemplateIds, err error) {
+func (dbx *APIClient) PropertiesTemplateList() (res *properties.ListPropertyTemplateIds, err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -3187,7 +3187,7 @@ type PropertiesTemplateUpdateAPIError struct {
 	EndpointError *properties.ModifyPropertyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateUpdate(arg *UpdatePropertyTemplateArg) (res *UpdatePropertyTemplateResult, err error) {
+func (dbx *APIClient) PropertiesTemplateUpdate(arg *UpdatePropertyTemplateArg) (res *UpdatePropertyTemplateResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3264,7 +3264,7 @@ type ReportsGetActivityAPIError struct {
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, err error) {
+func (dbx *APIClient) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3341,7 +3341,7 @@ type ReportsGetDevicesAPIError struct {
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, err error) {
+func (dbx *APIClient) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3418,7 +3418,7 @@ type ReportsGetMembershipAPIError struct {
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetMembership(arg *DateRange) (res *GetMembershipReport, err error) {
+func (dbx *APIClient) ReportsGetMembership(arg *DateRange) (res *GetMembershipReport, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3495,7 +3495,7 @@ type ReportsGetStorageAPIError struct {
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, err error) {
+func (dbx *APIClient) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3572,7 +3572,7 @@ type TeamFolderActivateAPIError struct {
 	EndpointError *TeamFolderActivateError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
+func (dbx *APIClient) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3649,7 +3649,7 @@ type TeamFolderArchiveAPIError struct {
 	EndpointError *TeamFolderArchiveError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
+func (dbx *APIClient) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3726,7 +3726,7 @@ type TeamFolderArchiveCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
+func (dbx *APIClient) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3803,7 +3803,7 @@ type TeamFolderCreateAPIError struct {
 	EndpointError *TeamFolderCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
+func (dbx *APIClient) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3880,7 +3880,7 @@ type TeamFolderGetInfoAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error) {
+func (dbx *APIClient) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -3957,7 +3957,7 @@ type TeamFolderListAPIError struct {
 	EndpointError *TeamFolderListError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListResult, err error) {
+func (dbx *APIClient) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListResult, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -4034,7 +4034,7 @@ type TeamFolderPermanentlyDeleteAPIError struct {
 	EndpointError *TeamFolderPermanentlyDeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error) {
+func (dbx *APIClient) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -4106,7 +4106,7 @@ type TeamFolderRenameAPIError struct {
 	EndpointError *TeamFolderRenameError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error) {
+func (dbx *APIClient) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -4178,7 +4178,7 @@ func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderM
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/dropbox/users/client.go
+++ b/dropbox/users/client.go
@@ -44,7 +44,7 @@ type Client interface {
 	GetSpaceUsage() (res *SpaceUsage, err error)
 }
 
-type apiImpl dropbox.Context
+type APIClient dropbox.Context
 
 //GetAccountAPIError is an error-wrapper for the get_account route
 type GetAccountAPIError struct {
@@ -52,7 +52,7 @@ type GetAccountAPIError struct {
 	EndpointError *GetAccountError `json:"error"`
 }
 
-func (dbx *apiImpl) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error) {
+func (dbx *APIClient) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -132,7 +132,7 @@ type GetAccountBatchAPIError struct {
 	EndpointError *GetAccountBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
+func (dbx *APIClient) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
 	cli := dbx.Client
 
 	if dbx.Config.Verbose {
@@ -212,7 +212,7 @@ type GetCurrentAccountAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetCurrentAccount() (res *FullAccount, err error) {
+func (dbx *APIClient) GetCurrentAccount() (res *FullAccount, err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -282,7 +282,7 @@ type GetSpaceUsageAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
+func (dbx *APIClient) GetSpaceUsage() (res *SpaceUsage, err error) {
 	cli := dbx.Client
 
 	headers := map[string]string{}
@@ -347,7 +347,7 @@ func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
 }
 
 // New returns a Client implementation for this namespace
-func New(c dropbox.Config) *apiImpl {
-	ctx := apiImpl(dropbox.NewContext(c))
+func New(c dropbox.Config) *APIClient {
+	ctx := APIClient(dropbox.NewContext(c))
 	return &ctx
 }

--- a/generator/README.md
+++ b/generator/README.md
@@ -218,7 +218,7 @@ type metadataUnion struct {
 
 func (u *metadataUnion) UnmarshalJSON(body []byte) error {...}
 
-func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
+func (dbx *APIClient) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
    	...
    	var tmp metadataUnion
 	err = json.Unmarshal(body, &tmp)

--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -36,12 +36,12 @@ class GoClientGenerator(CodeGenerator):
                     self.emit(self._generate_route_signature(namespace, route))
             self.emit()
 
-            self.emit('type apiImpl dropbox.Context')
+            self.emit('type APIClient dropbox.Context')
             for route in namespace.routes:
                 self._generate_route(namespace, route)
             self.emit('// New returns a Client implementation for this namespace')
-            with self.block('func New(c dropbox.Config) *apiImpl'):
-                self.emit('ctx := apiImpl(dropbox.NewContext(c))')
+            with self.block('func New(c dropbox.Config) *APIClient'):
+                self.emit('ctx := APIClient(dropbox.NewContext(c))')
                 self.emit('return &ctx')
 
     def _generate_route_signature(self, namespace, route):
@@ -75,7 +75,7 @@ class GoClientGenerator(CodeGenerator):
             out('EndpointError {err} `json:"error"`'.format(err=err))
         out()
 
-        signature = 'func (dbx *apiImpl) ' + self._generate_route_signature(
+        signature = 'func (dbx *APIClient) ' + self._generate_route_signature(
             namespace, route)
         with self.block(signature):
             out('cli := dbx.Client')


### PR DESCRIPTION
Client would have been a better name but it clashes with the existing
public API in the client module.