### PR TITLE
Fixup generator script on ubuntu 17.04

### DIFF
--- a/generator/generate-sdk.sh
+++ b/generator/generate-sdk.sh
@@ -20,6 +20,7 @@ pushd ${spec_dir}
 spec_version=$(git rev-parse --short HEAD)
 popd
 
-sed -i '' -e "s/UNKNOWN SDK VERSION/${sdk_version}/" \
-	-e "s/UNKNOWN SPEC VERSION/${spec_version}/" ${gen_dir}/sdk.go
+sed -i.bak -e "s/UNKNOWN SDK VERSION/${sdk_version}/" \
+    -e "s/UNKNOWN SPEC VERSION/${spec_version}/" ${gen_dir}/sdk.go
+rm ${gen_dir}/sdk.go.bak
 goimports -l -w ${gen_dir}


### PR DESCRIPTION
GNU sed doesn't understand `-i ''` as meaning don't make a backup
file.  Change this to just `-i` which is the canonical form for sed.