### PR TITLE
Stabilise the sort order of the headers

### DIFF
--- a/dropbox/files/client.go
+++ b/dropbox/files/client.go
@@ -361,8 +361,8 @@ func (dbx *apiImpl) AlphaUpload(arg *CommitInfoWithProperties, content io.Reader
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3106,8 +3106,8 @@ func (dbx *apiImpl) Upload(arg *CommitInfo, content io.Reader) (res *FileMetadat
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3182,8 +3182,8 @@ func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Rea
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3250,8 +3250,8 @@ func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content i
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3318,8 +3318,8 @@ func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3535,8 +3535,8 @@ func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Re
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
 		"Content-Type":    "application/octet-stream",
+		"Dropbox-API-Arg": string(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID

--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -125,7 +125,7 @@ class GoClientGenerator(CodeGenerator):
             headers["Content-Type"] = '"application/octet-stream"'
 
         out('headers := map[string]string{')
-        for k, v in headers.items():
+        for k, v in sorted(headers.items()):
             out('\t"{}": {},'.format(k, v))
         out('}')
         if auth != 'noauth' and auth != 'team':


### PR DESCRIPTION
Without this patch the output can change from run to run depending on
the hashing order of a Python dictionary.