### PR TITLE
Regenerate SDK w/ latest API spec, and fixes to generator for content-style endpoints

### DIFF
--- a/dropbox/paper/types.go
+++ b/dropbox/paper/types.go
@@ -247,6 +247,19 @@ func NewFoldersContainingPaperDoc() *FoldersContainingPaperDoc {
 	return s
 }
 
+// ImportFormat : The import format of the incoming data.
+type ImportFormat struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for ImportFormat
+const (
+	ImportFormatHtml      = "html"
+	ImportFormatMarkdown  = "markdown"
+	ImportFormatPlainText = "plain_text"
+	ImportFormatOther     = "other"
+)
+
 // InviteeInfoWithPermissionLevel : has no documentation (yet)
 type InviteeInfoWithPermissionLevel struct {
 	// Invitee : Email address invited to the Paper doc.
@@ -582,6 +595,55 @@ const (
 	PaperApiCursorErrorOther             = "other"
 )
 
+// PaperDocCreateArgs : has no documentation (yet)
+type PaperDocCreateArgs struct {
+	// ParentFolderId : The Paper folder ID where the Paper document should be
+	// created. The API user has to have write access to this folder or error is
+	// thrown.
+	ParentFolderId string `json:"parent_folder_id,omitempty"`
+	// ImportFormat : The format of provided data.
+	ImportFormat *ImportFormat `json:"import_format"`
+}
+
+// NewPaperDocCreateArgs returns a new PaperDocCreateArgs instance
+func NewPaperDocCreateArgs(ImportFormat *ImportFormat) *PaperDocCreateArgs {
+	s := new(PaperDocCreateArgs)
+	s.ImportFormat = ImportFormat
+	return s
+}
+
+// PaperDocCreateError : has no documentation (yet)
+type PaperDocCreateError struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for PaperDocCreateError
+const (
+	PaperDocCreateErrorContentMalformed  = "content_malformed"
+	PaperDocCreateErrorFolderNotFound    = "folder_not_found"
+	PaperDocCreateErrorDocLengthExceeded = "doc_length_exceeded"
+	PaperDocCreateErrorImageSizeExceeded = "image_size_exceeded"
+)
+
+// PaperDocCreateUpdateResult : has no documentation (yet)
+type PaperDocCreateUpdateResult struct {
+	// DocId : Doc ID of the newly created doc.
+	DocId string `json:"doc_id"`
+	// Revision : The Paper doc revision. Simply an ever increasing number.
+	Revision int64 `json:"revision"`
+	// Title : The Paper doc title.
+	Title string `json:"title"`
+}
+
+// NewPaperDocCreateUpdateResult returns a new PaperDocCreateUpdateResult instance
+func NewPaperDocCreateUpdateResult(DocId string, Revision int64, Title string) *PaperDocCreateUpdateResult {
+	s := new(PaperDocCreateUpdateResult)
+	s.DocId = DocId
+	s.Revision = Revision
+	s.Title = Title
+	return s
+}
+
 // PaperDocExport : has no documentation (yet)
 type PaperDocExport struct {
 	RefPaperDoc
@@ -646,6 +708,57 @@ func NewPaperDocSharingPolicy(DocId string, SharingPolicy *SharingPolicy) *Paper
 	s.SharingPolicy = SharingPolicy
 	return s
 }
+
+// PaperDocUpdateArgs : has no documentation (yet)
+type PaperDocUpdateArgs struct {
+	RefPaperDoc
+	// DocUpdatePolicy : The policy used for the current update call.
+	DocUpdatePolicy *PaperDocUpdatePolicy `json:"doc_update_policy"`
+	// Revision : The latest doc revision. This value must match the head
+	// revision or an error code will be returned. This is to prevent colliding
+	// writes.
+	Revision int64 `json:"revision"`
+	// ImportFormat : The format of provided data.
+	ImportFormat *ImportFormat `json:"import_format"`
+}
+
+// NewPaperDocUpdateArgs returns a new PaperDocUpdateArgs instance
+func NewPaperDocUpdateArgs(DocId string, DocUpdatePolicy *PaperDocUpdatePolicy, Revision int64, ImportFormat *ImportFormat) *PaperDocUpdateArgs {
+	s := new(PaperDocUpdateArgs)
+	s.DocId = DocId
+	s.DocUpdatePolicy = DocUpdatePolicy
+	s.Revision = Revision
+	s.ImportFormat = ImportFormat
+	return s
+}
+
+// PaperDocUpdateError : has no documentation (yet)
+type PaperDocUpdateError struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for PaperDocUpdateError
+const (
+	PaperDocUpdateErrorContentMalformed  = "content_malformed"
+	PaperDocUpdateErrorRevisionMismatch  = "revision_mismatch"
+	PaperDocUpdateErrorDocLengthExceeded = "doc_length_exceeded"
+	PaperDocUpdateErrorImageSizeExceeded = "image_size_exceeded"
+	PaperDocUpdateErrorDocArchived       = "doc_archived"
+	PaperDocUpdateErrorDocDeleted        = "doc_deleted"
+)
+
+// PaperDocUpdatePolicy : has no documentation (yet)
+type PaperDocUpdatePolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for PaperDocUpdatePolicy
+const (
+	PaperDocUpdatePolicyAppend       = "append"
+	PaperDocUpdatePolicyPrepend      = "prepend"
+	PaperDocUpdatePolicyOverwriteAll = "overwrite_all"
+	PaperDocUpdatePolicyOther        = "other"
+)
 
 // RemovePaperDocUser : has no documentation (yet)
 type RemovePaperDocUser struct {

--- a/dropbox/sdk.go
+++ b/dropbox/sdk.go
@@ -36,7 +36,7 @@ const (
 	hostContent   = "content"
 	hostNotify    = "notify"
 	sdkVersion    = "1.0.0-beta"
-	specVersion   = "6194bea"
+	specVersion   = "e7a71c8"
 )
 
 // Version returns the current SDK version and API Spec version

--- a/dropbox/sharing/types.go
+++ b/dropbox/sharing/types.go
@@ -552,9 +552,9 @@ func (u *CreateSharedLinkError) UnmarshalJSON(body []byte) error {
 
 // CreateSharedLinkWithSettingsArg : has no documentation (yet)
 type CreateSharedLinkWithSettingsArg struct {
-	// Path : The path to be shared by the shared link
+	// Path : The path to be shared by the shared link.
 	Path string `json:"path"`
-	// Settings : The requested settings for the newly created shared link
+	// Settings : The requested settings for the newly created shared link.
 	Settings *SharedLinkSettings `json:"settings,omitempty"`
 }
 
@@ -570,7 +570,7 @@ type CreateSharedLinkWithSettingsError struct {
 	dropbox.Tagged
 	// Path : has no documentation (yet)
 	Path *files.LookupError `json:"path,omitempty"`
-	// SettingsError : There is an error with the given settings
+	// SettingsError : There is an error with the given settings.
 	SettingsError *SharedLinkSettingsError `json:"settings_error,omitempty"`
 }
 
@@ -589,7 +589,7 @@ func (u *CreateSharedLinkWithSettingsError) UnmarshalJSON(body []byte) error {
 		dropbox.Tagged
 		// Path : has no documentation (yet)
 		Path json.RawMessage `json:"path,omitempty"`
-		// SettingsError : There is an error with the given settings
+		// SettingsError : There is an error with the given settings.
 		SettingsError json.RawMessage `json:"settings_error,omitempty"`
 	}
 	var w wrap
@@ -741,7 +741,7 @@ func (u *FileErrorResult) UnmarshalJSON(body []byte) error {
 	return nil
 }
 
-// SharedLinkMetadata : The metadata of a shared link
+// SharedLinkMetadata : The metadata of a shared link.
 type SharedLinkMetadata struct {
 	// Url : URL of the shared link.
 	Url string `json:"url"`
@@ -847,7 +847,7 @@ func IsSharedLinkMetadataFromJSON(data []byte) (IsSharedLinkMetadata, error) {
 	return nil, nil
 }
 
-// FileLinkMetadata : The metadata of a file shared link
+// FileLinkMetadata : The metadata of a file shared link.
 type FileLinkMetadata struct {
 	SharedLinkMetadata
 	// ClientModified : The modification time set by the desktop client when the
@@ -1092,7 +1092,7 @@ const (
 	FolderActionOther                 = "other"
 )
 
-// FolderLinkMetadata : The metadata of a folder shared link
+// FolderLinkMetadata : The metadata of a folder shared link.
 type FolderLinkMetadata struct {
 	SharedLinkMetadata
 }
@@ -1820,7 +1820,7 @@ type LinkPermissions struct {
 	// after considering these policies, can be found in `resolved_visibility`.
 	// This is shown only if the caller is the link's owner.
 	RequestedVisibility *RequestedVisibility `json:"requested_visibility,omitempty"`
-	// CanRevoke : Whether the caller can revoke the shared link
+	// CanRevoke : Whether the caller can revoke the shared link.
 	CanRevoke bool `json:"can_revoke"`
 	// RevokeFailureReason : The failure reason for revoking the link. This
 	// field will only be present if the `can_revoke` is false.
@@ -2510,7 +2510,7 @@ func (u *MemberSelector) UnmarshalJSON(body []byte) error {
 
 // ModifySharedLinkSettingsArgs : has no documentation (yet)
 type ModifySharedLinkSettingsArgs struct {
-	// Url : URL of the shared link to change its settings
+	// Url : URL of the shared link to change its settings.
 	Url string `json:"url"`
 	// Settings : Set of settings for the shared link.
 	Settings *SharedLinkSettings `json:"settings"`
@@ -2531,7 +2531,7 @@ func NewModifySharedLinkSettingsArgs(Url string, Settings *SharedLinkSettings) *
 // ModifySharedLinkSettingsError : has no documentation (yet)
 type ModifySharedLinkSettingsError struct {
 	dropbox.Tagged
-	// SettingsError : There is an error with the given settings
+	// SettingsError : There is an error with the given settings.
 	SettingsError *SharedLinkSettingsError `json:"settings_error,omitempty"`
 }
 
@@ -2545,7 +2545,7 @@ const (
 func (u *ModifySharedLinkSettingsError) UnmarshalJSON(body []byte) error {
 	type wrap struct {
 		dropbox.Tagged
-		// SettingsError : There is an error with the given settings
+		// SettingsError : There is an error with the given settings.
 		SettingsError json.RawMessage `json:"settings_error,omitempty"`
 	}
 	var w wrap
@@ -2706,6 +2706,7 @@ const (
 	PermissionDeniedReasonUserAccountType            = "user_account_type"
 	PermissionDeniedReasonUserNotOnTeam              = "user_not_on_team"
 	PermissionDeniedReasonFolderIsInsideSharedFolder = "folder_is_inside_shared_folder"
+	PermissionDeniedReasonRestrictedByParentFolder   = "restricted_by_parent_folder"
 	PermissionDeniedReasonInsufficientPlan           = "insufficient_plan"
 	PermissionDeniedReasonOther                      = "other"
 )
@@ -3683,7 +3684,7 @@ const (
 
 // TeamMemberInfo : Information about a team member.
 type TeamMemberInfo struct {
-	// TeamInfo : Information about the member's team
+	// TeamInfo : Information about the member's team.
 	TeamInfo *users.Team `json:"team_info"`
 	// DisplayName : The display name of the user.
 	DisplayName string `json:"display_name"`

--- a/dropbox/team/types.go
+++ b/dropbox/team/types.go
@@ -34,16 +34,16 @@ import (
 
 // DeviceSession : has no documentation (yet)
 type DeviceSession struct {
-	// SessionId : The session id
+	// SessionId : The session id.
 	SessionId string `json:"session_id"`
-	// IpAddress : The IP address of the last activity from this session
+	// IpAddress : The IP address of the last activity from this session.
 	IpAddress string `json:"ip_address,omitempty"`
 	// Country : The country from which the last activity from this session was
-	// made
+	// made.
 	Country string `json:"country,omitempty"`
-	// Created : The time this session was created
+	// Created : The time this session was created.
 	Created time.Time `json:"created,omitempty"`
-	// Updated : The time of the last activity from this session
+	// Updated : The time of the last activity from this session.
 	Updated time.Time `json:"updated,omitempty"`
 }
 
@@ -54,16 +54,16 @@ func NewDeviceSession(SessionId string) *DeviceSession {
 	return s
 }
 
-// ActiveWebSession : Information on active web sessions
+// ActiveWebSession : Information on active web sessions.
 type ActiveWebSession struct {
 	DeviceSession
-	// UserAgent : Information on the hosting device
+	// UserAgent : Information on the hosting device.
 	UserAgent string `json:"user_agent"`
-	// Os : Information on the hosting operating system
+	// Os : Information on the hosting operating system.
 	Os string `json:"os"`
-	// Browser : Information on the browser used for this web session
+	// Browser : Information on the browser used for this web session.
 	Browser string `json:"browser"`
-	// Expires : The time this session expires
+	// Expires : The time this session expires.
 	Expires time.Time `json:"expires,omitempty"`
 }
 
@@ -118,19 +118,19 @@ const (
 	AdminTierMemberOnly          = "member_only"
 )
 
-// ApiApp : Information on linked third party applications
+// ApiApp : Information on linked third party applications.
 type ApiApp struct {
-	// AppId : The application unique id
+	// AppId : The application unique id.
 	AppId string `json:"app_id"`
-	// AppName : The application name
+	// AppName : The application name.
 	AppName string `json:"app_name"`
-	// Publisher : The application publisher name
+	// Publisher : The application publisher name.
 	Publisher string `json:"publisher,omitempty"`
-	// PublisherUrl : The publisher's URL
+	// PublisherUrl : The publisher's URL.
 	PublisherUrl string `json:"publisher_url,omitempty"`
-	// Linked : The time this application was linked
+	// Linked : The time this application was linked.
 	Linked time.Time `json:"linked,omitempty"`
-	// IsAppFolder : Whether the linked application uses a dedicated folder
+	// IsAppFolder : Whether the linked application uses a dedicated folder.
 	IsAppFolder bool `json:"is_app_folder"`
 }
 
@@ -216,11 +216,83 @@ func (u *BaseTeamFolderError) UnmarshalJSON(body []byte) error {
 	return nil
 }
 
+// CustomQuotaError : Error returned by setting member custom quota.
+type CustomQuotaError struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for CustomQuotaError
+const (
+	CustomQuotaErrorTooManyUsers = "too_many_users"
+	CustomQuotaErrorOther        = "other"
+)
+
+// CustomQuotaResult : User custom quota.
+type CustomQuotaResult struct {
+	dropbox.Tagged
+	// Success : User's custom quota.
+	Success *UserCustomQuotaResult `json:"success,omitempty"`
+	// InvalidUser : Invalid user (not in team).
+	InvalidUser *UserSelectorArg `json:"invalid_user,omitempty"`
+}
+
+// Valid tag values for CustomQuotaResult
+const (
+	CustomQuotaResultSuccess     = "success"
+	CustomQuotaResultInvalidUser = "invalid_user"
+	CustomQuotaResultOther       = "other"
+)
+
+// UnmarshalJSON deserializes into a CustomQuotaResult instance
+func (u *CustomQuotaResult) UnmarshalJSON(body []byte) error {
+	type wrap struct {
+		dropbox.Tagged
+		// Success : User's custom quota.
+		Success json.RawMessage `json:"success,omitempty"`
+		// InvalidUser : Invalid user (not in team).
+		InvalidUser json.RawMessage `json:"invalid_user,omitempty"`
+	}
+	var w wrap
+	var err error
+	if err = json.Unmarshal(body, &w); err != nil {
+		return err
+	}
+	u.Tag = w.Tag
+	switch u.Tag {
+	case "success":
+		err = json.Unmarshal(body, &u.Success)
+
+		if err != nil {
+			return err
+		}
+	case "invalid_user":
+		err = json.Unmarshal(w.InvalidUser, &u.InvalidUser)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CustomQuotaUsersArg : has no documentation (yet)
+type CustomQuotaUsersArg struct {
+	// Users : List of users.
+	Users []*UserSelectorArg `json:"users"`
+}
+
+// NewCustomQuotaUsersArg returns a new CustomQuotaUsersArg instance
+func NewCustomQuotaUsersArg(Users []*UserSelectorArg) *CustomQuotaUsersArg {
+	s := new(CustomQuotaUsersArg)
+	s.Users = Users
+	return s
+}
+
 // DateRange : Input arguments that can be provided for most reports.
 type DateRange struct {
-	// StartDate : Optional starting date (inclusive)
+	// StartDate : Optional starting date (inclusive).
 	StartDate time.Time `json:"start_date,omitempty"`
-	// EndDate : Optional ending date (exclusive)
+	// EndDate : Optional ending date (exclusive).
 	EndDate time.Time `json:"end_date,omitempty"`
 }
 
@@ -242,19 +314,19 @@ const (
 )
 
 // DesktopClientSession : Information about linked Dropbox desktop client
-// sessions
+// sessions.
 type DesktopClientSession struct {
 	DeviceSession
-	// HostName : Name of the hosting desktop
+	// HostName : Name of the hosting desktop.
 	HostName string `json:"host_name"`
-	// ClientType : The Dropbox desktop client type
+	// ClientType : The Dropbox desktop client type.
 	ClientType *DesktopPlatform `json:"client_type"`
-	// ClientVersion : The Dropbox client version
+	// ClientVersion : The Dropbox client version.
 	ClientVersion string `json:"client_version"`
-	// Platform : Information on the hosting platform
+	// Platform : Information on the hosting platform.
 	Platform string `json:"platform"`
 	// IsDeleteOnUnlinkSupported : Whether it's possible to delete all of the
-	// account files upon unlinking
+	// account files upon unlinking.
 	IsDeleteOnUnlinkSupported bool `json:"is_delete_on_unlink_supported"`
 }
 
@@ -285,9 +357,9 @@ const (
 
 // DeviceSessionArg : has no documentation (yet)
 type DeviceSessionArg struct {
-	// SessionId : The session id
+	// SessionId : The session id.
 	SessionId string `json:"session_id"`
-	// TeamMemberId : The unique id of the member owning the device
+	// TeamMemberId : The unique id of the member owning the device.
 	TeamMemberId string `json:"team_member_id"`
 }
 
@@ -1330,7 +1402,7 @@ func (u *HasTeamSharedDropboxValue) UnmarshalJSON(body []byte) error {
 
 // ListMemberAppsArg : has no documentation (yet)
 type ListMemberAppsArg struct {
-	// TeamMemberId : The team member id
+	// TeamMemberId : The team member id.
 	TeamMemberId string `json:"team_member_id"`
 }
 
@@ -1355,7 +1427,7 @@ const (
 // ListMemberAppsResult : has no documentation (yet)
 type ListMemberAppsResult struct {
 	// LinkedApiApps : List of third party applications linked by this team
-	// member
+	// member.
 	LinkedApiApps []*ApiApp `json:"linked_api_apps"`
 }
 
@@ -1368,15 +1440,15 @@ func NewListMemberAppsResult(LinkedApiApps []*ApiApp) *ListMemberAppsResult {
 
 // ListMemberDevicesArg : has no documentation (yet)
 type ListMemberDevicesArg struct {
-	// TeamMemberId : The team's member id
+	// TeamMemberId : The team's member id.
 	TeamMemberId string `json:"team_member_id"`
-	// IncludeWebSessions : Whether to list web sessions of the team's member
+	// IncludeWebSessions : Whether to list web sessions of the team's member.
 	IncludeWebSessions bool `json:"include_web_sessions"`
 	// IncludeDesktopClients : Whether to list linked desktop devices of the
-	// team's member
+	// team's member.
 	IncludeDesktopClients bool `json:"include_desktop_clients"`
 	// IncludeMobileClients : Whether to list linked mobile devices of the
-	// team's member
+	// team's member.
 	IncludeMobileClients bool `json:"include_mobile_clients"`
 }
 
@@ -1403,11 +1475,11 @@ const (
 
 // ListMemberDevicesResult : has no documentation (yet)
 type ListMemberDevicesResult struct {
-	// ActiveWebSessions : List of web sessions made by this team member
+	// ActiveWebSessions : List of web sessions made by this team member.
 	ActiveWebSessions []*ActiveWebSession `json:"active_web_sessions,omitempty"`
-	// DesktopClientSessions : List of desktop clients used by this team member
+	// DesktopClientSessions : List of desktop clients used by this team member.
 	DesktopClientSessions []*DesktopClientSession `json:"desktop_client_sessions,omitempty"`
-	// MobileClientSessions : List of mobile client used by this team member
+	// MobileClientSessions : List of mobile client used by this team member.
 	MobileClientSessions []*MobileClientSession `json:"mobile_client_sessions,omitempty"`
 }
 
@@ -1422,7 +1494,7 @@ type ListMembersAppsArg struct {
 	// Cursor : At the first call to the `linkedAppsListMembersLinkedApps` the
 	// cursor shouldn't be passed. Then, if the result of the call includes a
 	// cursor, the following requests should include the received cursors in
-	// order to receive the next sub list of the team applications
+	// order to receive the next sub list of the team applications.
 	Cursor string `json:"cursor,omitempty"`
 }
 
@@ -1432,7 +1504,7 @@ func NewListMembersAppsArg() *ListMembersAppsArg {
 	return s
 }
 
-// ListMembersAppsError : Error returned by `linkedAppsListMembersLinkedApps`
+// ListMembersAppsError : Error returned by `linkedAppsListMembersLinkedApps`.
 type ListMembersAppsError struct {
 	dropbox.Tagged
 }
@@ -1446,7 +1518,7 @@ const (
 // ListMembersAppsResult : Information returned by
 // `linkedAppsListMembersLinkedApps`.
 type ListMembersAppsResult struct {
-	// Apps : The linked applications of each member of the team
+	// Apps : The linked applications of each member of the team.
 	Apps []*MemberLinkedApps `json:"apps"`
 	// HasMore : If true, then there are more apps available. Pass the cursor to
 	// `linkedAppsListMembersLinkedApps` to retrieve the rest.
@@ -1469,14 +1541,15 @@ type ListMembersDevicesArg struct {
 	// Cursor : At the first call to the `devicesListMembersDevices` the cursor
 	// shouldn't be passed. Then, if the result of the call includes a cursor,
 	// the following requests should include the received cursors in order to
-	// receive the next sub list of team devices
+	// receive the next sub list of team devices.
 	Cursor string `json:"cursor,omitempty"`
-	// IncludeWebSessions : Whether to list web sessions of the team members
+	// IncludeWebSessions : Whether to list web sessions of the team members.
 	IncludeWebSessions bool `json:"include_web_sessions"`
 	// IncludeDesktopClients : Whether to list desktop clients of the team
-	// members
+	// members.
 	IncludeDesktopClients bool `json:"include_desktop_clients"`
-	// IncludeMobileClients : Whether to list mobile clients of the team members
+	// IncludeMobileClients : Whether to list mobile clients of the team
+	// members.
 	IncludeMobileClients bool `json:"include_mobile_clients"`
 }
 
@@ -1502,7 +1575,7 @@ const (
 
 // ListMembersDevicesResult : has no documentation (yet)
 type ListMembersDevicesResult struct {
-	// Devices : The devices of each member of the team
+	// Devices : The devices of each member of the team.
 	Devices []*MemberDevices `json:"devices"`
 	// HasMore : If true, then there are more devices available. Pass the cursor
 	// to `devicesListMembersDevices` to retrieve the rest.
@@ -1525,7 +1598,7 @@ type ListTeamAppsArg struct {
 	// Cursor : At the first call to the `linkedAppsListTeamLinkedApps` the
 	// cursor shouldn't be passed. Then, if the result of the call includes a
 	// cursor, the following requests should include the received cursors in
-	// order to receive the next sub list of the team applications
+	// order to receive the next sub list of the team applications.
 	Cursor string `json:"cursor,omitempty"`
 }
 
@@ -1535,7 +1608,7 @@ func NewListTeamAppsArg() *ListTeamAppsArg {
 	return s
 }
 
-// ListTeamAppsError : Error returned by `linkedAppsListTeamLinkedApps`
+// ListTeamAppsError : Error returned by `linkedAppsListTeamLinkedApps`.
 type ListTeamAppsError struct {
 	dropbox.Tagged
 }
@@ -1548,7 +1621,7 @@ const (
 
 // ListTeamAppsResult : Information returned by `linkedAppsListTeamLinkedApps`.
 type ListTeamAppsResult struct {
-	// Apps : The linked applications of each member of the team
+	// Apps : The linked applications of each member of the team.
 	Apps []*MemberLinkedApps `json:"apps"`
 	// HasMore : If true, then there are more apps available. Pass the cursor to
 	// `linkedAppsListTeamLinkedApps` to retrieve the rest.
@@ -1571,14 +1644,15 @@ type ListTeamDevicesArg struct {
 	// Cursor : At the first call to the `devicesListTeamDevices` the cursor
 	// shouldn't be passed. Then, if the result of the call includes a cursor,
 	// the following requests should include the received cursors in order to
-	// receive the next sub list of team devices
+	// receive the next sub list of team devices.
 	Cursor string `json:"cursor,omitempty"`
-	// IncludeWebSessions : Whether to list web sessions of the team members
+	// IncludeWebSessions : Whether to list web sessions of the team members.
 	IncludeWebSessions bool `json:"include_web_sessions"`
 	// IncludeDesktopClients : Whether to list desktop clients of the team
-	// members
+	// members.
 	IncludeDesktopClients bool `json:"include_desktop_clients"`
-	// IncludeMobileClients : Whether to list mobile clients of the team members
+	// IncludeMobileClients : Whether to list mobile clients of the team
+	// members.
 	IncludeMobileClients bool `json:"include_mobile_clients"`
 }
 
@@ -1604,7 +1678,7 @@ const (
 
 // ListTeamDevicesResult : has no documentation (yet)
 type ListTeamDevicesResult struct {
-	// Devices : The devices of each member of the team
+	// Devices : The devices of each member of the team.
 	Devices []*MemberDevices `json:"devices"`
 	// HasMore : If true, then there are more devices available. Pass the cursor
 	// to `devicesListTeamDevices` to retrieve the rest.
@@ -1811,13 +1885,13 @@ func (u *MemberAddResult) UnmarshalJSON(body []byte) error {
 
 // MemberDevices : Information on devices of a team's member.
 type MemberDevices struct {
-	// TeamMemberId : The member unique Id
+	// TeamMemberId : The member unique Id.
 	TeamMemberId string `json:"team_member_id"`
-	// WebSessions : List of web sessions made by this team member
+	// WebSessions : List of web sessions made by this team member.
 	WebSessions []*ActiveWebSession `json:"web_sessions,omitempty"`
-	// DesktopClients : List of desktop clients by this team member
+	// DesktopClients : List of desktop clients by this team member.
 	DesktopClients []*DesktopClientSession `json:"desktop_clients,omitempty"`
-	// MobileClients : List of mobile clients by this team member
+	// MobileClients : List of mobile clients by this team member.
 	MobileClients []*MobileClientSession `json:"mobile_clients,omitempty"`
 }
 
@@ -1830,10 +1904,10 @@ func NewMemberDevices(TeamMemberId string) *MemberDevices {
 
 // MemberLinkedApps : Information on linked applications of a team member.
 type MemberLinkedApps struct {
-	// TeamMemberId : The member unique Id
+	// TeamMemberId : The member unique Id.
 	TeamMemberId string `json:"team_member_id"`
 	// LinkedApiApps : List of third party applications linked by this team
-	// member
+	// member.
 	LinkedApiApps []*ApiApp `json:"linked_api_apps"`
 }
 
@@ -2409,18 +2483,19 @@ const (
 	MobileClientPlatformOther        = "other"
 )
 
-// MobileClientSession : Information about linked Dropbox mobile client sessions
+// MobileClientSession : Information about linked Dropbox mobile client
+// sessions.
 type MobileClientSession struct {
 	DeviceSession
-	// DeviceName : The device name
+	// DeviceName : The device name.
 	DeviceName string `json:"device_name"`
-	// ClientType : The mobile application type
+	// ClientType : The mobile application type.
 	ClientType *MobileClientPlatform `json:"client_type"`
-	// ClientVersion : The dropbox client version
+	// ClientVersion : The dropbox client version.
 	ClientVersion string `json:"client_version,omitempty"`
-	// OsVersion : The hosting OS version
+	// OsVersion : The hosting OS version.
 	OsVersion string `json:"os_version,omitempty"`
-	// LastCarrier : last carrier used by the device
+	// LastCarrier : last carrier used by the device.
 	LastCarrier string `json:"last_carrier,omitempty"`
 }
 
@@ -2469,6 +2544,54 @@ const (
 	NamespaceTypeOther            = "other"
 )
 
+// RemoveCustomQuotaResult : User result for setting member custom quota.
+type RemoveCustomQuotaResult struct {
+	dropbox.Tagged
+	// Success : Successfully removed user.
+	Success *UserSelectorArg `json:"success,omitempty"`
+	// InvalidUser : Invalid user (not in team).
+	InvalidUser *UserSelectorArg `json:"invalid_user,omitempty"`
+}
+
+// Valid tag values for RemoveCustomQuotaResult
+const (
+	RemoveCustomQuotaResultSuccess     = "success"
+	RemoveCustomQuotaResultInvalidUser = "invalid_user"
+	RemoveCustomQuotaResultOther       = "other"
+)
+
+// UnmarshalJSON deserializes into a RemoveCustomQuotaResult instance
+func (u *RemoveCustomQuotaResult) UnmarshalJSON(body []byte) error {
+	type wrap struct {
+		dropbox.Tagged
+		// Success : Successfully removed user.
+		Success json.RawMessage `json:"success,omitempty"`
+		// InvalidUser : Invalid user (not in team).
+		InvalidUser json.RawMessage `json:"invalid_user,omitempty"`
+	}
+	var w wrap
+	var err error
+	if err = json.Unmarshal(body, &w); err != nil {
+		return err
+	}
+	u.Tag = w.Tag
+	switch u.Tag {
+	case "success":
+		err = json.Unmarshal(w.Success, &u.Success)
+
+		if err != nil {
+			return err
+		}
+	case "invalid_user":
+		err = json.Unmarshal(w.InvalidUser, &u.InvalidUser)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RemovedStatus : has no documentation (yet)
 type RemovedStatus struct {
 	// IsRecoverable : True if the removed team member is recoverable.
@@ -2487,7 +2610,7 @@ type RevokeDesktopClientArg struct {
 	DeviceSessionArg
 	// DeleteOnUnlink : Whether to delete all files of the account (this is
 	// possible only if supported by the desktop client and  will be made the
-	// next time the client access the account)
+	// next time the client access the account).
 	DeleteOnUnlink bool `json:"delete_on_unlink"`
 }
 
@@ -2503,11 +2626,11 @@ func NewRevokeDesktopClientArg(SessionId string, TeamMemberId string) *RevokeDes
 // RevokeDeviceSessionArg : has no documentation (yet)
 type RevokeDeviceSessionArg struct {
 	dropbox.Tagged
-	// WebSession : End an active session
+	// WebSession : End an active session.
 	WebSession *DeviceSessionArg `json:"web_session,omitempty"`
-	// DesktopClient : Unlink a linked desktop device
+	// DesktopClient : Unlink a linked desktop device.
 	DesktopClient *RevokeDesktopClientArg `json:"desktop_client,omitempty"`
-	// MobileClient : Unlink a linked mobile device
+	// MobileClient : Unlink a linked mobile device.
 	MobileClient *DeviceSessionArg `json:"mobile_client,omitempty"`
 }
 
@@ -2522,11 +2645,11 @@ const (
 func (u *RevokeDeviceSessionArg) UnmarshalJSON(body []byte) error {
 	type wrap struct {
 		dropbox.Tagged
-		// WebSession : End an active session
+		// WebSession : End an active session.
 		WebSession json.RawMessage `json:"web_session,omitempty"`
-		// DesktopClient : Unlink a linked desktop device
+		// DesktopClient : Unlink a linked desktop device.
 		DesktopClient json.RawMessage `json:"desktop_client,omitempty"`
-		// MobileClient : Unlink a linked mobile device
+		// MobileClient : Unlink a linked mobile device.
 		MobileClient json.RawMessage `json:"mobile_client,omitempty"`
 	}
 	var w wrap
@@ -2608,9 +2731,9 @@ const (
 
 // RevokeDeviceSessionStatus : has no documentation (yet)
 type RevokeDeviceSessionStatus struct {
-	// Success : Result of the revoking request
+	// Success : Result of the revoking request.
 	Success bool `json:"success"`
-	// ErrorType : The error cause in case of a failure
+	// ErrorType : The error cause in case of a failure.
 	ErrorType *RevokeDeviceSessionError `json:"error_type,omitempty"`
 }
 
@@ -2623,12 +2746,12 @@ func NewRevokeDeviceSessionStatus(Success bool) *RevokeDeviceSessionStatus {
 
 // RevokeLinkedApiAppArg : has no documentation (yet)
 type RevokeLinkedApiAppArg struct {
-	// AppId : The application's unique id
+	// AppId : The application's unique id.
 	AppId string `json:"app_id"`
-	// TeamMemberId : The unique id of the member owning the device
+	// TeamMemberId : The unique id of the member owning the device.
 	TeamMemberId string `json:"team_member_id"`
 	// KeepAppFolder : Whether to keep the application dedicated folder (in case
-	// the application uses  one)
+	// the application uses  one).
 	KeepAppFolder bool `json:"keep_app_folder"`
 }
 
@@ -2692,9 +2815,9 @@ const (
 
 // RevokeLinkedAppStatus : has no documentation (yet)
 type RevokeLinkedAppStatus struct {
-	// Success : Result of the revoking request
+	// Success : Result of the revoking request.
 	Success bool `json:"success"`
-	// ErrorType : The error cause in case of a failure
+	// ErrorType : The error cause in case of a failure.
 	ErrorType *RevokeLinkedAppError `json:"error_type,omitempty"`
 }
 
@@ -2702,6 +2825,19 @@ type RevokeLinkedAppStatus struct {
 func NewRevokeLinkedAppStatus(Success bool) *RevokeLinkedAppStatus {
 	s := new(RevokeLinkedAppStatus)
 	s.Success = Success
+	return s
+}
+
+// SetCustomQuotaArg : has no documentation (yet)
+type SetCustomQuotaArg struct {
+	// UsersAndQuotas : List of users and their custom quotas.
+	UsersAndQuotas []*UserCustomQuotaArg `json:"users_and_quotas"`
+}
+
+// NewSetCustomQuotaArg returns a new SetCustomQuotaArg instance
+func NewSetCustomQuotaArg(UsersAndQuotas []*UserCustomQuotaArg) *SetCustomQuotaArg {
+	s := new(SetCustomQuotaArg)
+	s.UsersAndQuotas = UsersAndQuotas
 	return s
 }
 
@@ -3238,8 +3374,7 @@ const (
 
 // TeamNamespacesListArg : has no documentation (yet)
 type TeamNamespacesListArg struct {
-	// Limit : The approximate maximum number of results to return per request.
-	// This limit may be exceeded.
+	// Limit : Specifying a value here has no effect.
 	Limit uint32 `json:"limit"`
 }
 
@@ -3393,6 +3528,39 @@ func (u *UploadApiRateLimitValue) UnmarshalJSON(body []byte) error {
 		}
 	}
 	return nil
+}
+
+// UserCustomQuotaArg : User and their required custom quota in GB (1 TB = 1024
+// GB).
+type UserCustomQuotaArg struct {
+	// User : has no documentation (yet)
+	User *UserSelectorArg `json:"user"`
+	// QuotaGb : has no documentation (yet)
+	QuotaGb uint32 `json:"quota_gb"`
+}
+
+// NewUserCustomQuotaArg returns a new UserCustomQuotaArg instance
+func NewUserCustomQuotaArg(User *UserSelectorArg, QuotaGb uint32) *UserCustomQuotaArg {
+	s := new(UserCustomQuotaArg)
+	s.User = User
+	s.QuotaGb = QuotaGb
+	return s
+}
+
+// UserCustomQuotaResult : User and their custom quota in GB (1 TB = 1024 GB).
+// No quota returns if the user has no custom quota set.
+type UserCustomQuotaResult struct {
+	// User : has no documentation (yet)
+	User *UserSelectorArg `json:"user"`
+	// QuotaGb : has no documentation (yet)
+	QuotaGb uint32 `json:"quota_gb,omitempty"`
+}
+
+// NewUserCustomQuotaResult returns a new UserCustomQuotaResult instance
+func NewUserCustomQuotaResult(User *UserSelectorArg) *UserCustomQuotaResult {
+	s := new(UserCustomQuotaResult)
+	s.User = User
+	return s
 }
 
 // UserSelectorArg : Argument for selecting a single user, either by

--- a/dropbox/team_log/types.go
+++ b/dropbox/team_log/types.go
@@ -843,7 +843,7 @@ func NewDeviceApprovalsChangeMobilePolicyDetails() *DeviceApprovalsChangeMobileP
 
 // DeviceApprovalsChangeOverageActionDetails : Changed the action taken when a
 // team member is already over the limits (e.g when they join the team, an admin
-// lowers limits, etc.).
+// lowers limits, etc).
 type DeviceApprovalsChangeOverageActionDetails struct {
 	// NewValue : New over the limits policy. Might be missing due to historical
 	// data gap.
@@ -1413,6 +1413,8 @@ type EventDetails struct {
 	// MemberTransferAccountContentsDetails : Transferred contents of a removed
 	// team member account to another member.
 	MemberTransferAccountContentsDetails *MemberTransferAccountContentsDetails `json:"member_transfer_account_contents_details,omitempty"`
+	// PaperAdminExportStartDetails : Exported all Paper documents in the team.
+	PaperAdminExportStartDetails *PaperAdminExportStartDetails `json:"paper_admin_export_start_details,omitempty"`
 	// PaperEnabledUsersGroupAdditionDetails : Users added to Paper enabled
 	// users list.
 	PaperEnabledUsersGroupAdditionDetails *PaperEnabledUsersGroupAdditionDetails `json:"paper_enabled_users_group_addition_details,omitempty"`
@@ -1443,6 +1445,21 @@ type EventDetails struct {
 	AppUnlinkTeamDetails *AppUnlinkTeamDetails `json:"app_unlink_team_details,omitempty"`
 	// AppUnlinkUserDetails : Unlinked an app for team member.
 	AppUnlinkUserDetails *AppUnlinkUserDetails `json:"app_unlink_user_details,omitempty"`
+	// FileAddCommentDetails : Added a file comment.
+	FileAddCommentDetails *FileAddCommentDetails `json:"file_add_comment_details,omitempty"`
+	// FileChangeCommentSubscriptionDetails : Subscribed to or unsubscribed from
+	// comment notifications for file.
+	FileChangeCommentSubscriptionDetails *FileChangeCommentSubscriptionDetails `json:"file_change_comment_subscription_details,omitempty"`
+	// FileDeleteCommentDetails : Deleted a file comment.
+	FileDeleteCommentDetails *FileDeleteCommentDetails `json:"file_delete_comment_details,omitempty"`
+	// FileLikeCommentDetails : Liked a file comment.
+	FileLikeCommentDetails *FileLikeCommentDetails `json:"file_like_comment_details,omitempty"`
+	// FileResolveCommentDetails : Resolved a file comment.
+	FileResolveCommentDetails *FileResolveCommentDetails `json:"file_resolve_comment_details,omitempty"`
+	// FileUnlikeCommentDetails : Unliked a file comment.
+	FileUnlikeCommentDetails *FileUnlikeCommentDetails `json:"file_unlike_comment_details,omitempty"`
+	// FileUnresolveCommentDetails : Unresolved a file comment.
+	FileUnresolveCommentDetails *FileUnresolveCommentDetails `json:"file_unresolve_comment_details,omitempty"`
 	// DeviceChangeIpDesktopDetails : IP address associated with active desktop
 	// session changed.
 	DeviceChangeIpDesktopDetails *DeviceChangeIpDesktopDetails `json:"device_change_ip_desktop_details,omitempty"`
@@ -1704,12 +1721,6 @@ type EventDetails struct {
 	TeamActivityCreateReportDetails *TeamActivityCreateReportDetails `json:"team_activity_create_report_details,omitempty"`
 	// CollectionShareDetails : Shared an album.
 	CollectionShareDetails *CollectionShareDetails `json:"collection_share_details,omitempty"`
-	// FileAddCommentDetails : Added a file comment.
-	FileAddCommentDetails *FileAddCommentDetails `json:"file_add_comment_details,omitempty"`
-	// FileLikeCommentDetails : Liked a file comment.
-	FileLikeCommentDetails *FileLikeCommentDetails `json:"file_like_comment_details,omitempty"`
-	// FileUnlikeCommentDetails : Unliked a file comment.
-	FileUnlikeCommentDetails *FileUnlikeCommentDetails `json:"file_unlike_comment_details,omitempty"`
 	// NoteAclInviteOnlyDetails : Changed a Paper document to be invite-only.
 	NoteAclInviteOnlyDetails *NoteAclInviteOnlyDetails `json:"note_acl_invite_only_details,omitempty"`
 	// NoteAclLinkDetails : Changed a Paper document to be link accessible.
@@ -1868,10 +1879,10 @@ type EventDetails struct {
 	// ShmodelVisibilityTeamOnlyDetails : Made a file/folder visible only to
 	// team members with the link.
 	ShmodelVisibilityTeamOnlyDetails *ShmodelVisibilityTeamOnlyDetails `json:"shmodel_visibility_team_only_details,omitempty"`
-	// RemoveLogoutUrlDetails : Removed single sign-on logout URL.
-	RemoveLogoutUrlDetails *RemoveLogoutUrlDetails `json:"remove_logout_url_details,omitempty"`
-	// RemoveSsoUrlDetails : Changed the sign-out URL for SSO.
-	RemoveSsoUrlDetails *RemoveSsoUrlDetails `json:"remove_sso_url_details,omitempty"`
+	// SsoAddLoginUrlDetails : Added sign-in URL for SSO.
+	SsoAddLoginUrlDetails *SsoAddLoginUrlDetails `json:"sso_add_login_url_details,omitempty"`
+	// SsoAddLogoutUrlDetails : Added sign-out URL for SSO.
+	SsoAddLogoutUrlDetails *SsoAddLogoutUrlDetails `json:"sso_add_logout_url_details,omitempty"`
 	// SsoChangeCertDetails : Changed the X.509 certificate for SSO.
 	SsoChangeCertDetails *SsoChangeCertDetails `json:"sso_change_cert_details,omitempty"`
 	// SsoChangeLoginUrlDetails : Changed the sign-in URL for SSO.
@@ -1881,6 +1892,10 @@ type EventDetails struct {
 	// SsoChangeSamlIdentityModeDetails : Changed the SAML identity mode for
 	// SSO.
 	SsoChangeSamlIdentityModeDetails *SsoChangeSamlIdentityModeDetails `json:"sso_change_saml_identity_mode_details,omitempty"`
+	// SsoRemoveLoginUrlDetails : Removed the sign-in URL for SSO.
+	SsoRemoveLoginUrlDetails *SsoRemoveLoginUrlDetails `json:"sso_remove_login_url_details,omitempty"`
+	// SsoRemoveLogoutUrlDetails : Removed single sign-on logout URL.
+	SsoRemoveLogoutUrlDetails *SsoRemoveLogoutUrlDetails `json:"sso_remove_logout_url_details,omitempty"`
 	// TeamFolderChangeStatusDetails : Changed the archival status of a team
 	// folder.
 	TeamFolderChangeStatusDetails *TeamFolderChangeStatusDetails `json:"team_folder_change_status_details,omitempty"`
@@ -1919,7 +1934,7 @@ type EventDetails struct {
 	DeviceApprovalsChangeMobilePolicyDetails *DeviceApprovalsChangeMobilePolicyDetails `json:"device_approvals_change_mobile_policy_details,omitempty"`
 	// DeviceApprovalsChangeOverageActionDetails : Changed the action taken when
 	// a team member is already over the limits (e.g when they join the team, an
-	// admin lowers limits, etc.).
+	// admin lowers limits, etc).
 	DeviceApprovalsChangeOverageActionDetails *DeviceApprovalsChangeOverageActionDetails `json:"device_approvals_change_overage_action_details,omitempty"`
 	// DeviceApprovalsChangeUnlinkActionDetails : Changed the action taken with
 	// respect to approval limits when a team member unlinks an approved device.
@@ -2060,6 +2075,7 @@ const (
 	EventDetailsMemberPermanentlyDeleteAccountContentsDetails   = "member_permanently_delete_account_contents_details"
 	EventDetailsMemberSpaceLimitsChangeStatusDetails            = "member_space_limits_change_status_details"
 	EventDetailsMemberTransferAccountContentsDetails            = "member_transfer_account_contents_details"
+	EventDetailsPaperAdminExportStartDetails                    = "paper_admin_export_start_details"
 	EventDetailsPaperEnabledUsersGroupAdditionDetails           = "paper_enabled_users_group_addition_details"
 	EventDetailsPaperEnabledUsersGroupRemovalDetails            = "paper_enabled_users_group_removal_details"
 	EventDetailsPaperExternalViewAllowDetails                   = "paper_external_view_allow_details"
@@ -2072,6 +2088,13 @@ const (
 	EventDetailsAppLinkUserDetails                              = "app_link_user_details"
 	EventDetailsAppUnlinkTeamDetails                            = "app_unlink_team_details"
 	EventDetailsAppUnlinkUserDetails                            = "app_unlink_user_details"
+	EventDetailsFileAddCommentDetails                           = "file_add_comment_details"
+	EventDetailsFileChangeCommentSubscriptionDetails            = "file_change_comment_subscription_details"
+	EventDetailsFileDeleteCommentDetails                        = "file_delete_comment_details"
+	EventDetailsFileLikeCommentDetails                          = "file_like_comment_details"
+	EventDetailsFileResolveCommentDetails                       = "file_resolve_comment_details"
+	EventDetailsFileUnlikeCommentDetails                        = "file_unlike_comment_details"
+	EventDetailsFileUnresolveCommentDetails                     = "file_unresolve_comment_details"
 	EventDetailsDeviceChangeIpDesktopDetails                    = "device_change_ip_desktop_details"
 	EventDetailsDeviceChangeIpMobileDetails                     = "device_change_ip_mobile_details"
 	EventDetailsDeviceChangeIpWebDetails                        = "device_change_ip_web_details"
@@ -2186,9 +2209,6 @@ const (
 	EventDetailsSmartSyncCreateAdminPrivilegeReportDetails      = "smart_sync_create_admin_privilege_report_details"
 	EventDetailsTeamActivityCreateReportDetails                 = "team_activity_create_report_details"
 	EventDetailsCollectionShareDetails                          = "collection_share_details"
-	EventDetailsFileAddCommentDetails                           = "file_add_comment_details"
-	EventDetailsFileLikeCommentDetails                          = "file_like_comment_details"
-	EventDetailsFileUnlikeCommentDetails                        = "file_unlike_comment_details"
 	EventDetailsNoteAclInviteOnlyDetails                        = "note_acl_invite_only_details"
 	EventDetailsNoteAclLinkDetails                              = "note_acl_link_details"
 	EventDetailsNoteAclTeamLinkDetails                          = "note_acl_team_link_details"
@@ -2251,12 +2271,14 @@ const (
 	EventDetailsShmodelVisibilityPasswordDetails                = "shmodel_visibility_password_details"
 	EventDetailsShmodelVisibilityPublicDetails                  = "shmodel_visibility_public_details"
 	EventDetailsShmodelVisibilityTeamOnlyDetails                = "shmodel_visibility_team_only_details"
-	EventDetailsRemoveLogoutUrlDetails                          = "remove_logout_url_details"
-	EventDetailsRemoveSsoUrlDetails                             = "remove_sso_url_details"
+	EventDetailsSsoAddLoginUrlDetails                           = "sso_add_login_url_details"
+	EventDetailsSsoAddLogoutUrlDetails                          = "sso_add_logout_url_details"
 	EventDetailsSsoChangeCertDetails                            = "sso_change_cert_details"
 	EventDetailsSsoChangeLoginUrlDetails                        = "sso_change_login_url_details"
 	EventDetailsSsoChangeLogoutUrlDetails                       = "sso_change_logout_url_details"
 	EventDetailsSsoChangeSamlIdentityModeDetails                = "sso_change_saml_identity_mode_details"
+	EventDetailsSsoRemoveLoginUrlDetails                        = "sso_remove_login_url_details"
+	EventDetailsSsoRemoveLogoutUrlDetails                       = "sso_remove_logout_url_details"
 	EventDetailsTeamFolderChangeStatusDetails                   = "team_folder_change_status_details"
 	EventDetailsTeamFolderCreateDetails                         = "team_folder_create_details"
 	EventDetailsTeamFolderDowngradeDetails                      = "team_folder_downgrade_details"
@@ -2335,6 +2357,9 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		// MemberTransferAccountContentsDetails : Transferred contents of a
 		// removed team member account to another member.
 		MemberTransferAccountContentsDetails json.RawMessage `json:"member_transfer_account_contents_details,omitempty"`
+		// PaperAdminExportStartDetails : Exported all Paper documents in the
+		// team.
+		PaperAdminExportStartDetails json.RawMessage `json:"paper_admin_export_start_details,omitempty"`
 		// PaperEnabledUsersGroupAdditionDetails : Users added to Paper enabled
 		// users list.
 		PaperEnabledUsersGroupAdditionDetails json.RawMessage `json:"paper_enabled_users_group_addition_details,omitempty"`
@@ -2365,6 +2390,21 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		AppUnlinkTeamDetails json.RawMessage `json:"app_unlink_team_details,omitempty"`
 		// AppUnlinkUserDetails : Unlinked an app for team member.
 		AppUnlinkUserDetails json.RawMessage `json:"app_unlink_user_details,omitempty"`
+		// FileAddCommentDetails : Added a file comment.
+		FileAddCommentDetails json.RawMessage `json:"file_add_comment_details,omitempty"`
+		// FileChangeCommentSubscriptionDetails : Subscribed to or unsubscribed
+		// from comment notifications for file.
+		FileChangeCommentSubscriptionDetails json.RawMessage `json:"file_change_comment_subscription_details,omitempty"`
+		// FileDeleteCommentDetails : Deleted a file comment.
+		FileDeleteCommentDetails json.RawMessage `json:"file_delete_comment_details,omitempty"`
+		// FileLikeCommentDetails : Liked a file comment.
+		FileLikeCommentDetails json.RawMessage `json:"file_like_comment_details,omitempty"`
+		// FileResolveCommentDetails : Resolved a file comment.
+		FileResolveCommentDetails json.RawMessage `json:"file_resolve_comment_details,omitempty"`
+		// FileUnlikeCommentDetails : Unliked a file comment.
+		FileUnlikeCommentDetails json.RawMessage `json:"file_unlike_comment_details,omitempty"`
+		// FileUnresolveCommentDetails : Unresolved a file comment.
+		FileUnresolveCommentDetails json.RawMessage `json:"file_unresolve_comment_details,omitempty"`
 		// DeviceChangeIpDesktopDetails : IP address associated with active
 		// desktop session changed.
 		DeviceChangeIpDesktopDetails json.RawMessage `json:"device_change_ip_desktop_details,omitempty"`
@@ -2632,12 +2672,6 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		TeamActivityCreateReportDetails json.RawMessage `json:"team_activity_create_report_details,omitempty"`
 		// CollectionShareDetails : Shared an album.
 		CollectionShareDetails json.RawMessage `json:"collection_share_details,omitempty"`
-		// FileAddCommentDetails : Added a file comment.
-		FileAddCommentDetails json.RawMessage `json:"file_add_comment_details,omitempty"`
-		// FileLikeCommentDetails : Liked a file comment.
-		FileLikeCommentDetails json.RawMessage `json:"file_like_comment_details,omitempty"`
-		// FileUnlikeCommentDetails : Unliked a file comment.
-		FileUnlikeCommentDetails json.RawMessage `json:"file_unlike_comment_details,omitempty"`
 		// NoteAclInviteOnlyDetails : Changed a Paper document to be
 		// invite-only.
 		NoteAclInviteOnlyDetails json.RawMessage `json:"note_acl_invite_only_details,omitempty"`
@@ -2798,10 +2832,10 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		// ShmodelVisibilityTeamOnlyDetails : Made a file/folder visible only to
 		// team members with the link.
 		ShmodelVisibilityTeamOnlyDetails json.RawMessage `json:"shmodel_visibility_team_only_details,omitempty"`
-		// RemoveLogoutUrlDetails : Removed single sign-on logout URL.
-		RemoveLogoutUrlDetails json.RawMessage `json:"remove_logout_url_details,omitempty"`
-		// RemoveSsoUrlDetails : Changed the sign-out URL for SSO.
-		RemoveSsoUrlDetails json.RawMessage `json:"remove_sso_url_details,omitempty"`
+		// SsoAddLoginUrlDetails : Added sign-in URL for SSO.
+		SsoAddLoginUrlDetails json.RawMessage `json:"sso_add_login_url_details,omitempty"`
+		// SsoAddLogoutUrlDetails : Added sign-out URL for SSO.
+		SsoAddLogoutUrlDetails json.RawMessage `json:"sso_add_logout_url_details,omitempty"`
 		// SsoChangeCertDetails : Changed the X.509 certificate for SSO.
 		SsoChangeCertDetails json.RawMessage `json:"sso_change_cert_details,omitempty"`
 		// SsoChangeLoginUrlDetails : Changed the sign-in URL for SSO.
@@ -2811,6 +2845,10 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		// SsoChangeSamlIdentityModeDetails : Changed the SAML identity mode for
 		// SSO.
 		SsoChangeSamlIdentityModeDetails json.RawMessage `json:"sso_change_saml_identity_mode_details,omitempty"`
+		// SsoRemoveLoginUrlDetails : Removed the sign-in URL for SSO.
+		SsoRemoveLoginUrlDetails json.RawMessage `json:"sso_remove_login_url_details,omitempty"`
+		// SsoRemoveLogoutUrlDetails : Removed single sign-on logout URL.
+		SsoRemoveLogoutUrlDetails json.RawMessage `json:"sso_remove_logout_url_details,omitempty"`
 		// TeamFolderChangeStatusDetails : Changed the archival status of a team
 		// folder.
 		TeamFolderChangeStatusDetails json.RawMessage `json:"team_folder_change_status_details,omitempty"`
@@ -2850,7 +2888,7 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		DeviceApprovalsChangeMobilePolicyDetails json.RawMessage `json:"device_approvals_change_mobile_policy_details,omitempty"`
 		// DeviceApprovalsChangeOverageActionDetails : Changed the action taken
 		// when a team member is already over the limits (e.g when they join the
-		// team, an admin lowers limits, etc.).
+		// team, an admin lowers limits, etc).
 		DeviceApprovalsChangeOverageActionDetails json.RawMessage `json:"device_approvals_change_overage_action_details,omitempty"`
 		// DeviceApprovalsChangeUnlinkActionDetails : Changed the action taken
 		// with respect to approval limits when a team member unlinks an
@@ -3023,6 +3061,12 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		if err != nil {
 			return err
 		}
+	case "paper_admin_export_start_details":
+		err = json.Unmarshal(body, &u.PaperAdminExportStartDetails)
+
+		if err != nil {
+			return err
+		}
 	case "paper_enabled_users_group_addition_details":
 		err = json.Unmarshal(body, &u.PaperEnabledUsersGroupAdditionDetails)
 
@@ -3091,6 +3135,48 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		}
 	case "app_unlink_user_details":
 		err = json.Unmarshal(body, &u.AppUnlinkUserDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_add_comment_details":
+		err = json.Unmarshal(body, &u.FileAddCommentDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_change_comment_subscription_details":
+		err = json.Unmarshal(body, &u.FileChangeCommentSubscriptionDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_delete_comment_details":
+		err = json.Unmarshal(body, &u.FileDeleteCommentDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_like_comment_details":
+		err = json.Unmarshal(body, &u.FileLikeCommentDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_resolve_comment_details":
+		err = json.Unmarshal(body, &u.FileResolveCommentDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_unlike_comment_details":
+		err = json.Unmarshal(body, &u.FileUnlikeCommentDetails)
+
+		if err != nil {
+			return err
+		}
+	case "file_unresolve_comment_details":
+		err = json.Unmarshal(body, &u.FileUnresolveCommentDetails)
 
 		if err != nil {
 			return err
@@ -3779,24 +3865,6 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		if err != nil {
 			return err
 		}
-	case "file_add_comment_details":
-		err = json.Unmarshal(body, &u.FileAddCommentDetails)
-
-		if err != nil {
-			return err
-		}
-	case "file_like_comment_details":
-		err = json.Unmarshal(body, &u.FileLikeCommentDetails)
-
-		if err != nil {
-			return err
-		}
-	case "file_unlike_comment_details":
-		err = json.Unmarshal(body, &u.FileUnlikeCommentDetails)
-
-		if err != nil {
-			return err
-		}
 	case "note_acl_invite_only_details":
 		err = json.Unmarshal(body, &u.NoteAclInviteOnlyDetails)
 
@@ -4169,14 +4237,14 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		if err != nil {
 			return err
 		}
-	case "remove_logout_url_details":
-		err = json.Unmarshal(body, &u.RemoveLogoutUrlDetails)
+	case "sso_add_login_url_details":
+		err = json.Unmarshal(body, &u.SsoAddLoginUrlDetails)
 
 		if err != nil {
 			return err
 		}
-	case "remove_sso_url_details":
-		err = json.Unmarshal(body, &u.RemoveSsoUrlDetails)
+	case "sso_add_logout_url_details":
+		err = json.Unmarshal(body, &u.SsoAddLogoutUrlDetails)
 
 		if err != nil {
 			return err
@@ -4201,6 +4269,18 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 		}
 	case "sso_change_saml_identity_mode_details":
 		err = json.Unmarshal(body, &u.SsoChangeSamlIdentityModeDetails)
+
+		if err != nil {
+			return err
+		}
+	case "sso_remove_login_url_details":
+		err = json.Unmarshal(body, &u.SsoRemoveLoginUrlDetails)
+
+		if err != nil {
+			return err
+		}
+	case "sso_remove_logout_url_details":
+		err = json.Unmarshal(body, &u.SsoRemoveLogoutUrlDetails)
 
 		if err != nil {
 			return err
@@ -4568,6 +4648,7 @@ const (
 	EventTypeMemberPermanentlyDeleteAccountContents   = "member_permanently_delete_account_contents"
 	EventTypeMemberSpaceLimitsChangeStatus            = "member_space_limits_change_status"
 	EventTypeMemberTransferAccountContents            = "member_transfer_account_contents"
+	EventTypePaperAdminExportStart                    = "paper_admin_export_start"
 	EventTypePaperEnabledUsersGroupAddition           = "paper_enabled_users_group_addition"
 	EventTypePaperEnabledUsersGroupRemoval            = "paper_enabled_users_group_removal"
 	EventTypePaperExternalViewAllow                   = "paper_external_view_allow"
@@ -4580,6 +4661,13 @@ const (
 	EventTypeAppLinkUser                              = "app_link_user"
 	EventTypeAppUnlinkTeam                            = "app_unlink_team"
 	EventTypeAppUnlinkUser                            = "app_unlink_user"
+	EventTypeFileAddComment                           = "file_add_comment"
+	EventTypeFileChangeCommentSubscription            = "file_change_comment_subscription"
+	EventTypeFileDeleteComment                        = "file_delete_comment"
+	EventTypeFileLikeComment                          = "file_like_comment"
+	EventTypeFileResolveComment                       = "file_resolve_comment"
+	EventTypeFileUnlikeComment                        = "file_unlike_comment"
+	EventTypeFileUnresolveComment                     = "file_unresolve_comment"
 	EventTypeDeviceChangeIpDesktop                    = "device_change_ip_desktop"
 	EventTypeDeviceChangeIpMobile                     = "device_change_ip_mobile"
 	EventTypeDeviceChangeIpWeb                        = "device_change_ip_web"
@@ -4694,9 +4782,6 @@ const (
 	EventTypeSmartSyncCreateAdminPrivilegeReport      = "smart_sync_create_admin_privilege_report"
 	EventTypeTeamActivityCreateReport                 = "team_activity_create_report"
 	EventTypeCollectionShare                          = "collection_share"
-	EventTypeFileAddComment                           = "file_add_comment"
-	EventTypeFileLikeComment                          = "file_like_comment"
-	EventTypeFileUnlikeComment                        = "file_unlike_comment"
 	EventTypeNoteAclInviteOnly                        = "note_acl_invite_only"
 	EventTypeNoteAclLink                              = "note_acl_link"
 	EventTypeNoteAclTeamLink                          = "note_acl_team_link"
@@ -4759,12 +4844,14 @@ const (
 	EventTypeShmodelVisibilityPassword                = "shmodel_visibility_password"
 	EventTypeShmodelVisibilityPublic                  = "shmodel_visibility_public"
 	EventTypeShmodelVisibilityTeamOnly                = "shmodel_visibility_team_only"
-	EventTypeRemoveLogoutUrl                          = "remove_logout_url"
-	EventTypeRemoveSsoUrl                             = "remove_sso_url"
+	EventTypeSsoAddLoginUrl                           = "sso_add_login_url"
+	EventTypeSsoAddLogoutUrl                          = "sso_add_logout_url"
 	EventTypeSsoChangeCert                            = "sso_change_cert"
 	EventTypeSsoChangeLoginUrl                        = "sso_change_login_url"
 	EventTypeSsoChangeLogoutUrl                       = "sso_change_logout_url"
 	EventTypeSsoChangeSamlIdentityMode                = "sso_change_saml_identity_mode"
+	EventTypeSsoRemoveLoginUrl                        = "sso_remove_login_url"
+	EventTypeSsoRemoveLogoutUrl                       = "sso_remove_logout_url"
 	EventTypeTeamFolderChangeStatus                   = "team_folder_change_status"
 	EventTypeTeamFolderCreate                         = "team_folder_create"
 	EventTypeTeamFolderDowngrade                      = "team_folder_downgrade"
@@ -4849,9 +4936,10 @@ type ExtendedVersionHistoryPolicy struct {
 
 // Valid tag values for ExtendedVersionHistoryPolicy
 const (
-	ExtendedVersionHistoryPolicyLimited   = "limited"
-	ExtendedVersionHistoryPolicyUnlimited = "unlimited"
-	ExtendedVersionHistoryPolicyOther     = "other"
+	ExtendedVersionHistoryPolicyExplicitlyLimited   = "explicitly_limited"
+	ExtendedVersionHistoryPolicyExplicitlyUnlimited = "explicitly_unlimited"
+	ExtendedVersionHistoryPolicyImplicitlyLimited   = "implicitly_limited"
+	ExtendedVersionHistoryPolicyOther               = "other"
 )
 
 // FailureDetailsLogInfo : Provides details about a failure
@@ -4872,16 +4960,16 @@ func NewFailureDetailsLogInfo() *FailureDetailsLogInfo {
 
 // FileAddCommentDetails : Added a file comment.
 type FileAddCommentDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// CommentText : Comment text. Might be missing due to historical data gap.
 	CommentText string `json:"comment_text,omitempty"`
 }
 
 // NewFileAddCommentDetails returns a new FileAddCommentDetails instance
-func NewFileAddCommentDetails(TargetIndex int64) *FileAddCommentDetails {
+func NewFileAddCommentDetails(TargetAssetIndex uint64) *FileAddCommentDetails {
 	s := new(FileAddCommentDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -4894,6 +4982,38 @@ func NewFileAddDetails() *FileAddDetails {
 	s := new(FileAddDetails)
 	return s
 }
+
+// FileChangeCommentSubscriptionDetails : Subscribed to or unsubscribed from
+// comment notifications for file.
+type FileChangeCommentSubscriptionDetails struct {
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
+	// NewValue : New file comment subscription.
+	NewValue *FileCommentNotificationPolicy `json:"new_value"`
+	// PreviousValue : Previous file comment subscription. Might be missing due
+	// to historical data gap.
+	PreviousValue *FileCommentNotificationPolicy `json:"previous_value,omitempty"`
+}
+
+// NewFileChangeCommentSubscriptionDetails returns a new FileChangeCommentSubscriptionDetails instance
+func NewFileChangeCommentSubscriptionDetails(TargetAssetIndex uint64, NewValue *FileCommentNotificationPolicy) *FileChangeCommentSubscriptionDetails {
+	s := new(FileChangeCommentSubscriptionDetails)
+	s.TargetAssetIndex = TargetAssetIndex
+	s.NewValue = NewValue
+	return s
+}
+
+// FileCommentNotificationPolicy : Enable or disable file comments notifications
+type FileCommentNotificationPolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for FileCommentNotificationPolicy
+const (
+	FileCommentNotificationPolicyDisabled = "disabled"
+	FileCommentNotificationPolicyEnabled  = "enabled"
+	FileCommentNotificationPolicyOther    = "other"
+)
 
 // FileCommentsChangePolicyDetails : Enabled or disabled commenting on team
 // files.
@@ -4934,6 +5054,21 @@ type FileCopyDetails struct {
 func NewFileCopyDetails(RelocateActionDetails []*RelocateAssetReferencesLogInfo) *FileCopyDetails {
 	s := new(FileCopyDetails)
 	s.RelocateActionDetails = RelocateActionDetails
+	return s
+}
+
+// FileDeleteCommentDetails : Deleted a file comment.
+type FileDeleteCommentDetails struct {
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
+	// CommentText : Comment text. Might be missing due to historical data gap.
+	CommentText string `json:"comment_text,omitempty"`
+}
+
+// NewFileDeleteCommentDetails returns a new FileDeleteCommentDetails instance
+func NewFileDeleteCommentDetails(TargetAssetIndex uint64) *FileDeleteCommentDetails {
+	s := new(FileDeleteCommentDetails)
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -4979,16 +5114,16 @@ func NewFileGetCopyReferenceDetails() *FileGetCopyReferenceDetails {
 
 // FileLikeCommentDetails : Liked a file comment.
 type FileLikeCommentDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// CommentText : Comment text. Might be missing due to historical data gap.
 	CommentText string `json:"comment_text,omitempty"`
 }
 
 // NewFileLikeCommentDetails returns a new FileLikeCommentDetails instance
-func NewFileLikeCommentDetails(TargetIndex int64) *FileLikeCommentDetails {
+func NewFileLikeCommentDetails(TargetAssetIndex uint64) *FileLikeCommentDetails {
 	s := new(FileLikeCommentDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -5070,80 +5205,74 @@ func NewFileRenameDetails(RelocateActionDetails []*RelocateAssetReferencesLogInf
 // FileRequestAddDeadlineDetails : Added a deadline to a file request.
 type FileRequestAddDeadlineDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestAddDeadlineDetails returns a new FileRequestAddDeadlineDetails instance
-func NewFileRequestAddDeadlineDetails(RequestTitle string) *FileRequestAddDeadlineDetails {
+func NewFileRequestAddDeadlineDetails() *FileRequestAddDeadlineDetails {
 	s := new(FileRequestAddDeadlineDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestChangeFolderDetails : Changed the file request folder.
 type FileRequestChangeFolderDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestChangeFolderDetails returns a new FileRequestChangeFolderDetails instance
-func NewFileRequestChangeFolderDetails(RequestTitle string) *FileRequestChangeFolderDetails {
+func NewFileRequestChangeFolderDetails() *FileRequestChangeFolderDetails {
 	s := new(FileRequestChangeFolderDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestChangeTitleDetails : Change the file request title.
 type FileRequestChangeTitleDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestChangeTitleDetails returns a new FileRequestChangeTitleDetails instance
-func NewFileRequestChangeTitleDetails(RequestTitle string) *FileRequestChangeTitleDetails {
+func NewFileRequestChangeTitleDetails() *FileRequestChangeTitleDetails {
 	s := new(FileRequestChangeTitleDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestCloseDetails : Closed a file request.
 type FileRequestCloseDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestCloseDetails returns a new FileRequestCloseDetails instance
-func NewFileRequestCloseDetails(RequestTitle string) *FileRequestCloseDetails {
+func NewFileRequestCloseDetails() *FileRequestCloseDetails {
 	s := new(FileRequestCloseDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestCreateDetails : Created a file request.
 type FileRequestCreateDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestCreateDetails returns a new FileRequestCreateDetails instance
-func NewFileRequestCreateDetails(RequestTitle string) *FileRequestCreateDetails {
+func NewFileRequestCreateDetails() *FileRequestCreateDetails {
 	s := new(FileRequestCreateDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestReceiveFileDetails : Received files for a file request.
 type FileRequestReceiveFileDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 	// SubmittedFileNames : Submitted file names.
 	SubmittedFileNames []string `json:"submitted_file_names"`
 }
 
 // NewFileRequestReceiveFileDetails returns a new FileRequestReceiveFileDetails instance
-func NewFileRequestReceiveFileDetails(RequestTitle string, SubmittedFileNames []string) *FileRequestReceiveFileDetails {
+func NewFileRequestReceiveFileDetails(SubmittedFileNames []string) *FileRequestReceiveFileDetails {
 	s := new(FileRequestReceiveFileDetails)
-	s.RequestTitle = RequestTitle
 	s.SubmittedFileNames = SubmittedFileNames
 	return s
 }
@@ -5151,26 +5280,24 @@ func NewFileRequestReceiveFileDetails(RequestTitle string, SubmittedFileNames []
 // FileRequestRemoveDeadlineDetails : Removed the file request deadline.
 type FileRequestRemoveDeadlineDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestRemoveDeadlineDetails returns a new FileRequestRemoveDeadlineDetails instance
-func NewFileRequestRemoveDeadlineDetails(RequestTitle string) *FileRequestRemoveDeadlineDetails {
+func NewFileRequestRemoveDeadlineDetails() *FileRequestRemoveDeadlineDetails {
 	s := new(FileRequestRemoveDeadlineDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
 // FileRequestSendDetails : Sent file request to users via email.
 type FileRequestSendDetails struct {
 	// RequestTitle : File request title.
-	RequestTitle string `json:"request_title"`
+	RequestTitle string `json:"request_title,omitempty"`
 }
 
 // NewFileRequestSendDetails returns a new FileRequestSendDetails instance
-func NewFileRequestSendDetails(RequestTitle string) *FileRequestSendDetails {
+func NewFileRequestSendDetails() *FileRequestSendDetails {
 	s := new(FileRequestSendDetails)
-	s.RequestTitle = RequestTitle
 	return s
 }
 
@@ -5223,6 +5350,21 @@ const (
 	FileRequestsPolicyOther    = "other"
 )
 
+// FileResolveCommentDetails : Resolved a file comment.
+type FileResolveCommentDetails struct {
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
+	// CommentText : Comment text. Might be missing due to historical data gap.
+	CommentText string `json:"comment_text,omitempty"`
+}
+
+// NewFileResolveCommentDetails returns a new FileResolveCommentDetails instance
+func NewFileResolveCommentDetails(TargetAssetIndex uint64) *FileResolveCommentDetails {
+	s := new(FileResolveCommentDetails)
+	s.TargetAssetIndex = TargetAssetIndex
+	return s
+}
+
 // FileRestoreDetails : Restored deleted files and/or folders.
 type FileRestoreDetails struct {
 }
@@ -5268,16 +5410,31 @@ func NewFileSaveCopyReferenceDetails(RelocateActionDetails []*RelocateAssetRefer
 
 // FileUnlikeCommentDetails : Unliked a file comment.
 type FileUnlikeCommentDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// CommentText : Comment text. Might be missing due to historical data gap.
 	CommentText string `json:"comment_text,omitempty"`
 }
 
 // NewFileUnlikeCommentDetails returns a new FileUnlikeCommentDetails instance
-func NewFileUnlikeCommentDetails(TargetIndex int64) *FileUnlikeCommentDetails {
+func NewFileUnlikeCommentDetails(TargetAssetIndex uint64) *FileUnlikeCommentDetails {
 	s := new(FileUnlikeCommentDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
+	return s
+}
+
+// FileUnresolveCommentDetails : Unresolved a file comment.
+type FileUnresolveCommentDetails struct {
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
+	// CommentText : Comment text. Might be missing due to historical data gap.
+	CommentText string `json:"comment_text,omitempty"`
+}
+
+// NewFileUnresolveCommentDetails returns a new FileUnresolveCommentDetails instance
+func NewFileUnresolveCommentDetails(TargetAssetIndex uint64) *FileUnresolveCommentDetails {
+	s := new(FileUnresolveCommentDetails)
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -5659,8 +5816,8 @@ type GroupUserManagementPolicy struct {
 
 // Valid tag values for GroupUserManagementPolicy
 const (
+	GroupUserManagementPolicyAdminsOnly = "admins_only"
 	GroupUserManagementPolicyAllUsers   = "all_users"
-	GroupUserManagementPolicyOnlyAdmins = "only_admins"
 	GroupUserManagementPolicyOther      = "other"
 )
 
@@ -5789,15 +5946,15 @@ func NewMemberChangeMembershipTypeDetails(PrevValue *TeamMembershipType, NewValu
 type MemberChangeNameDetails struct {
 	// NewValue : New user's name.
 	NewValue *UserNameLogInfo `json:"new_value"`
-	// PreviousValue : Previous user's name.
-	PreviousValue *UserNameLogInfo `json:"previous_value"`
+	// PreviousValue : Previous user's name. Might be missing due to historical
+	// data gap.
+	PreviousValue *UserNameLogInfo `json:"previous_value,omitempty"`
 }
 
 // NewMemberChangeNameDetails returns a new MemberChangeNameDetails instance
-func NewMemberChangeNameDetails(NewValue *UserNameLogInfo, PreviousValue *UserNameLogInfo) *MemberChangeNameDetails {
+func NewMemberChangeNameDetails(NewValue *UserNameLogInfo) *MemberChangeNameDetails {
 	s := new(MemberChangeNameDetails)
 	s.NewValue = NewValue
-	s.PreviousValue = PreviousValue
 	return s
 }
 
@@ -5855,9 +6012,9 @@ type MemberRequestsPolicy struct {
 
 // Valid tag values for MemberRequestsPolicy
 const (
+	MemberRequestsPolicyAutoAccept      = "auto_accept"
 	MemberRequestsPolicyDisabled        = "disabled"
 	MemberRequestsPolicyRequireApproval = "require_approval"
-	MemberRequestsPolicyAutoApproval    = "auto_approval"
 	MemberRequestsPolicyOther           = "other"
 )
 
@@ -5974,17 +6131,19 @@ const (
 // MemberTransferAccountContentsDetails : Transferred contents of a removed team
 // member account to another member.
 type MemberTransferAccountContentsDetails struct {
-	// SrcIndex : Source asset index.
-	SrcIndex int64 `json:"src_index"`
-	// DestIndex : Destination asset index.
-	DestIndex int64 `json:"dest_index"`
+	// SrcParticipantIndex : Source participant position in the Participants
+	// list.
+	SrcParticipantIndex uint64 `json:"src_participant_index"`
+	// DestParticipantIndex : Destination participant position in the
+	// Participants list.
+	DestParticipantIndex uint64 `json:"dest_participant_index"`
 }
 
 // NewMemberTransferAccountContentsDetails returns a new MemberTransferAccountContentsDetails instance
-func NewMemberTransferAccountContentsDetails(SrcIndex int64, DestIndex int64) *MemberTransferAccountContentsDetails {
+func NewMemberTransferAccountContentsDetails(SrcParticipantIndex uint64, DestParticipantIndex uint64) *MemberTransferAccountContentsDetails {
 	s := new(MemberTransferAccountContentsDetails)
-	s.SrcIndex = SrcIndex
-	s.DestIndex = DestIndex
+	s.SrcParticipantIndex = SrcParticipantIndex
+	s.DestParticipantIndex = DestParticipantIndex
 	return s
 }
 
@@ -6273,6 +6432,16 @@ const (
 	PaperAccessTypeOther     = "other"
 )
 
+// PaperAdminExportStartDetails : Exported all Paper documents in the team.
+type PaperAdminExportStartDetails struct {
+}
+
+// NewPaperAdminExportStartDetails returns a new PaperAdminExportStartDetails instance
+func NewPaperAdminExportStartDetails() *PaperAdminExportStartDetails {
+	s := new(PaperAdminExportStartDetails)
+	return s
+}
+
 // PaperChangeDeploymentPolicyDetails : Changed whether Dropbox Paper, when
 // enabled, is deployed to all teams or to specific members of the team.
 type PaperChangeDeploymentPolicyDetails struct {
@@ -6342,18 +6511,18 @@ func NewPaperContentAddMemberDetails(EventUuid string) *PaperContentAddMemberDet
 type PaperContentAddToFolderDetails struct {
 	// EventUuid : Event unique identifier.
 	EventUuid string `json:"event_uuid"`
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
-	// ParentIndex : Parent asset index.
-	ParentIndex int64 `json:"parent_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
+	// ParentAssetIndex : Parent asset position in the Assets list.
+	ParentAssetIndex uint64 `json:"parent_asset_index"`
 }
 
 // NewPaperContentAddToFolderDetails returns a new PaperContentAddToFolderDetails instance
-func NewPaperContentAddToFolderDetails(EventUuid string, TargetIndex int64, ParentIndex int64) *PaperContentAddToFolderDetails {
+func NewPaperContentAddToFolderDetails(EventUuid string, TargetAssetIndex uint64, ParentAssetIndex uint64) *PaperContentAddToFolderDetails {
 	s := new(PaperContentAddToFolderDetails)
 	s.EventUuid = EventUuid
-	s.TargetIndex = TargetIndex
-	s.ParentIndex = ParentIndex
+	s.TargetAssetIndex = TargetAssetIndex
+	s.ParentAssetIndex = ParentAssetIndex
 	return s
 }
 
@@ -6478,8 +6647,8 @@ type PaperDeploymentPolicy struct {
 
 // Valid tag values for PaperDeploymentPolicy
 const (
-	PaperDeploymentPolicyPartial = "partial"
 	PaperDeploymentPolicyFull    = "full"
+	PaperDeploymentPolicyPartial = "partial"
 	PaperDeploymentPolicyOther   = "other"
 )
 
@@ -6876,10 +7045,10 @@ type PaperMemberPolicy struct {
 
 // Valid tag values for PaperMemberPolicy
 const (
-	PaperMemberPolicyTeamOnly        = "team_only"
-	PaperMemberPolicyDefaultTeamOnly = "default_team_only"
-	PaperMemberPolicyDefaultAnyone   = "default_anyone"
-	PaperMemberPolicyOther           = "other"
+	PaperMemberPolicyAnyoneWithLink          = "anyone_with_link"
+	PaperMemberPolicyOnlyTeam                = "only_team"
+	PaperMemberPolicyTeamAndExplicitlyShared = "team_and_explicitly_shared"
+	PaperMemberPolicyOther                   = "other"
 )
 
 // PaperPolicy : Policy for enabling or disabling Dropbox Paper for the team.
@@ -6889,21 +7058,22 @@ type PaperPolicy struct {
 
 // Valid tag values for PaperPolicy
 const (
-	PaperPolicyDisabled = "disabled"
-	PaperPolicyEnabled  = "enabled"
-	PaperPolicyOther    = "other"
+	PaperPolicyDisabled    = "disabled"
+	PaperPolicyEnabled     = "enabled"
+	PaperPolicyUnspecified = "unspecified"
+	PaperPolicyOther       = "other"
 )
 
 // PaperTaggedValue : Paper tagged value.
 type PaperTaggedValue struct {
-	// Tag : Tag.
-	Tag string `json:"tag"`
+	// Ptag : Tag.
+	Ptag string `json:"ptag"`
 }
 
 // NewPaperTaggedValue returns a new PaperTaggedValue instance
-func NewPaperTaggedValue(Tag string) *PaperTaggedValue {
+func NewPaperTaggedValue(Ptag string) *PaperTaggedValue {
 	s := new(PaperTaggedValue)
-	s.Tag = Tag
+	s.Ptag = Ptag
 	return s
 }
 
@@ -7057,46 +7227,17 @@ const (
 // RelocateAssetReferencesLogInfo : Provides the indices of the source asset and
 // the destination asset for a relocate action.
 type RelocateAssetReferencesLogInfo struct {
-	// SrcIndex : Source asset index.
-	SrcIndex int64 `json:"src_index"`
-	// DestIndex : Destination asset index.
-	DestIndex int64 `json:"dest_index"`
+	// SrcAssetIndex : Source asset position in the Assets list.
+	SrcAssetIndex uint64 `json:"src_asset_index"`
+	// DestAssetIndex : Destination asset position in the Assets list.
+	DestAssetIndex uint64 `json:"dest_asset_index"`
 }
 
 // NewRelocateAssetReferencesLogInfo returns a new RelocateAssetReferencesLogInfo instance
-func NewRelocateAssetReferencesLogInfo(SrcIndex int64, DestIndex int64) *RelocateAssetReferencesLogInfo {
+func NewRelocateAssetReferencesLogInfo(SrcAssetIndex uint64, DestAssetIndex uint64) *RelocateAssetReferencesLogInfo {
 	s := new(RelocateAssetReferencesLogInfo)
-	s.SrcIndex = SrcIndex
-	s.DestIndex = DestIndex
-	return s
-}
-
-// RemoveLogoutUrlDetails : Removed single sign-on logout URL.
-type RemoveLogoutUrlDetails struct {
-	// PreviousValue : Previous single sign-on logout URL.
-	PreviousValue string `json:"previous_value"`
-	// NewValue : New single sign-on logout URL. Might be missing due to
-	// historical data gap.
-	NewValue string `json:"new_value,omitempty"`
-}
-
-// NewRemoveLogoutUrlDetails returns a new RemoveLogoutUrlDetails instance
-func NewRemoveLogoutUrlDetails(PreviousValue string) *RemoveLogoutUrlDetails {
-	s := new(RemoveLogoutUrlDetails)
-	s.PreviousValue = PreviousValue
-	return s
-}
-
-// RemoveSsoUrlDetails : Changed the sign-out URL for SSO.
-type RemoveSsoUrlDetails struct {
-	// PreviousValue : Previous single sign-on logout URL.
-	PreviousValue string `json:"previous_value"`
-}
-
-// NewRemoveSsoUrlDetails returns a new RemoveSsoUrlDetails instance
-func NewRemoveSsoUrlDetails(PreviousValue string) *RemoveSsoUrlDetails {
-	s := new(RemoveSsoUrlDetails)
-	s.PreviousValue = PreviousValue
+	s.SrcAssetIndex = SrcAssetIndex
+	s.DestAssetIndex = DestAssetIndex
 	return s
 }
 
@@ -7138,8 +7279,8 @@ func NewResellerSupportSessionStartDetails() *ResellerSupportSessionStartDetails
 
 // SfAddGroupDetails : Added the team to a shared folder.
 type SfAddGroupDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharingPermission : Sharing permission. Might be missing due to
@@ -7150,9 +7291,9 @@ type SfAddGroupDetails struct {
 }
 
 // NewSfAddGroupDetails returns a new SfAddGroupDetails instance
-func NewSfAddGroupDetails(TargetIndex int64, OriginalFolderName string, TeamName string) *SfAddGroupDetails {
+func NewSfAddGroupDetails(TargetAssetIndex uint64, OriginalFolderName string, TeamName string) *SfAddGroupDetails {
 	s := new(SfAddGroupDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	s.TeamName = TeamName
 	return s
@@ -7161,8 +7302,8 @@ func NewSfAddGroupDetails(TargetIndex int64, OriginalFolderName string, TeamName
 // SfAllowNonMembersToViewSharedLinksDetails : Allowed non collaborators to view
 // links to files in a shared folder.
 type SfAllowNonMembersToViewSharedLinksDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7171,9 +7312,9 @@ type SfAllowNonMembersToViewSharedLinksDetails struct {
 }
 
 // NewSfAllowNonMembersToViewSharedLinksDetails returns a new SfAllowNonMembersToViewSharedLinksDetails instance
-func NewSfAllowNonMembersToViewSharedLinksDetails(TargetIndex int64, OriginalFolderName string) *SfAllowNonMembersToViewSharedLinksDetails {
+func NewSfAllowNonMembersToViewSharedLinksDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfAllowNonMembersToViewSharedLinksDetails {
 	s := new(SfAllowNonMembersToViewSharedLinksDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7191,21 +7332,21 @@ func NewSfExternalInviteWarnDetails() *SfExternalInviteWarnDetails {
 
 // SfInviteGroupDetails : Invited a group to a shared folder.
 type SfInviteGroupDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 }
 
 // NewSfInviteGroupDetails returns a new SfInviteGroupDetails instance
-func NewSfInviteGroupDetails(TargetIndex int64) *SfInviteGroupDetails {
+func NewSfInviteGroupDetails(TargetAssetIndex uint64) *SfInviteGroupDetails {
 	s := new(SfInviteGroupDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SfNestDetails : Changed parent of shared folder.
 type SfNestDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// PrevParentNsId : Previous parent namespace ID. Might be missing due to
@@ -7217,9 +7358,9 @@ type SfNestDetails struct {
 }
 
 // NewSfNestDetails returns a new SfNestDetails instance
-func NewSfNestDetails(TargetIndex int64, OriginalFolderName string) *SfNestDetails {
+func NewSfNestDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfNestDetails {
 	s := new(SfNestDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7227,32 +7368,32 @@ func NewSfNestDetails(TargetIndex int64, OriginalFolderName string) *SfNestDetai
 // SfTeamDeclineDetails : Declined a team member's invitation to a shared
 // folder.
 type SfTeamDeclineDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSfTeamDeclineDetails returns a new SfTeamDeclineDetails instance
-func NewSfTeamDeclineDetails(TargetIndex int64, OriginalFolderName string) *SfTeamDeclineDetails {
+func NewSfTeamDeclineDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamDeclineDetails {
 	s := new(SfTeamDeclineDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
 
 // SfTeamGrantAccessDetails : Granted access to a shared folder.
 type SfTeamGrantAccessDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSfTeamGrantAccessDetails returns a new SfTeamGrantAccessDetails instance
-func NewSfTeamGrantAccessDetails(TargetIndex int64, OriginalFolderName string) *SfTeamGrantAccessDetails {
+func NewSfTeamGrantAccessDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamGrantAccessDetails {
 	s := new(SfTeamGrantAccessDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7260,8 +7401,8 @@ func NewSfTeamGrantAccessDetails(TargetIndex int64, OriginalFolderName string) *
 // SfTeamInviteChangeRoleDetails : Changed a team member's role in a shared
 // folder.
 type SfTeamInviteChangeRoleDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// NewSharingPermission : New sharing permission. Might be missing due to
@@ -7273,17 +7414,17 @@ type SfTeamInviteChangeRoleDetails struct {
 }
 
 // NewSfTeamInviteChangeRoleDetails returns a new SfTeamInviteChangeRoleDetails instance
-func NewSfTeamInviteChangeRoleDetails(TargetIndex int64, OriginalFolderName string) *SfTeamInviteChangeRoleDetails {
+func NewSfTeamInviteChangeRoleDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamInviteChangeRoleDetails {
 	s := new(SfTeamInviteChangeRoleDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
 
 // SfTeamInviteDetails : Invited team members to a shared folder.
 type SfTeamInviteDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharingPermission : Sharing permission. Might be missing due to
@@ -7292,25 +7433,25 @@ type SfTeamInviteDetails struct {
 }
 
 // NewSfTeamInviteDetails returns a new SfTeamInviteDetails instance
-func NewSfTeamInviteDetails(TargetIndex int64, OriginalFolderName string) *SfTeamInviteDetails {
+func NewSfTeamInviteDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamInviteDetails {
 	s := new(SfTeamInviteDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
 
 // SfTeamJoinDetails : Joined a team member's shared folder.
 type SfTeamJoinDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSfTeamJoinDetails returns a new SfTeamJoinDetails instance
-func NewSfTeamJoinDetails(TargetIndex int64, OriginalFolderName string) *SfTeamJoinDetails {
+func NewSfTeamJoinDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamJoinDetails {
 	s := new(SfTeamJoinDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7318,8 +7459,8 @@ func NewSfTeamJoinDetails(TargetIndex int64, OriginalFolderName string) *SfTeamJ
 // SfTeamJoinFromOobLinkDetails : Joined a team member's shared folder from a
 // link.
 type SfTeamJoinFromOobLinkDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// TokenKey : Shared link token key.
@@ -7330,25 +7471,25 @@ type SfTeamJoinFromOobLinkDetails struct {
 }
 
 // NewSfTeamJoinFromOobLinkDetails returns a new SfTeamJoinFromOobLinkDetails instance
-func NewSfTeamJoinFromOobLinkDetails(TargetIndex int64, OriginalFolderName string) *SfTeamJoinFromOobLinkDetails {
+func NewSfTeamJoinFromOobLinkDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamJoinFromOobLinkDetails {
 	s := new(SfTeamJoinFromOobLinkDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
 
 // SfTeamUninviteDetails : Unshared a folder with a team member.
 type SfTeamUninviteDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSfTeamUninviteDetails returns a new SfTeamUninviteDetails instance
-func NewSfTeamUninviteDetails(TargetIndex int64, OriginalFolderName string) *SfTeamUninviteDetails {
+func NewSfTeamUninviteDetails(TargetAssetIndex uint64, OriginalFolderName string) *SfTeamUninviteDetails {
 	s := new(SfTeamUninviteDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7356,8 +7497,8 @@ func NewSfTeamUninviteDetails(TargetIndex int64, OriginalFolderName string) *SfT
 // SharedContentAddInviteesDetails : Sent an email invitation to the membership
 // of a shared file or folder.
 type SharedContentAddInviteesDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharingPermission : Sharing permission. Might be missing due to
@@ -7366,17 +7507,17 @@ type SharedContentAddInviteesDetails struct {
 }
 
 // NewSharedContentAddInviteesDetails returns a new SharedContentAddInviteesDetails instance
-func NewSharedContentAddInviteesDetails(TargetIndex int64) *SharedContentAddInviteesDetails {
+func NewSharedContentAddInviteesDetails(TargetAssetIndex uint64) *SharedContentAddInviteesDetails {
 	s := new(SharedContentAddInviteesDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentAddLinkExpiryDetails : Added an expiry to the link for the
 // shared file or folder.
 type SharedContentAddLinkExpiryDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7390,9 +7531,9 @@ type SharedContentAddLinkExpiryDetails struct {
 }
 
 // NewSharedContentAddLinkExpiryDetails returns a new SharedContentAddLinkExpiryDetails instance
-func NewSharedContentAddLinkExpiryDetails(TargetIndex int64, ExpirationStartDate string, ExpirationDays int64) *SharedContentAddLinkExpiryDetails {
+func NewSharedContentAddLinkExpiryDetails(TargetAssetIndex uint64, ExpirationStartDate string, ExpirationDays int64) *SharedContentAddLinkExpiryDetails {
 	s := new(SharedContentAddLinkExpiryDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.ExpirationStartDate = ExpirationStartDate
 	s.ExpirationDays = ExpirationDays
 	return s
@@ -7401,8 +7542,8 @@ func NewSharedContentAddLinkExpiryDetails(TargetIndex int64, ExpirationStartDate
 // SharedContentAddLinkPasswordDetails : Added a password to the link for the
 // shared file or folder.
 type SharedContentAddLinkPasswordDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7411,17 +7552,17 @@ type SharedContentAddLinkPasswordDetails struct {
 }
 
 // NewSharedContentAddLinkPasswordDetails returns a new SharedContentAddLinkPasswordDetails instance
-func NewSharedContentAddLinkPasswordDetails(TargetIndex int64) *SharedContentAddLinkPasswordDetails {
+func NewSharedContentAddLinkPasswordDetails(TargetAssetIndex uint64) *SharedContentAddLinkPasswordDetails {
 	s := new(SharedContentAddLinkPasswordDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentAddMemberDetails : Added users and/or groups to the membership
 // of a shared file or folder.
 type SharedContentAddMemberDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharingPermission : Sharing permission. Might be missing due to
@@ -7433,17 +7574,17 @@ type SharedContentAddMemberDetails struct {
 }
 
 // NewSharedContentAddMemberDetails returns a new SharedContentAddMemberDetails instance
-func NewSharedContentAddMemberDetails(TargetIndex int64) *SharedContentAddMemberDetails {
+func NewSharedContentAddMemberDetails(TargetAssetIndex uint64) *SharedContentAddMemberDetails {
 	s := new(SharedContentAddMemberDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentChangeDownloadsPolicyDetails : Changed whether members can
 // download the shared file or folder.
 type SharedContentChangeDownloadsPolicyDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7457,9 +7598,9 @@ type SharedContentChangeDownloadsPolicyDetails struct {
 }
 
 // NewSharedContentChangeDownloadsPolicyDetails returns a new SharedContentChangeDownloadsPolicyDetails instance
-func NewSharedContentChangeDownloadsPolicyDetails(TargetIndex int64, NewValue *SharedContentDownloadsPolicy) *SharedContentChangeDownloadsPolicyDetails {
+func NewSharedContentChangeDownloadsPolicyDetails(TargetAssetIndex uint64, NewValue *SharedContentDownloadsPolicy) *SharedContentChangeDownloadsPolicyDetails {
 	s := new(SharedContentChangeDownloadsPolicyDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.NewValue = NewValue
 	return s
 }
@@ -7467,8 +7608,8 @@ func NewSharedContentChangeDownloadsPolicyDetails(TargetIndex int64, NewValue *S
 // SharedContentChangeInviteeRoleDetails : Changed the access type of an invitee
 // to a shared file or folder before the invitation was claimed.
 type SharedContentChangeInviteeRoleDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// NewSharingPermission : New sharing permission. Might be missing due to
@@ -7480,9 +7621,9 @@ type SharedContentChangeInviteeRoleDetails struct {
 }
 
 // NewSharedContentChangeInviteeRoleDetails returns a new SharedContentChangeInviteeRoleDetails instance
-func NewSharedContentChangeInviteeRoleDetails(TargetIndex int64, OriginalFolderName string) *SharedContentChangeInviteeRoleDetails {
+func NewSharedContentChangeInviteeRoleDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedContentChangeInviteeRoleDetails {
 	s := new(SharedContentChangeInviteeRoleDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7490,8 +7631,8 @@ func NewSharedContentChangeInviteeRoleDetails(TargetIndex int64, OriginalFolderN
 // SharedContentChangeLinkAudienceDetails : Changed the audience of the link for
 // a shared file or folder.
 type SharedContentChangeLinkAudienceDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7505,9 +7646,9 @@ type SharedContentChangeLinkAudienceDetails struct {
 }
 
 // NewSharedContentChangeLinkAudienceDetails returns a new SharedContentChangeLinkAudienceDetails instance
-func NewSharedContentChangeLinkAudienceDetails(TargetIndex int64, NewValue *LinkAudience) *SharedContentChangeLinkAudienceDetails {
+func NewSharedContentChangeLinkAudienceDetails(TargetAssetIndex uint64, NewValue *LinkAudience) *SharedContentChangeLinkAudienceDetails {
 	s := new(SharedContentChangeLinkAudienceDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.NewValue = NewValue
 	return s
 }
@@ -7515,8 +7656,8 @@ func NewSharedContentChangeLinkAudienceDetails(TargetIndex int64, NewValue *Link
 // SharedContentChangeLinkExpiryDetails : Changed the expiry of the link for the
 // shared file or folder.
 type SharedContentChangeLinkExpiryDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7530,9 +7671,9 @@ type SharedContentChangeLinkExpiryDetails struct {
 }
 
 // NewSharedContentChangeLinkExpiryDetails returns a new SharedContentChangeLinkExpiryDetails instance
-func NewSharedContentChangeLinkExpiryDetails(TargetIndex int64, ExpirationStartDate string, ExpirationDays int64) *SharedContentChangeLinkExpiryDetails {
+func NewSharedContentChangeLinkExpiryDetails(TargetAssetIndex uint64, ExpirationStartDate string, ExpirationDays int64) *SharedContentChangeLinkExpiryDetails {
 	s := new(SharedContentChangeLinkExpiryDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.ExpirationStartDate = ExpirationStartDate
 	s.ExpirationDays = ExpirationDays
 	return s
@@ -7541,8 +7682,8 @@ func NewSharedContentChangeLinkExpiryDetails(TargetIndex int64, ExpirationStartD
 // SharedContentChangeLinkPasswordDetails : Changed the password on the link for
 // the shared file or folder.
 type SharedContentChangeLinkPasswordDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7551,17 +7692,17 @@ type SharedContentChangeLinkPasswordDetails struct {
 }
 
 // NewSharedContentChangeLinkPasswordDetails returns a new SharedContentChangeLinkPasswordDetails instance
-func NewSharedContentChangeLinkPasswordDetails(TargetIndex int64) *SharedContentChangeLinkPasswordDetails {
+func NewSharedContentChangeLinkPasswordDetails(TargetAssetIndex uint64) *SharedContentChangeLinkPasswordDetails {
 	s := new(SharedContentChangeLinkPasswordDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentChangeMemberRoleDetails : Changed the access type of a shared
 // file or folder member.
 type SharedContentChangeMemberRoleDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// NewSharingPermission : New sharing permission. Might be missing due to
@@ -7576,17 +7717,17 @@ type SharedContentChangeMemberRoleDetails struct {
 }
 
 // NewSharedContentChangeMemberRoleDetails returns a new SharedContentChangeMemberRoleDetails instance
-func NewSharedContentChangeMemberRoleDetails(TargetIndex int64) *SharedContentChangeMemberRoleDetails {
+func NewSharedContentChangeMemberRoleDetails(TargetAssetIndex uint64) *SharedContentChangeMemberRoleDetails {
 	s := new(SharedContentChangeMemberRoleDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentChangeViewerInfoPolicyDetails : Changed whether members can see
 // who viewed the shared file or folder.
 type SharedContentChangeViewerInfoPolicyDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7600,9 +7741,9 @@ type SharedContentChangeViewerInfoPolicyDetails struct {
 }
 
 // NewSharedContentChangeViewerInfoPolicyDetails returns a new SharedContentChangeViewerInfoPolicyDetails instance
-func NewSharedContentChangeViewerInfoPolicyDetails(TargetIndex int64, NewValue *SharedContentViewerInfoPolicy) *SharedContentChangeViewerInfoPolicyDetails {
+func NewSharedContentChangeViewerInfoPolicyDetails(TargetAssetIndex uint64, NewValue *SharedContentViewerInfoPolicy) *SharedContentChangeViewerInfoPolicyDetails {
 	s := new(SharedContentChangeViewerInfoPolicyDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.NewValue = NewValue
 	return s
 }
@@ -7610,8 +7751,8 @@ func NewSharedContentChangeViewerInfoPolicyDetails(TargetIndex int64, NewValue *
 // SharedContentClaimInvitationDetails : Claimed membership to a team member's
 // shared folder.
 type SharedContentClaimInvitationDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedContentLink : Shared content link.
@@ -7619,9 +7760,9 @@ type SharedContentClaimInvitationDetails struct {
 }
 
 // NewSharedContentClaimInvitationDetails returns a new SharedContentClaimInvitationDetails instance
-func NewSharedContentClaimInvitationDetails(TargetIndex int64) *SharedContentClaimInvitationDetails {
+func NewSharedContentClaimInvitationDetails(TargetAssetIndex uint64) *SharedContentClaimInvitationDetails {
 	s := new(SharedContentClaimInvitationDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -7632,18 +7773,18 @@ type SharedContentCopyDetails struct {
 	// SharingPermission : Sharing permission. Might be missing due to
 	// historical data gap.
 	SharingPermission string `json:"sharing_permission,omitempty"`
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// RelocateActionDetails : Specifies the source and destination indices in
 	// the assets list.
 	RelocateActionDetails *RelocateAssetReferencesLogInfo `json:"relocate_action_details"`
 }
 
 // NewSharedContentCopyDetails returns a new SharedContentCopyDetails instance
-func NewSharedContentCopyDetails(SharedContentLink string, TargetIndex int64, RelocateActionDetails *RelocateAssetReferencesLogInfo) *SharedContentCopyDetails {
+func NewSharedContentCopyDetails(SharedContentLink string, TargetAssetIndex uint64, RelocateActionDetails *RelocateAssetReferencesLogInfo) *SharedContentCopyDetails {
 	s := new(SharedContentCopyDetails)
 	s.SharedContentLink = SharedContentLink
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.RelocateActionDetails = RelocateActionDetails
 	return s
 }
@@ -7655,15 +7796,15 @@ type SharedContentDownloadDetails struct {
 	// SharingPermission : Sharing permission. Might be missing due to
 	// historical data gap.
 	SharingPermission string `json:"sharing_permission,omitempty"`
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 }
 
 // NewSharedContentDownloadDetails returns a new SharedContentDownloadDetails instance
-func NewSharedContentDownloadDetails(SharedContentLink string, TargetIndex int64) *SharedContentDownloadDetails {
+func NewSharedContentDownloadDetails(SharedContentLink string, TargetAssetIndex uint64) *SharedContentDownloadDetails {
 	s := new(SharedContentDownloadDetails)
 	s.SharedContentLink = SharedContentLink
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -7682,16 +7823,16 @@ const (
 // SharedContentRelinquishMembershipDetails : Left the membership of a shared
 // file or folder.
 type SharedContentRelinquishMembershipDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSharedContentRelinquishMembershipDetails returns a new SharedContentRelinquishMembershipDetails instance
-func NewSharedContentRelinquishMembershipDetails(TargetIndex int64, OriginalFolderName string) *SharedContentRelinquishMembershipDetails {
+func NewSharedContentRelinquishMembershipDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedContentRelinquishMembershipDetails {
 	s := new(SharedContentRelinquishMembershipDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7699,16 +7840,16 @@ func NewSharedContentRelinquishMembershipDetails(TargetIndex int64, OriginalFold
 // SharedContentRemoveInviteeDetails : Removed an invitee from the membership of
 // a shared file or folder before it was claimed.
 type SharedContentRemoveInviteeDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSharedContentRemoveInviteeDetails returns a new SharedContentRemoveInviteeDetails instance
-func NewSharedContentRemoveInviteeDetails(TargetIndex int64, OriginalFolderName string) *SharedContentRemoveInviteeDetails {
+func NewSharedContentRemoveInviteeDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedContentRemoveInviteeDetails {
 	s := new(SharedContentRemoveInviteeDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -7716,8 +7857,8 @@ func NewSharedContentRemoveInviteeDetails(TargetIndex int64, OriginalFolderName 
 // SharedContentRemoveLinkExpiryDetails : Removed the expiry of the link for the
 // shared file or folder.
 type SharedContentRemoveLinkExpiryDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7726,17 +7867,17 @@ type SharedContentRemoveLinkExpiryDetails struct {
 }
 
 // NewSharedContentRemoveLinkExpiryDetails returns a new SharedContentRemoveLinkExpiryDetails instance
-func NewSharedContentRemoveLinkExpiryDetails(TargetIndex int64) *SharedContentRemoveLinkExpiryDetails {
+func NewSharedContentRemoveLinkExpiryDetails(TargetAssetIndex uint64) *SharedContentRemoveLinkExpiryDetails {
 	s := new(SharedContentRemoveLinkExpiryDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentRemoveLinkPasswordDetails : Removed the password on the link for
 // the shared file or folder.
 type SharedContentRemoveLinkPasswordDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7745,17 +7886,17 @@ type SharedContentRemoveLinkPasswordDetails struct {
 }
 
 // NewSharedContentRemoveLinkPasswordDetails returns a new SharedContentRemoveLinkPasswordDetails instance
-func NewSharedContentRemoveLinkPasswordDetails(TargetIndex int64) *SharedContentRemoveLinkPasswordDetails {
+func NewSharedContentRemoveLinkPasswordDetails(TargetAssetIndex uint64) *SharedContentRemoveLinkPasswordDetails {
 	s := new(SharedContentRemoveLinkPasswordDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentRemoveMemberDetails : Removed a user or a group from the
 // membership of a shared file or folder.
 type SharedContentRemoveMemberDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharingPermission : Sharing permission. Might be missing due to
@@ -7767,17 +7908,17 @@ type SharedContentRemoveMemberDetails struct {
 }
 
 // NewSharedContentRemoveMemberDetails returns a new SharedContentRemoveMemberDetails instance
-func NewSharedContentRemoveMemberDetails(TargetIndex int64) *SharedContentRemoveMemberDetails {
+func NewSharedContentRemoveMemberDetails(TargetAssetIndex uint64) *SharedContentRemoveMemberDetails {
 	s := new(SharedContentRemoveMemberDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentRequestAccessDetails : Requested to be on the membership of a
 // shared file or folder.
 type SharedContentRequestAccessDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 	// SharedContentLink : Shared content link.
@@ -7785,25 +7926,25 @@ type SharedContentRequestAccessDetails struct {
 }
 
 // NewSharedContentRequestAccessDetails returns a new SharedContentRequestAccessDetails instance
-func NewSharedContentRequestAccessDetails(TargetIndex int64) *SharedContentRequestAccessDetails {
+func NewSharedContentRequestAccessDetails(TargetAssetIndex uint64) *SharedContentRequestAccessDetails {
 	s := new(SharedContentRequestAccessDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
 // SharedContentUnshareDetails : Unshared a shared file or folder by clearing
 // its membership and turning off its link.
 type SharedContentUnshareDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name,omitempty"`
 }
 
 // NewSharedContentUnshareDetails returns a new SharedContentUnshareDetails instance
-func NewSharedContentUnshareDetails(TargetIndex int64) *SharedContentUnshareDetails {
+func NewSharedContentUnshareDetails(TargetAssetIndex uint64) *SharedContentUnshareDetails {
 	s := new(SharedContentUnshareDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -7814,15 +7955,15 @@ type SharedContentViewDetails struct {
 	// SharingPermission : Sharing permission. Might be missing due to
 	// historical data gap.
 	SharingPermission string `json:"sharing_permission,omitempty"`
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 }
 
 // NewSharedContentViewDetails returns a new SharedContentViewDetails instance
-func NewSharedContentViewDetails(SharedContentLink string, TargetIndex int64) *SharedContentViewDetails {
+func NewSharedContentViewDetails(SharedContentLink string, TargetAssetIndex uint64) *SharedContentViewDetails {
 	s := new(SharedContentViewDetails)
 	s.SharedContentLink = SharedContentLink
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -7841,8 +7982,8 @@ const (
 // SharedFolderChangeConfidentialityDetails : Set or unset the confidential flag
 // on a shared folder.
 type SharedFolderChangeConfidentialityDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// NewValue : New confidentiality value.
@@ -7853,9 +7994,9 @@ type SharedFolderChangeConfidentialityDetails struct {
 }
 
 // NewSharedFolderChangeConfidentialityDetails returns a new SharedFolderChangeConfidentialityDetails instance
-func NewSharedFolderChangeConfidentialityDetails(TargetIndex int64, OriginalFolderName string, NewValue *Confidentiality) *SharedFolderChangeConfidentialityDetails {
+func NewSharedFolderChangeConfidentialityDetails(TargetAssetIndex uint64, OriginalFolderName string, NewValue *Confidentiality) *SharedFolderChangeConfidentialityDetails {
 	s := new(SharedFolderChangeConfidentialityDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	s.NewValue = NewValue
 	return s
@@ -7864,8 +8005,8 @@ func NewSharedFolderChangeConfidentialityDetails(TargetIndex int64, OriginalFold
 // SharedFolderChangeLinkPolicyDetails : Changed who can access the shared
 // folder via a link.
 type SharedFolderChangeLinkPolicyDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7879,9 +8020,9 @@ type SharedFolderChangeLinkPolicyDetails struct {
 }
 
 // NewSharedFolderChangeLinkPolicyDetails returns a new SharedFolderChangeLinkPolicyDetails instance
-func NewSharedFolderChangeLinkPolicyDetails(TargetIndex int64, OriginalFolderName string, NewValue *SharedFolderLinkPolicy) *SharedFolderChangeLinkPolicyDetails {
+func NewSharedFolderChangeLinkPolicyDetails(TargetAssetIndex uint64, OriginalFolderName string, NewValue *SharedFolderLinkPolicy) *SharedFolderChangeLinkPolicyDetails {
 	s := new(SharedFolderChangeLinkPolicyDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	s.NewValue = NewValue
 	return s
@@ -7890,8 +8031,8 @@ func NewSharedFolderChangeLinkPolicyDetails(TargetIndex int64, OriginalFolderNam
 // SharedFolderChangeMemberManagementPolicyDetails : Changed who can manage the
 // membership of a shared folder.
 type SharedFolderChangeMemberManagementPolicyDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7905,9 +8046,9 @@ type SharedFolderChangeMemberManagementPolicyDetails struct {
 }
 
 // NewSharedFolderChangeMemberManagementPolicyDetails returns a new SharedFolderChangeMemberManagementPolicyDetails instance
-func NewSharedFolderChangeMemberManagementPolicyDetails(TargetIndex int64, OriginalFolderName string, NewValue *SharedFolderMembershipManagementPolicy) *SharedFolderChangeMemberManagementPolicyDetails {
+func NewSharedFolderChangeMemberManagementPolicyDetails(TargetAssetIndex uint64, OriginalFolderName string, NewValue *SharedFolderMembershipManagementPolicy) *SharedFolderChangeMemberManagementPolicyDetails {
 	s := new(SharedFolderChangeMemberManagementPolicyDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	s.NewValue = NewValue
 	return s
@@ -7916,8 +8057,8 @@ func NewSharedFolderChangeMemberManagementPolicyDetails(TargetIndex int64, Origi
 // SharedFolderChangeMemberPolicyDetails : Changed who can become a member of
 // the shared folder.
 type SharedFolderChangeMemberPolicyDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 	// SharedFolderType : Shared folder type. Might be missing due to historical
@@ -7931,9 +8072,9 @@ type SharedFolderChangeMemberPolicyDetails struct {
 }
 
 // NewSharedFolderChangeMemberPolicyDetails returns a new SharedFolderChangeMemberPolicyDetails instance
-func NewSharedFolderChangeMemberPolicyDetails(TargetIndex int64, OriginalFolderName string, NewValue *SharedFolderMemberPolicy) *SharedFolderChangeMemberPolicyDetails {
+func NewSharedFolderChangeMemberPolicyDetails(TargetAssetIndex uint64, OriginalFolderName string, NewValue *SharedFolderMemberPolicy) *SharedFolderChangeMemberPolicyDetails {
 	s := new(SharedFolderChangeMemberPolicyDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	s.NewValue = NewValue
 	return s
@@ -7941,17 +8082,17 @@ func NewSharedFolderChangeMemberPolicyDetails(TargetIndex int64, OriginalFolderN
 
 // SharedFolderCreateDetails : Created a shared folder.
 type SharedFolderCreateDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// ParentNsId : Parent namespace ID. Might be missing due to historical data
 	// gap.
 	ParentNsId string `json:"parent_ns_id,omitempty"`
 }
 
 // NewSharedFolderCreateDetails returns a new SharedFolderCreateDetails instance
-func NewSharedFolderCreateDetails(TargetIndex int64) *SharedFolderCreateDetails {
+func NewSharedFolderCreateDetails(TargetAssetIndex uint64) *SharedFolderCreateDetails {
 	s := new(SharedFolderCreateDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -7995,16 +8136,16 @@ const (
 
 // SharedFolderMountDetails : Added a shared folder to own Dropbox.
 type SharedFolderMountDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSharedFolderMountDetails returns a new SharedFolderMountDetails instance
-func NewSharedFolderMountDetails(TargetIndex int64, OriginalFolderName string) *SharedFolderMountDetails {
+func NewSharedFolderMountDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedFolderMountDetails {
 	s := new(SharedFolderMountDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -8012,32 +8153,32 @@ func NewSharedFolderMountDetails(TargetIndex int64, OriginalFolderName string) *
 // SharedFolderTransferOwnershipDetails : Transferred the ownership of a shared
 // folder to another member.
 type SharedFolderTransferOwnershipDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSharedFolderTransferOwnershipDetails returns a new SharedFolderTransferOwnershipDetails instance
-func NewSharedFolderTransferOwnershipDetails(TargetIndex int64, OriginalFolderName string) *SharedFolderTransferOwnershipDetails {
+func NewSharedFolderTransferOwnershipDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedFolderTransferOwnershipDetails {
 	s := new(SharedFolderTransferOwnershipDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
 
 // SharedFolderUnmountDetails : Deleted a shared folder from Dropbox.
 type SharedFolderUnmountDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 	// OriginalFolderName : Original shared folder name.
 	OriginalFolderName string `json:"original_folder_name"`
 }
 
 // NewSharedFolderUnmountDetails returns a new SharedFolderUnmountDetails instance
-func NewSharedFolderUnmountDetails(TargetIndex int64, OriginalFolderName string) *SharedFolderUnmountDetails {
+func NewSharedFolderUnmountDetails(TargetAssetIndex uint64, OriginalFolderName string) *SharedFolderUnmountDetails {
 	s := new(SharedFolderUnmountDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	s.OriginalFolderName = OriginalFolderName
 	return s
 }
@@ -8112,9 +8253,9 @@ type SharingFolderJoinPolicy struct {
 
 // Valid tag values for SharingFolderJoinPolicy
 const (
-	SharingFolderJoinPolicyTeamOnly = "team_only"
-	SharingFolderJoinPolicyAnyone   = "anyone"
-	SharingFolderJoinPolicyOther    = "other"
+	SharingFolderJoinPolicyFromAnyone   = "from_anyone"
+	SharingFolderJoinPolicyFromTeamOnly = "from_team_only"
+	SharingFolderJoinPolicyOther        = "other"
 )
 
 // SharingLinkPolicy : Policy for controlling if team members can share links
@@ -8125,10 +8266,10 @@ type SharingLinkPolicy struct {
 
 // Valid tag values for SharingLinkPolicy
 const (
-	SharingLinkPolicyTeamOnly        = "team_only"
-	SharingLinkPolicyDefaultTeamOnly = "default_team_only"
-	SharingLinkPolicyDefaultAnyone   = "default_anyone"
-	SharingLinkPolicyOther           = "other"
+	SharingLinkPolicyDefaultPrivate = "default_private"
+	SharingLinkPolicyDefaultPublic  = "default_public"
+	SharingLinkPolicyOnlyPrivate    = "only_private"
+	SharingLinkPolicyOther          = "other"
 )
 
 // SharingMemberPolicy : External sharing policy
@@ -8138,9 +8279,9 @@ type SharingMemberPolicy struct {
 
 // Valid tag values for SharingMemberPolicy
 const (
-	SharingMemberPolicyTeamOnly = "team_only"
-	SharingMemberPolicyAnyone   = "anyone"
-	SharingMemberPolicyOther    = "other"
+	SharingMemberPolicyAllow  = "allow"
+	SharingMemberPolicyForbid = "forbid"
+	SharingMemberPolicyOther  = "other"
 )
 
 // ShmodelAppCreateDetails : Created a link to a file using an app.
@@ -8399,8 +8540,8 @@ type SmartSyncOptOutPolicy struct {
 
 // Valid tag values for SmartSyncOptOutPolicy
 const (
-	SmartSyncOptOutPolicyOptedOut = "opted_out"
 	SmartSyncOptOutPolicyDefault  = "default"
+	SmartSyncOptOutPolicyOptedOut = "opted_out"
 	SmartSyncOptOutPolicyOther    = "other"
 )
 
@@ -8443,6 +8584,32 @@ const (
 	SpaceLimitsStatusOther       = "other"
 )
 
+// SsoAddLoginUrlDetails : Added sign-in URL for SSO.
+type SsoAddLoginUrlDetails struct {
+	// NewValue : New single sign-on login URL.
+	NewValue string `json:"new_value"`
+}
+
+// NewSsoAddLoginUrlDetails returns a new SsoAddLoginUrlDetails instance
+func NewSsoAddLoginUrlDetails(NewValue string) *SsoAddLoginUrlDetails {
+	s := new(SsoAddLoginUrlDetails)
+	s.NewValue = NewValue
+	return s
+}
+
+// SsoAddLogoutUrlDetails : Added sign-out URL for SSO.
+type SsoAddLogoutUrlDetails struct {
+	// NewValue : New single sign-on logout URL. Might be missing due to
+	// historical data gap.
+	NewValue string `json:"new_value,omitempty"`
+}
+
+// NewSsoAddLogoutUrlDetails returns a new SsoAddLogoutUrlDetails instance
+func NewSsoAddLogoutUrlDetails() *SsoAddLogoutUrlDetails {
+	s := new(SsoAddLogoutUrlDetails)
+	return s
+}
+
 // SsoChangeCertDetails : Changed the X.509 certificate for SSO.
 type SsoChangeCertDetails struct {
 	// CertificateDetails : SSO certificate details.
@@ -8474,17 +8641,17 @@ func NewSsoChangeLoginUrlDetails(PreviousValue string, NewValue string) *SsoChan
 
 // SsoChangeLogoutUrlDetails : Changed the sign-out URL for SSO.
 type SsoChangeLogoutUrlDetails struct {
-	// PreviousValue : Previous single sign-on logout URL.
-	PreviousValue string `json:"previous_value"`
+	// PreviousValue : Previous single sign-on logout URL. Might be missing due
+	// to historical data gap.
+	PreviousValue string `json:"previous_value,omitempty"`
 	// NewValue : New single sign-on logout URL. Might be missing due to
 	// historical data gap.
 	NewValue string `json:"new_value,omitempty"`
 }
 
 // NewSsoChangeLogoutUrlDetails returns a new SsoChangeLogoutUrlDetails instance
-func NewSsoChangeLogoutUrlDetails(PreviousValue string) *SsoChangeLogoutUrlDetails {
+func NewSsoChangeLogoutUrlDetails() *SsoChangeLogoutUrlDetails {
 	s := new(SsoChangeLogoutUrlDetails)
-	s.PreviousValue = PreviousValue
 	return s
 }
 
@@ -8546,6 +8713,32 @@ const (
 	SsoPolicyOther    = "other"
 )
 
+// SsoRemoveLoginUrlDetails : Removed the sign-in URL for SSO.
+type SsoRemoveLoginUrlDetails struct {
+	// PreviousValue : Previous single sign-on login URL.
+	PreviousValue string `json:"previous_value"`
+}
+
+// NewSsoRemoveLoginUrlDetails returns a new SsoRemoveLoginUrlDetails instance
+func NewSsoRemoveLoginUrlDetails(PreviousValue string) *SsoRemoveLoginUrlDetails {
+	s := new(SsoRemoveLoginUrlDetails)
+	s.PreviousValue = PreviousValue
+	return s
+}
+
+// SsoRemoveLogoutUrlDetails : Removed single sign-on logout URL.
+type SsoRemoveLogoutUrlDetails struct {
+	// PreviousValue : Previous single sign-on logout URL.
+	PreviousValue string `json:"previous_value"`
+}
+
+// NewSsoRemoveLogoutUrlDetails returns a new SsoRemoveLogoutUrlDetails instance
+func NewSsoRemoveLogoutUrlDetails(PreviousValue string) *SsoRemoveLogoutUrlDetails {
+	s := new(SsoRemoveLogoutUrlDetails)
+	s.PreviousValue = PreviousValue
+	return s
+}
+
 // TeamActivityCreateReportDetails : Created a team activity report.
 type TeamActivityCreateReportDetails struct {
 	// StartDate : Report start date.
@@ -8575,6 +8768,12 @@ type TeamEvent struct {
 	// was performed programmatically via the API the origin represents the API
 	// client.
 	Origin *OriginLogInfo `json:"origin,omitempty"`
+	// InvolveNonTeamMember : True if the action involved a non team member
+	// either as the actor or as one of the affected users.
+	InvolveNonTeamMember bool `json:"involve_non_team_member"`
+	// Context : The user or team on whose behalf the actor performed the
+	// action.
+	Context *ContextLogInfo `json:"context"`
 	// Participants : Zero or more users and/or groups that are affected by the
 	// action. Note that this list doesn't include any actors or users in
 	// context.
@@ -8583,12 +8782,6 @@ type TeamEvent struct {
 	// these include Dropbox files and folders but in the future we might add
 	// other asset types such as Paper documents, folders, projects, etc.
 	Assets []*AssetLogInfo `json:"assets,omitempty"`
-	// InvolveNonTeamMember : True if the action involved a non team member
-	// either as the actor or as one of the affected users.
-	InvolveNonTeamMember bool `json:"involve_non_team_member"`
-	// Context : The user or team on whose behalf the actor performed the
-	// action.
-	Context *ContextLogInfo `json:"context"`
 	// EventType : The particular type of action taken.
 	EventType *EventType `json:"event_type"`
 	// Details : The variable event schema applicable to this type of action,
@@ -8638,14 +8831,14 @@ func NewTeamFolderCreateDetails() *TeamFolderCreateDetails {
 // TeamFolderDowngradeDetails : Downgraded a team folder to a regular shared
 // folder.
 type TeamFolderDowngradeDetails struct {
-	// TargetIndex : Target asset index.
-	TargetIndex int64 `json:"target_index"`
+	// TargetAssetIndex : Target asset position in the Assets list.
+	TargetAssetIndex uint64 `json:"target_asset_index"`
 }
 
 // NewTeamFolderDowngradeDetails returns a new TeamFolderDowngradeDetails instance
-func NewTeamFolderDowngradeDetails(TargetIndex int64) *TeamFolderDowngradeDetails {
+func NewTeamFolderDowngradeDetails(TargetAssetIndex uint64) *TeamFolderDowngradeDetails {
 	s := new(TeamFolderDowngradeDetails)
-	s.TargetIndex = TargetIndex
+	s.TargetAssetIndex = TargetAssetIndex
 	return s
 }
 
@@ -8905,10 +9098,9 @@ type TfaPolicy struct {
 
 // Valid tag values for TfaPolicy
 const (
-	TfaPolicyDisabled = "disabled"
-	TfaPolicyOptional = "optional"
-	TfaPolicyRequired = "required"
-	TfaPolicyOther    = "other"
+	TfaPolicyAllowDisable = "allow_disable"
+	TfaPolicyStickyEnable = "sticky_enable"
+	TfaPolicyOther        = "other"
 )
 
 // TfaRemoveBackupPhoneDetails : Removed the backup phone for two-step
@@ -9046,34 +9238,34 @@ func NewWebSessionLogInfo() *WebSessionLogInfo {
 // WebSessionsChangeFixedLengthPolicyDetails : Changed how long team members can
 // stay signed in to Dropbox on the web.
 type WebSessionsChangeFixedLengthPolicyDetails struct {
-	// NewValue : New session length policy.
-	NewValue *WebSessionsFixedLengthPolicy `json:"new_value"`
-	// PreviousValue : Previous session length policy.
-	PreviousValue *WebSessionsFixedLengthPolicy `json:"previous_value"`
+	// NewValue : New session length policy. Might be missing due to historical
+	// data gap.
+	NewValue *WebSessionsFixedLengthPolicy `json:"new_value,omitempty"`
+	// PreviousValue : Previous session length policy. Might be missing due to
+	// historical data gap.
+	PreviousValue *WebSessionsFixedLengthPolicy `json:"previous_value,omitempty"`
 }
 
 // NewWebSessionsChangeFixedLengthPolicyDetails returns a new WebSessionsChangeFixedLengthPolicyDetails instance
-func NewWebSessionsChangeFixedLengthPolicyDetails(NewValue *WebSessionsFixedLengthPolicy, PreviousValue *WebSessionsFixedLengthPolicy) *WebSessionsChangeFixedLengthPolicyDetails {
+func NewWebSessionsChangeFixedLengthPolicyDetails() *WebSessionsChangeFixedLengthPolicyDetails {
 	s := new(WebSessionsChangeFixedLengthPolicyDetails)
-	s.NewValue = NewValue
-	s.PreviousValue = PreviousValue
 	return s
 }
 
 // WebSessionsChangeIdleLengthPolicyDetails : Changed how long team members can
 // be idle while signed in to Dropbox on the web.
 type WebSessionsChangeIdleLengthPolicyDetails struct {
-	// NewValue : New idle length policy.
-	NewValue *WebSessionsIdleLengthPolicy `json:"new_value"`
-	// PreviousValue : Previous idle length policy.
-	PreviousValue *WebSessionsIdleLengthPolicy `json:"previous_value"`
+	// NewValue : New idle length policy. Might be missing due to historical
+	// data gap.
+	NewValue *WebSessionsIdleLengthPolicy `json:"new_value,omitempty"`
+	// PreviousValue : Previous idle length policy. Might be missing due to
+	// historical data gap.
+	PreviousValue *WebSessionsIdleLengthPolicy `json:"previous_value,omitempty"`
 }
 
 // NewWebSessionsChangeIdleLengthPolicyDetails returns a new WebSessionsChangeIdleLengthPolicyDetails instance
-func NewWebSessionsChangeIdleLengthPolicyDetails(NewValue *WebSessionsIdleLengthPolicy, PreviousValue *WebSessionsIdleLengthPolicy) *WebSessionsChangeIdleLengthPolicyDetails {
+func NewWebSessionsChangeIdleLengthPolicyDetails() *WebSessionsChangeIdleLengthPolicyDetails {
 	s := new(WebSessionsChangeIdleLengthPolicyDetails)
-	s.NewValue = NewValue
-	s.PreviousValue = PreviousValue
 	return s
 }
 

--- a/dropbox/users_common/types.go
+++ b/dropbox/users_common/types.go
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // Package users_common : This namespace contains common data types used within
-// the users namespace
+// the users namespace.
 package users_common
 
 import "github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"

--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -120,7 +120,7 @@ class GoClientGenerator(CodeGenerator):
 
         headers = {}
         if not is_void_type(route.arg_data_type):
-            if host == 'content':
+            if host == 'content' or style in ['upload', 'download']:
                 headers["Dropbox-API-Arg"] = "string(b)"
             else:
                 headers["Content-Type"] = '"application/json"'


### PR DESCRIPTION
My main priority is getting the Paper SDK to work. It is currently missing a lot of new endpoints, but the latest API spec includes them. The problem is, when generating with the latest API spec, the generated code is broken, and hence, I have included a fix for it in the first commit.

There is a separate commit for bringing the rest of the SDK up to speed as well, and they all compile / build correctly (untested though, which is why I kept it separate).

From the looks of it, the changes made to the generator does not affect any existing code, besides the download endpoint for Paper, but that was already broken.

```
Update to latest Dropbox API spec, and re-generate Dropbox Paper API SDK
The updated API spec includes a fix to the download method, and
support for creating, and updating documents.

The client generator has also been updated to account for
`Content-upload`, and `Content-download` endpoint styles.
The previous implementation of download would fail with
a 400 bad request error as it was trying to pass the
export arguments as a JSON body payload. Instead, the
API expected the arguments in `Dropbox-API-Arg`.

Without the changes to the client generator, the `paper`
package would not compile as well because `b` (the arguments)
was not being used.
```
