### PR TITLE
Fix go1.6 incompatibility

### DIFF
--- a/dropbox/sdk.go
+++ b/dropbox/sdk.go
@@ -21,12 +21,12 @@
 package dropbox
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -21,12 +21,12 @@
 package dropbox
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 


### PR DESCRIPTION
This makes the repo compile-able with go1.6 again.

Note that "context" and "golang.org/x/net/context" are [aliased in go1.9](https://github.com/golang/net/blob/master/context/go19.go#L15) so this should not change anything.