### PR TITLE
Fix travis build to compile code in older go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ go:
   - 1.8.x
   - 1.9.x
 install: go get -u golang.org/x/oauth2
-before_script: go get -u github.com/mitchellh/gox
-script: gox -osarch="darwin/amd64 linux/amd64 windows/amd64" ./dropbox/...
+script:
+- set -e
+- GOOS=linux   GOARCH=amd64 go install ./...
+- GOOS=darwin  GOARCH=amd64 go install ./...
+- GOOS=windows GOARCH=amd64 go install ./...
+- set +e
 
 jobs:
   include:


### PR DESCRIPTION
This may take me a few tries to get right, so don't merge until I say I'm ready ;-)