### PR TITLE
Encode Dropbox-API-Arg according to the specification

### DIFF
--- a/dropbox/files/client.go
+++ b/dropbox/files/client.go
@@ -481,7 +481,7 @@ func (dbx *apiImpl) AlphaUpload(arg *CommitInfoWithProperties, content io.Reader
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -1640,7 +1640,7 @@ func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.Re
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	for k, v := range arg.ExtraHeaders {
 		headers[k] = v
@@ -1710,7 +1710,7 @@ func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, co
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -1777,7 +1777,7 @@ func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCl
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -1921,7 +1921,7 @@ func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.R
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -2120,7 +2120,7 @@ func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content 
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -2187,7 +2187,7 @@ func (dbx *apiImpl) GetThumbnailBatch(arg *GetThumbnailBatchArg) (res *GetThumbn
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3696,7 +3696,7 @@ func (dbx *apiImpl) Upload(arg *CommitInfo, content io.Reader) (res *FileMetadat
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3763,7 +3763,7 @@ func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content i
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3828,7 +3828,7 @@ func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Rea
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -3890,7 +3890,7 @@ func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -4089,7 +4089,7 @@ func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Re
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID

--- a/dropbox/paper/client.go
+++ b/dropbox/paper/client.go
@@ -178,7 +178,7 @@ func (dbx *apiImpl) DocsCreate(arg *PaperDocCreateArgs, content io.Reader) (res 
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -244,7 +244,7 @@ func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID
@@ -830,7 +830,7 @@ func (dbx *apiImpl) DocsUpdate(arg *PaperDocUpdateArgs, content io.Reader) (res 
 
 	headers := map[string]string{
 		"Content-Type":    "application/octet-stream",
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID

--- a/dropbox/sdk.go
+++ b/dropbox/sdk.go
@@ -21,6 +21,7 @@
 package dropbox
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -220,4 +221,21 @@ func HandleCommonAPIErrors(c Config, resp *http.Response, body []byte) error {
 		return e
 	}
 	return apiError
+}
+
+// HTTPHeaderSafeJSON encode the JSON passed in b []byte passed in in
+// a way that is suitable for HTTP headers.
+//
+// See: https://www.dropbox.com/developers/reference/json-encoding
+func HTTPHeaderSafeJSON(b []byte) string {
+	var s bytes.Buffer
+	s.Grow(len(b))
+	for _, r := range string(b) {
+		if r >= 0x007f {
+			fmt.Fprintf(&s, "\\u%04x", r)
+		} else {
+			s.WriteRune(r)
+		}
+	}
+	return s.String()
 }

--- a/dropbox/sharing/client.go
+++ b/dropbox/sharing/client.go
@@ -966,7 +966,7 @@ func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsShar
 	}
 
 	headers := map[string]string{
-		"Dropbox-API-Arg": string(b),
+		"Dropbox-API-Arg": dropbox.HTTPHeaderSafeJSON(b),
 	}
 	if dbx.Config.AsMemberID != "" {
 		headers["Dropbox-API-Select-User"] = dbx.Config.AsMemberID

--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -125,7 +125,7 @@ class GoClientBackend(CodeBackend):
         headers = {}
         if not is_void_type(route.arg_data_type):
             if host == 'content' or style in ['upload', 'download']:
-                headers["Dropbox-API-Arg"] = "string(b)"
+                headers["Dropbox-API-Arg"] = "dropbox.HTTPHeaderSafeJSON(b)"
             else:
                 headers["Content-Type"] = '"application/json"'
         if style == 'upload':

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -220,4 +221,21 @@ func HandleCommonAPIErrors(c Config, resp *http.Response, body []byte) error {
 		return e
 	}
 	return apiError
+}
+
+// HTTPHeaderSafeJSON encode the JSON passed in b []byte passed in in
+// a way that is suitable for HTTP headers.
+//
+// See: https://www.dropbox.com/developers/reference/json-encoding
+func HTTPHeaderSafeJSON(b []byte) string {
+	var s strings.Builder
+	s.Grow(len(b))
+	for _, r := range string(b) {
+		if r >= 0x007f {
+			fmt.Fprintf(&s, "\\u%04x", r)
+		} else {
+			s.WriteRune(r)
+		}
+	}
+	return s.String()
 }


### PR DESCRIPTION
As part of investigating a filename corruption issue, it was noted
that this SDK doesn't encode the Dropbox-API-Arg to make it "HTTP
header safe" according to the specification here:
https://www.dropbox.com/developers/reference/json-encoding

This fixes the encoding and updates the generator to apply it
everywhere.

Fixes #54