### PR TITLE
Fix generation for download-style RPCs

### DIFF
--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -144,7 +144,7 @@ class GoClientBackend(CodeBackend):
             else:
                 out("_ = resp")
 
-            if fmt_var(route.name) == "Download":
+            if route.attrs.get('style', 'rpc') == "download":
                 out("content = respBody")
             else:
                 out("_ = respBody")

--- a/v6/dropbox/files/client.go
+++ b/v6/dropbox/files/client.go
@@ -1241,7 +1241,7 @@ func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, co
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 
@@ -1279,7 +1279,7 @@ func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCl
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 
@@ -1404,7 +1404,7 @@ func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.R
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 
@@ -1518,7 +1518,7 @@ func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content 
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 
@@ -1556,7 +1556,7 @@ func (dbx *apiImpl) GetThumbnailV2(arg *ThumbnailV2Arg) (res *PreviewResult, con
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 

--- a/v6/dropbox/paper/client.go
+++ b/v6/dropbox/paper/client.go
@@ -342,7 +342,7 @@ func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult
 		return
 	}
 
-	_ = respBody
+	content = respBody
 	return
 }
 

--- a/v6/dropbox/sharing/client.go
+++ b/v6/dropbox/sharing/client.go
@@ -687,7 +687,7 @@ func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsShar
 		res = tmp.Folder
 
 	}
-	_ = respBody
+	content = respBody
 	return
 }
 


### PR DESCRIPTION
Download-style RPCs other than `files.Download` currently return a nil content.