### PR TITLE
Add context.Context support to API methods

### DIFF
--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -167,9 +167,9 @@ type Request struct {
 	ExtraHeaders map[string]string
 }
 
-func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
+func (c *Context) Execute(ctx context.Context, req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
 	url := c.URLGenerator(req.Host, req.Namespace, req.Route)
-	httpReq, err := http.NewRequest("POST", url, body)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, body)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Adds context.Context to HTTP requests for cancellation/timeouts, as requested in #108.

- Introduces ...Context variants for each API method, taking ctx as first arg.
- Original methods preserved for compatibility, delegating to ...Context with `context.Background()`.
- If `...WithContext` is preferred, adjust `name_suffix="Context"` and `'Context('` in the generator.
- Avoids breaking changes (e.g., no `ctx` in arg structs).
- The signature of `dropbox.context.Execute` is changed to take `ctx`, based on the assumption that this method is internal.
- In `Execute`, the call to `http.NewRequest` is replaced with `http.NewRequestWithContext`.
- No doc comments is set on ...Context methods; something like `// UploadContext is the context-aware version of Upload.` could be added.

Generated code is not updated by this commit. Example of impact:

Before:
```go
func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
  // implementation
}
```

After:
```go
func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
    return dbx.UploadContext(context.Background(), arg, content)
}

func (dbx *apiImpl) UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
    // implementation with ctx in Execute
}
```

Closes #108.