### PR TITLE
Fix time serialization format

### DIFF
--- a/generator/go_helpers.py
+++ b/generator/go_helpers.py
@@ -57,7 +57,7 @@ _type_table = {
     Float32: 'float32',
     Boolean: 'bool',
     String: 'string',
-    Timestamp: 'time.Time',
+    Timestamp: 'dropbox.DBXTime',
     Void: 'struct{}',
 }
 

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -212,7 +211,7 @@ func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, e
 			}
 
 			httpReq.Header.Set("Content-Type", "application/json")
-			httpReq.Body = ioutil.NopCloser(bytes.NewReader(serializedArg))
+			httpReq.Body = io.NopCloser(bytes.NewReader(serializedArg))
 			httpReq.ContentLength = int64(len(serializedArg))
 		case "upload", "download":
 			httpReq.Header.Set("Dropbox-API-Arg", string(serializedArg))
@@ -237,7 +236,7 @@ func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, e
 				return nil, nil, errors.New("Expected body in RPC response, got nil")
 			}
 
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if err != nil {
 				return nil, nil, err
@@ -250,7 +249,7 @@ func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, e
 		}
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, nil, err

--- a/v6/dropbox/file_requests/types.go
+++ b/v6/dropbox/file_requests/types.go
@@ -24,7 +24,6 @@ package file_requests
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 )
@@ -224,7 +223,7 @@ type FileRequest struct {
 	// with the app folder permission, this will be relative to the app folder.
 	Destination string `json:"destination,omitempty"`
 	// Created : When this file request was created.
-	Created time.Time `json:"created"`
+	Created dropbox.DBXTime `json:"created"`
 	// Deadline : The deadline for this file request. Only set if the request
 	// has a deadline.
 	Deadline *FileRequestDeadline `json:"deadline,omitempty"`
@@ -240,7 +239,7 @@ type FileRequest struct {
 }
 
 // NewFileRequest returns a new FileRequest instance
-func NewFileRequest(Id string, Url string, Title string, Created time.Time, IsOpen bool, FileCount int64) *FileRequest {
+func NewFileRequest(Id string, Url string, Title string, Created dropbox.DBXTime, IsOpen bool, FileCount int64) *FileRequest {
 	s := new(FileRequest)
 	s.Id = Id
 	s.Url = Url
@@ -254,14 +253,14 @@ func NewFileRequest(Id string, Url string, Title string, Created time.Time, IsOp
 // FileRequestDeadline : has no documentation (yet)
 type FileRequestDeadline struct {
 	// Deadline : The deadline for this file request.
-	Deadline time.Time `json:"deadline"`
+	Deadline dropbox.DBXTime `json:"deadline"`
 	// AllowLateUploads : If set, allow uploads after the deadline has passed.
 	// These uploads will be marked overdue.
 	AllowLateUploads *GracePeriod `json:"allow_late_uploads,omitempty"`
 }
 
 // NewFileRequestDeadline returns a new FileRequestDeadline instance
-func NewFileRequestDeadline(Deadline time.Time) *FileRequestDeadline {
+func NewFileRequestDeadline(Deadline dropbox.DBXTime) *FileRequestDeadline {
 	s := new(FileRequestDeadline)
 	s.Deadline = Deadline
 	return s

--- a/v6/dropbox/files/types.go
+++ b/v6/dropbox/files/types.go
@@ -24,7 +24,6 @@ package files
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/file_properties"
@@ -253,7 +252,7 @@ type CommitInfo struct {
 	// the Dropbox servers. It can also record an additional timestamp, provided
 	// by Dropbox desktop clients, mobile clients, and API apps of when the file
 	// was actually created or modified.
-	ClientModified *time.Time `json:"client_modified,omitempty"`
+	ClientModified *dropbox.DBXTime `json:"client_modified,omitempty"`
 	// Mute : Normally, users are made aware of any file modifications in their
 	// Dropbox account via notifications in the client software. If true, this
 	// tells the clients that this modification shouldn't result in a user
@@ -1346,7 +1345,7 @@ type FileLockMetadata struct {
 	// LockholderAccountId : The account ID of the lock holder if known.
 	LockholderAccountId string `json:"lockholder_account_id,omitempty"`
 	// Created : The timestamp of the lock was created.
-	Created *time.Time `json:"created,omitempty"`
+	Created *dropbox.DBXTime `json:"created,omitempty"`
 }
 
 // NewFileLockMetadata returns a new FileLockMetadata instance
@@ -1365,9 +1364,9 @@ type FileMetadata struct {
 	// verified (the Dropbox server stores whatever the desktop client sends
 	// up), this should only be used for display purposes (such as sorting) and
 	// not, for example, to determine if a file has changed or not.
-	ClientModified time.Time `json:"client_modified"`
+	ClientModified dropbox.DBXTime `json:"client_modified"`
 	// ServerModified : The last time the file was modified on Dropbox.
-	ServerModified time.Time `json:"server_modified"`
+	ServerModified dropbox.DBXTime `json:"server_modified"`
 	// Rev : A unique identifier for the current revision of a file. This field
 	// is the same rev as elsewhere in the API and can be used to detect changes
 	// and avoid conflicts.
@@ -1411,7 +1410,7 @@ type FileMetadata struct {
 }
 
 // NewFileMetadata returns a new FileMetadata instance
-func NewFileMetadata(Name string, Id string, ClientModified time.Time, ServerModified time.Time, Rev string, Size uint64) *FileMetadata {
+func NewFileMetadata(Name string, Id string, ClientModified dropbox.DBXTime, ServerModified dropbox.DBXTime, Rev string, Size uint64) *FileMetadata {
 	s := new(FileMetadata)
 	s.Name = Name
 	s.Id = Id
@@ -1577,11 +1576,11 @@ type GetCopyReferenceResult struct {
 	// Expires : The expiration date of the copy reference. This value is
 	// currently set to be far enough in the future so that expiration is
 	// effectively not an issue.
-	Expires time.Time `json:"expires"`
+	Expires dropbox.DBXTime `json:"expires"`
 }
 
 // NewGetCopyReferenceResult returns a new GetCopyReferenceResult instance
-func NewGetCopyReferenceResult(Metadata IsMetadata, CopyReference string, Expires time.Time) *GetCopyReferenceResult {
+func NewGetCopyReferenceResult(Metadata IsMetadata, CopyReference string, Expires dropbox.DBXTime) *GetCopyReferenceResult {
 	s := new(GetCopyReferenceResult)
 	s.Metadata = Metadata
 	s.CopyReference = CopyReference
@@ -1599,7 +1598,7 @@ func (u *GetCopyReferenceResult) UnmarshalJSON(b []byte) error {
 		// Expires : The expiration date of the copy reference. This value is
 		// currently set to be far enough in the future so that expiration is
 		// effectively not an issue.
-		Expires time.Time `json:"expires"`
+		Expires dropbox.DBXTime `json:"expires"`
 	}
 	var w wrap
 	if err := json.Unmarshal(b, &w); err != nil {
@@ -2231,7 +2230,7 @@ type ListRevisionsResult struct {
 	// latest revision of the file older than before_rev.
 	IsDeleted bool `json:"is_deleted"`
 	// ServerDeleted : The time of deletion if the file was deleted.
-	ServerDeleted *time.Time `json:"server_deleted,omitempty"`
+	ServerDeleted *dropbox.DBXTime `json:"server_deleted,omitempty"`
 	// Entries : The revisions for the file. Only revisions that are not deleted
 	// will show up here.
 	Entries []*FileMetadata `json:"entries"`
@@ -2526,7 +2525,7 @@ type MediaMetadata struct {
 	// Location : The GPS coordinate of the photo/video.
 	Location *GpsCoordinates `json:"location,omitempty"`
 	// TimeTaken : The timestamp when the photo/video is taken.
-	TimeTaken *time.Time `json:"time_taken,omitempty"`
+	TimeTaken *dropbox.DBXTime `json:"time_taken,omitempty"`
 }
 
 // NewMediaMetadata returns a new MediaMetadata instance
@@ -4268,7 +4267,7 @@ func NewSharedLinkFileInfo(Url string) *SharedLinkFileInfo {
 // SingleUserLock : has no documentation (yet)
 type SingleUserLock struct {
 	// Created : The time the lock was created.
-	Created time.Time `json:"created"`
+	Created dropbox.DBXTime `json:"created"`
 	// LockHolderAccountId : The account ID of the lock holder if known.
 	LockHolderAccountId string `json:"lock_holder_account_id"`
 	// LockHolderTeamId : The id of the team of the account holder if it exists.
@@ -4276,7 +4275,7 @@ type SingleUserLock struct {
 }
 
 // NewSingleUserLock returns a new SingleUserLock instance
-func NewSingleUserLock(Created time.Time, LockHolderAccountId string) *SingleUserLock {
+func NewSingleUserLock(Created dropbox.DBXTime, LockHolderAccountId string) *SingleUserLock {
 	s := new(SingleUserLock)
 	s.Created = Created
 	s.LockHolderAccountId = LockHolderAccountId

--- a/v6/dropbox/paper/types.go
+++ b/v6/dropbox/paper/types.go
@@ -29,7 +29,6 @@ package paper
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
@@ -138,7 +137,7 @@ type Cursor struct {
 	// time will have a very short expiration as docs do get modified very often
 	// and the modified time can be changed while the iteration is happening
 	// thus altering the results.
-	Expiration *time.Time `json:"expiration,omitempty"`
+	Expiration *dropbox.DBXTime `json:"expiration,omitempty"`
 }
 
 // NewCursor returns a new Cursor instance
@@ -347,7 +346,7 @@ type ListPaperDocsArgs struct {
 	Limit int32 `json:"limit"`
 	// StopAtDate : Do not return results beyond this date. Behavior depends on
 	// sort order.
-	StopAtDate *time.Time `json:"stop_at_date,omitempty"`
+	StopAtDate *dropbox.DBXTime `json:"stop_at_date,omitempty"`
 }
 
 // NewListPaperDocsArgs returns a new ListPaperDocsArgs instance
@@ -721,19 +720,19 @@ type PaperDocGetMetadataResult struct {
 	// Title : The Paper doc title.
 	Title string `json:"title"`
 	// CreatedDate : The Paper doc creation date.
-	CreatedDate time.Time `json:"created_date"`
+	CreatedDate dropbox.DBXTime `json:"created_date"`
 	// Status : The Paper doc status.
 	Status *PaperDocStatus `json:"status"`
 	// Revision : The Paper doc revision. Simply an ever increasing number.
 	Revision int64 `json:"revision"`
 	// LastUpdatedDate : The date when the Paper doc was last edited.
-	LastUpdatedDate time.Time `json:"last_updated_date"`
+	LastUpdatedDate dropbox.DBXTime `json:"last_updated_date"`
 	// LastEditor : The email address of the last editor of the Paper doc.
 	LastEditor string `json:"last_editor"`
 }
 
 // NewPaperDocGetMetadataResult returns a new PaperDocGetMetadataResult instance
-func NewPaperDocGetMetadataResult(DocId string, Owner string, Title string, CreatedDate time.Time, Status *PaperDocStatus, Revision int64, LastUpdatedDate time.Time, LastEditor string) *PaperDocGetMetadataResult {
+func NewPaperDocGetMetadataResult(DocId string, Owner string, Title string, CreatedDate dropbox.DBXTime, Status *PaperDocStatus, Revision int64, LastUpdatedDate dropbox.DBXTime, LastEditor string) *PaperDocGetMetadataResult {
 	s := new(PaperDocGetMetadataResult)
 	s.DocId = DocId
 	s.Owner = Owner

--- a/v6/dropbox/sharing/types.go
+++ b/v6/dropbox/sharing/types.go
@@ -24,7 +24,6 @@ package sharing
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -454,7 +453,7 @@ type LinkMetadata struct {
 	// Visibility : Who can access the link.
 	Visibility *Visibility `json:"visibility"`
 	// Expires : Expiration time, if set. By default the link won't expire.
-	Expires *time.Time `json:"expires,omitempty"`
+	Expires *dropbox.DBXTime `json:"expires,omitempty"`
 }
 
 // NewLinkMetadata returns a new LinkMetadata instance
@@ -690,7 +689,7 @@ type SharedContentLinkMetadataBase struct {
 	CurrentAudience *LinkAudience `json:"current_audience"`
 	// Expiry : Whether the link has an expiry set on it. A link with an expiry
 	// will have its audience changed to members when the expiry is reached.
-	Expiry *time.Time `json:"expiry,omitempty"`
+	Expiry *dropbox.DBXTime `json:"expiry,omitempty"`
 	// LinkPermissions : A list of permissions for actions you can perform on
 	// the link.
 	LinkPermissions []*LinkPermission `json:"link_permissions"`
@@ -811,7 +810,7 @@ type SharedLinkMetadata struct {
 	// slash.
 	Name string `json:"name"`
 	// Expires : Expiration time, if set. By default the link won't expire.
-	Expires *time.Time `json:"expires,omitempty"`
+	Expires *dropbox.DBXTime `json:"expires,omitempty"`
 	// PathLower : The lowercased full path in the user's Dropbox. This always
 	// starts with a slash. This field will only be present only if the linked
 	// file is in the authenticated user's dropbox and the user is the owner of
@@ -910,9 +909,9 @@ type FileLinkMetadata struct {
 	// server stores whatever the desktop client sends up), this should only be
 	// used for display purposes (such as sorting) and not, for example, to
 	// determine if a file has changed or not.
-	ClientModified time.Time `json:"client_modified"`
+	ClientModified dropbox.DBXTime `json:"client_modified"`
 	// ServerModified : The last time the file was modified on Dropbox.
-	ServerModified time.Time `json:"server_modified"`
+	ServerModified dropbox.DBXTime `json:"server_modified"`
 	// Rev : A unique identifier for the current revision of a file. This field
 	// is the same rev as elsewhere in the API and can be used to detect changes
 	// and avoid conflicts.
@@ -922,7 +921,7 @@ type FileLinkMetadata struct {
 }
 
 // NewFileLinkMetadata returns a new FileLinkMetadata instance
-func NewFileLinkMetadata(Url string, Name string, LinkPermissions *LinkPermissions, ClientModified time.Time, ServerModified time.Time, Rev string, Size uint64) *FileLinkMetadata {
+func NewFileLinkMetadata(Url string, Name string, LinkPermissions *LinkPermissions, ClientModified dropbox.DBXTime, ServerModified dropbox.DBXTime, Rev string, Size uint64) *FileLinkMetadata {
 	s := new(FileLinkMetadata)
 	s.Url = Url
 	s.Name = Name
@@ -1839,7 +1838,7 @@ func NewLinkAudienceOption(Audience *LinkAudience, Allowed bool) *LinkAudienceOp
 type LinkExpiry struct {
 	dropbox.Tagged
 	// SetExpiry : Set a new expiry or change an existing expiry.
-	SetExpiry time.Time `json:"set_expiry,omitempty"`
+	SetExpiry dropbox.DBXTime `json:"set_expiry,omitempty"`
 }
 
 // Valid tag values for LinkExpiry
@@ -1854,7 +1853,7 @@ func (u *LinkExpiry) UnmarshalJSON(body []byte) error {
 	type wrap struct {
 		dropbox.Tagged
 		// SetExpiry : Set a new expiry or change an existing expiry.
-		SetExpiry time.Time `json:"set_expiry,omitempty"`
+		SetExpiry dropbox.DBXTime `json:"set_expiry,omitempty"`
 	}
 	var w wrap
 	var err error
@@ -3842,7 +3841,7 @@ type SharedFileMetadata struct {
 	// this shared file. If the user was not invited to the shared file, the
 	// timestamp will indicate when the user was invited to the parent shared
 	// folder. This value may be absent.
-	TimeInvited *time.Time `json:"time_invited,omitempty"`
+	TimeInvited *dropbox.DBXTime `json:"time_invited,omitempty"`
 }
 
 // NewSharedFileMetadata returns a new SharedFileMetadata instance
@@ -3991,7 +3990,7 @@ type SharedFolderMetadata struct {
 	SharedFolderId string `json:"shared_folder_id"`
 	// TimeInvited : Timestamp indicating when the current user was invited to
 	// this shared folder.
-	TimeInvited time.Time `json:"time_invited"`
+	TimeInvited dropbox.DBXTime `json:"time_invited"`
 	// AccessInheritance : Whether the folder inherits its members from its
 	// parent.
 	AccessInheritance *AccessInheritance `json:"access_inheritance"`
@@ -4000,7 +3999,7 @@ type SharedFolderMetadata struct {
 }
 
 // NewSharedFolderMetadata returns a new SharedFolderMetadata instance
-func NewSharedFolderMetadata(AccessType *AccessLevel, IsInsideTeamFolder bool, IsTeamFolder bool, Name string, Policy *FolderPolicy, PreviewUrl string, SharedFolderId string, TimeInvited time.Time) *SharedFolderMetadata {
+func NewSharedFolderMetadata(AccessType *AccessLevel, IsInsideTeamFolder bool, IsTeamFolder bool, Name string, Policy *FolderPolicy, PreviewUrl string, SharedFolderId string, TimeInvited dropbox.DBXTime) *SharedFolderMetadata {
 	s := new(SharedFolderMetadata)
 	s.AccessType = AccessType
 	s.IsInsideTeamFolder = IsInsideTeamFolder
@@ -4102,7 +4101,7 @@ type SharedLinkSettings struct {
 	LinkPassword string `json:"link_password,omitempty"`
 	// Expires : Expiration time of the shared link. By default the link won't
 	// expire.
-	Expires *time.Time `json:"expires,omitempty"`
+	Expires *dropbox.DBXTime `json:"expires,omitempty"`
 	// Audience : The new audience who can benefit from the access level
 	// specified by the link's access level specified in the `link_access_level`
 	// field of `LinkPermissions`. This is used in conjunction with team
@@ -4646,7 +4645,7 @@ type UserFileMembershipInfo struct {
 	// TimeLastSeen : The UTC timestamp of when the user has last seen the
 	// content. Only populated if the user has seen the content and the caller
 	// has a plan that includes viewer history.
-	TimeLastSeen *time.Time `json:"time_last_seen,omitempty"`
+	TimeLastSeen *dropbox.DBXTime `json:"time_last_seen,omitempty"`
 	// PlatformType : The platform on which the user has last seen the content,
 	// or unknown.
 	PlatformType *seen_state.PlatformType `json:"platform_type,omitempty"`

--- a/v6/dropbox/team/types.go
+++ b/v6/dropbox/team/types.go
@@ -23,7 +23,6 @@ package team
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/account"
@@ -44,9 +43,9 @@ type DeviceSession struct {
 	// made.
 	Country string `json:"country,omitempty"`
 	// Created : The time this session was created.
-	Created *time.Time `json:"created,omitempty"`
+	Created *dropbox.DBXTime `json:"created,omitempty"`
 	// Updated : The time of the last activity from this session.
-	Updated *time.Time `json:"updated,omitempty"`
+	Updated *dropbox.DBXTime `json:"updated,omitempty"`
 }
 
 // NewDeviceSession returns a new DeviceSession instance
@@ -66,7 +65,7 @@ type ActiveWebSession struct {
 	// Browser : Information on the browser used for this web session.
 	Browser string `json:"browser"`
 	// Expires : The time this session expires.
-	Expires *time.Time `json:"expires,omitempty"`
+	Expires *dropbox.DBXTime `json:"expires,omitempty"`
 }
 
 // NewActiveWebSession returns a new ActiveWebSession instance
@@ -255,7 +254,7 @@ type ApiApp struct {
 	// PublisherUrl : The publisher's URL.
 	PublisherUrl string `json:"publisher_url,omitempty"`
 	// Linked : The time this application was linked.
-	Linked *time.Time `json:"linked,omitempty"`
+	Linked *dropbox.DBXTime `json:"linked,omitempty"`
 	// IsAppFolder : Whether the linked application uses a dedicated folder.
 	IsAppFolder bool `json:"is_app_folder"`
 }
@@ -403,9 +402,9 @@ func NewCustomQuotaUsersArg(Users []*UserSelectorArg) *CustomQuotaUsersArg {
 type DateRange struct {
 	// StartDate : Optional starting date (inclusive). If start_date is None or
 	// too long ago, this field will be set to 6 months ago.
-	StartDate *time.Time `json:"start_date,omitempty"`
+	StartDate *dropbox.DBXTime `json:"start_date,omitempty"`
 	// EndDate : Optional ending date (exclusive).
-	EndDate *time.Time `json:"end_date,omitempty"`
+	EndDate *dropbox.DBXTime `json:"end_date,omitempty"`
 }
 
 // NewDateRange returns a new DateRange instance
@@ -1856,7 +1855,7 @@ type LegalHoldHeldRevisionMetadata struct {
 	// OriginalFilePath : The original path of the held revision.
 	OriginalFilePath string `json:"original_file_path"`
 	// ServerModified : The last time the file was modified on Dropbox.
-	ServerModified time.Time `json:"server_modified"`
+	ServerModified dropbox.DBXTime `json:"server_modified"`
 	// AuthorMemberId : The member id of the revision's author.
 	AuthorMemberId string `json:"author_member_id"`
 	// AuthorMemberStatus : The member status of the revision's author.
@@ -1874,7 +1873,7 @@ type LegalHoldHeldRevisionMetadata struct {
 }
 
 // NewLegalHoldHeldRevisionMetadata returns a new LegalHoldHeldRevisionMetadata instance
-func NewLegalHoldHeldRevisionMetadata(NewFilename string, OriginalRevisionId string, OriginalFilePath string, ServerModified time.Time, AuthorMemberId string, AuthorMemberStatus *TeamMemberStatus, AuthorEmail string, FileType string, Size uint64, ContentHash string) *LegalHoldHeldRevisionMetadata {
+func NewLegalHoldHeldRevisionMetadata(NewFilename string, OriginalRevisionId string, OriginalFilePath string, ServerModified dropbox.DBXTime, AuthorMemberId string, AuthorMemberStatus *TeamMemberStatus, AuthorEmail string, FileType string, Size uint64, ContentHash string) *LegalHoldHeldRevisionMetadata {
 	s := new(LegalHoldHeldRevisionMetadata)
 	s.NewFilename = NewFilename
 	s.OriginalRevisionId = OriginalRevisionId
@@ -1898,20 +1897,20 @@ type LegalHoldPolicy struct {
 	// Description : A description of the legal hold policy.
 	Description string `json:"description,omitempty"`
 	// ActivationTime : The time at which the legal hold was activated.
-	ActivationTime *time.Time `json:"activation_time,omitempty"`
+	ActivationTime *dropbox.DBXTime `json:"activation_time,omitempty"`
 	// Members : Team members IDs and number of permanently deleted members
 	// under hold.
 	Members *MembersInfo `json:"members"`
 	// Status : The current state of the hold.
 	Status *LegalHoldStatus `json:"status"`
 	// StartDate : Start date of the legal hold policy.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : End date of the legal hold policy.
-	EndDate *time.Time `json:"end_date,omitempty"`
+	EndDate *dropbox.DBXTime `json:"end_date,omitempty"`
 }
 
 // NewLegalHoldPolicy returns a new LegalHoldPolicy instance
-func NewLegalHoldPolicy(Id string, Name string, Members *MembersInfo, Status *LegalHoldStatus, StartDate time.Time) *LegalHoldPolicy {
+func NewLegalHoldPolicy(Id string, Name string, Members *MembersInfo, Status *LegalHoldStatus, StartDate dropbox.DBXTime) *LegalHoldPolicy {
 	s := new(LegalHoldPolicy)
 	s.Id = Id
 	s.Name = Name
@@ -2104,9 +2103,9 @@ type LegalHoldsPolicyCreateArg struct {
 	// Members : List of team member IDs added to the hold.
 	Members []string `json:"members"`
 	// StartDate : start date of the legal hold policy.
-	StartDate *time.Time `json:"start_date,omitempty"`
+	StartDate *dropbox.DBXTime `json:"start_date,omitempty"`
 	// EndDate : end date of the legal hold policy.
-	EndDate *time.Time `json:"end_date,omitempty"`
+	EndDate *dropbox.DBXTime `json:"end_date,omitempty"`
 }
 
 // NewLegalHoldsPolicyCreateArg returns a new LegalHoldsPolicyCreateArg instance
@@ -3039,14 +3038,14 @@ type MemberProfile struct {
 	MembershipType *TeamMembershipType `json:"membership_type"`
 	// InvitedOn : The date and time the user was invited to the team (contains
 	// value only when the member's status matches `TeamMemberStatus.invited`).
-	InvitedOn *time.Time `json:"invited_on,omitempty"`
+	InvitedOn *dropbox.DBXTime `json:"invited_on,omitempty"`
 	// JoinedOn : The date and time the user joined as a member of a specific
 	// team.
-	JoinedOn *time.Time `json:"joined_on,omitempty"`
+	JoinedOn *dropbox.DBXTime `json:"joined_on,omitempty"`
 	// SuspendedOn : The date and time the user was suspended from the team
 	// (contains value only when the member's status matches
 	// `TeamMemberStatus.suspended`).
-	SuspendedOn *time.Time `json:"suspended_on,omitempty"`
+	SuspendedOn *dropbox.DBXTime `json:"suspended_on,omitempty"`
 	// PersistentId : Persistent ID that a team can attach to the user. The
 	// persistent ID is unique ID to be used for SAML authentication.
 	PersistentId string `json:"persistent_id,omitempty"`

--- a/v6/dropbox/team_common/types.go
+++ b/v6/dropbox/team_common/types.go
@@ -21,11 +21,7 @@
 // Package team_common : has no documentation (yet)
 package team_common
 
-import (
-	"time"
-
-	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
-)
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 
 // GroupManagementType : The group type determines how a group is managed.
 type GroupManagementType struct {
@@ -92,9 +88,9 @@ const (
 // TimeRange : Time range.
 type TimeRange struct {
 	// StartTime : Optional starting time (inclusive).
-	StartTime *time.Time `json:"start_time,omitempty"`
+	StartTime *dropbox.DBXTime `json:"start_time,omitempty"`
 	// EndTime : Optional ending time (exclusive).
-	EndTime *time.Time `json:"end_time,omitempty"`
+	EndTime *dropbox.DBXTime `json:"end_time,omitempty"`
 }
 
 // NewTimeRange returns a new TimeRange instance

--- a/v6/dropbox/team_log/types.go
+++ b/v6/dropbox/team_log/types.go
@@ -23,7 +23,6 @@ package team_log
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
@@ -3550,9 +3549,9 @@ type DeviceSessionLogInfo struct {
 	// IpAddress : The IP address of the last activity from this session.
 	IpAddress string `json:"ip_address,omitempty"`
 	// Created : The time this session was created.
-	Created *time.Time `json:"created,omitempty"`
+	Created *dropbox.DBXTime `json:"created,omitempty"`
 	// Updated : The time of the last activity from this session.
-	Updated *time.Time `json:"updated,omitempty"`
+	Updated *dropbox.DBXTime `json:"updated,omitempty"`
 }
 
 // NewDeviceSessionLogInfo returns a new DeviceSessionLogInfo instance
@@ -17399,7 +17398,7 @@ func NewFileRequestCreateType(Description string) *FileRequestCreateType {
 type FileRequestDeadline struct {
 	// Deadline : The deadline for this file request. Might be missing due to
 	// historical data gap.
-	Deadline *time.Time `json:"deadline,omitempty"`
+	Deadline *dropbox.DBXTime `json:"deadline,omitempty"`
 	// AllowLateUploads : If set, allow uploads after the deadline has passed.
 	AllowLateUploads string `json:"allow_late_uploads,omitempty"`
 }
@@ -18180,7 +18179,7 @@ type GetTeamEventsContinueError struct {
 	// `getEvents`. The associated value is the approximate timestamp of the
 	// most recent event returned by the cursor. This should be used as a
 	// resumption point when calling `getEvents` to obtain a new cursor.
-	Reset time.Time `json:"reset,omitempty"`
+	Reset dropbox.DBXTime `json:"reset,omitempty"`
 }
 
 // Valid tag values for GetTeamEventsContinueError
@@ -18201,7 +18200,7 @@ func (u *GetTeamEventsContinueError) UnmarshalJSON(body []byte) error {
 		// timestamp of the most recent event returned by the cursor. This
 		// should be used as a resumption point when calling `getEvents` to
 		// obtain a new cursor.
-		Reset time.Time `json:"reset,omitempty"`
+		Reset dropbox.DBXTime `json:"reset,omitempty"`
 	}
 	var w wrap
 	var err error
@@ -19500,9 +19499,9 @@ func (u *LegacyDeviceSessionLogInfo) UnmarshalJSON(b []byte) error {
 		// IpAddress : The IP address of the last activity from this session.
 		IpAddress string `json:"ip_address,omitempty"`
 		// Created : The time this session was created.
-		Created *time.Time `json:"created,omitempty"`
+		Created *dropbox.DBXTime `json:"created,omitempty"`
 		// Updated : The time of the last activity from this session.
-		Updated *time.Time `json:"updated,omitempty"`
+		Updated *dropbox.DBXTime `json:"updated,omitempty"`
 		// SessionInfo : Session unique id.
 		SessionInfo json.RawMessage `json:"session_info,omitempty"`
 		// DisplayName : The device name. Might be missing due to historical
@@ -19560,13 +19559,13 @@ type LegalHoldsActivateAHoldDetails struct {
 	// Name : Hold name.
 	Name string `json:"name"`
 	// StartDate : Hold start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Hold end date.
-	EndDate *time.Time `json:"end_date,omitempty"`
+	EndDate *dropbox.DBXTime `json:"end_date,omitempty"`
 }
 
 // NewLegalHoldsActivateAHoldDetails returns a new LegalHoldsActivateAHoldDetails instance
-func NewLegalHoldsActivateAHoldDetails(LegalHoldId string, Name string, StartDate time.Time) *LegalHoldsActivateAHoldDetails {
+func NewLegalHoldsActivateAHoldDetails(LegalHoldId string, Name string, StartDate dropbox.DBXTime) *LegalHoldsActivateAHoldDetails {
 	s := new(LegalHoldsActivateAHoldDetails)
 	s.LegalHoldId = LegalHoldId
 	s.Name = Name
@@ -19910,7 +19909,7 @@ type LinkSettingsLogInfo struct {
 	// Downloadable : Downloadable.
 	Downloadable bool `json:"downloadable"`
 	// ExpireAt : Expires at.
-	ExpireAt *time.Time `json:"expire_at,omitempty"`
+	ExpireAt *dropbox.DBXTime `json:"expire_at,omitempty"`
 	// PasswordRequired : Password required.
 	PasswordRequired bool `json:"password_required"`
 	// Url : Link URL.
@@ -21204,13 +21203,13 @@ const (
 // no expiration.
 type NoExpirationLinkGenCreateReportDetails struct {
 	// StartDate : Report start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Report end date.
-	EndDate time.Time `json:"end_date"`
+	EndDate dropbox.DBXTime `json:"end_date"`
 }
 
 // NewNoExpirationLinkGenCreateReportDetails returns a new NoExpirationLinkGenCreateReportDetails instance
-func NewNoExpirationLinkGenCreateReportDetails(StartDate time.Time, EndDate time.Time) *NoExpirationLinkGenCreateReportDetails {
+func NewNoExpirationLinkGenCreateReportDetails(StartDate dropbox.DBXTime, EndDate dropbox.DBXTime) *NoExpirationLinkGenCreateReportDetails {
 	s := new(NoExpirationLinkGenCreateReportDetails)
 	s.StartDate = StartDate
 	s.EndDate = EndDate
@@ -21261,13 +21260,13 @@ func NewNoExpirationLinkGenReportFailedType(Description string) *NoExpirationLin
 // passwords.
 type NoPasswordLinkGenCreateReportDetails struct {
 	// StartDate : Report start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Report end date.
-	EndDate time.Time `json:"end_date"`
+	EndDate dropbox.DBXTime `json:"end_date"`
 }
 
 // NewNoPasswordLinkGenCreateReportDetails returns a new NoPasswordLinkGenCreateReportDetails instance
-func NewNoPasswordLinkGenCreateReportDetails(StartDate time.Time, EndDate time.Time) *NoPasswordLinkGenCreateReportDetails {
+func NewNoPasswordLinkGenCreateReportDetails(StartDate dropbox.DBXTime, EndDate dropbox.DBXTime) *NoPasswordLinkGenCreateReportDetails {
 	s := new(NoPasswordLinkGenCreateReportDetails)
 	s.StartDate = StartDate
 	s.EndDate = EndDate
@@ -21318,13 +21317,13 @@ func NewNoPasswordLinkGenReportFailedType(Description string) *NoPasswordLinkGen
 // without passwords.
 type NoPasswordLinkViewCreateReportDetails struct {
 	// StartDate : Report start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Report end date.
-	EndDate time.Time `json:"end_date"`
+	EndDate dropbox.DBXTime `json:"end_date"`
 }
 
 // NewNoPasswordLinkViewCreateReportDetails returns a new NoPasswordLinkViewCreateReportDetails instance
-func NewNoPasswordLinkViewCreateReportDetails(StartDate time.Time, EndDate time.Time) *NoPasswordLinkViewCreateReportDetails {
+func NewNoPasswordLinkViewCreateReportDetails(StartDate dropbox.DBXTime, EndDate dropbox.DBXTime) *NoPasswordLinkViewCreateReportDetails {
 	s := new(NoPasswordLinkViewCreateReportDetails)
 	s.StartDate = StartDate
 	s.EndDate = EndDate
@@ -21770,13 +21769,13 @@ func NewOriginLogInfo(AccessMethod *AccessMethodLogInfo) *OriginLogInfo {
 // OutdatedLinkViewCreateReportDetails : Report created: Views of old links.
 type OutdatedLinkViewCreateReportDetails struct {
 	// StartDate : Report start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Report end date.
-	EndDate time.Time `json:"end_date"`
+	EndDate dropbox.DBXTime `json:"end_date"`
 }
 
 // NewOutdatedLinkViewCreateReportDetails returns a new OutdatedLinkViewCreateReportDetails instance
-func NewOutdatedLinkViewCreateReportDetails(StartDate time.Time, EndDate time.Time) *OutdatedLinkViewCreateReportDetails {
+func NewOutdatedLinkViewCreateReportDetails(StartDate dropbox.DBXTime, EndDate dropbox.DBXTime) *OutdatedLinkViewCreateReportDetails {
 	s := new(OutdatedLinkViewCreateReportDetails)
 	s.StartDate = StartDate
 	s.EndDate = EndDate
@@ -24403,11 +24402,11 @@ func NewResellerSupportSessionStartType(Description string) *ResellerSupportSess
 // RewindFolderDetails : Rewound a folder.
 type RewindFolderDetails struct {
 	// RewindFolderTargetTsMs : Folder was Rewound to this date.
-	RewindFolderTargetTsMs time.Time `json:"rewind_folder_target_ts_ms"`
+	RewindFolderTargetTsMs dropbox.DBXTime `json:"rewind_folder_target_ts_ms"`
 }
 
 // NewRewindFolderDetails returns a new RewindFolderDetails instance
-func NewRewindFolderDetails(RewindFolderTargetTsMs time.Time) *RewindFolderDetails {
+func NewRewindFolderDetails(RewindFolderTargetTsMs dropbox.DBXTime) *RewindFolderDetails {
 	s := new(RewindFolderDetails)
 	s.RewindFolderTargetTsMs = RewindFolderTargetTsMs
 	return s
@@ -25431,7 +25430,7 @@ func NewSharedContentAddInviteesType(Description string) *SharedContentAddInvite
 type SharedContentAddLinkExpiryDetails struct {
 	// NewValue : New shared content link expiration date. Might be missing due
 	// to historical data gap.
-	NewValue *time.Time `json:"new_value,omitempty"`
+	NewValue *dropbox.DBXTime `json:"new_value,omitempty"`
 }
 
 // NewSharedContentAddLinkExpiryDetails returns a new SharedContentAddLinkExpiryDetails instance
@@ -25601,10 +25600,10 @@ func NewSharedContentChangeLinkAudienceType(Description string) *SharedContentCh
 type SharedContentChangeLinkExpiryDetails struct {
 	// NewValue : New shared content link expiration date. Might be missing due
 	// to historical data gap.
-	NewValue *time.Time `json:"new_value,omitempty"`
+	NewValue *dropbox.DBXTime `json:"new_value,omitempty"`
 	// PreviousValue : Previous shared content link expiration date. Might be
 	// missing due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 }
 
 // NewSharedContentChangeLinkExpiryDetails returns a new SharedContentChangeLinkExpiryDetails instance
@@ -25906,7 +25905,7 @@ func NewSharedContentRemoveInviteesType(Description string) *SharedContentRemove
 type SharedContentRemoveLinkExpiryDetails struct {
 	// PreviousValue : Previous shared content link expiration date. Might be
 	// missing due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 }
 
 // NewSharedContentRemoveLinkExpiryDetails returns a new SharedContentRemoveLinkExpiryDetails instance
@@ -26492,14 +26491,14 @@ const (
 // SharedLinkAddExpiryDetails : Added shared link expiration date.
 type SharedLinkAddExpiryDetails struct {
 	// NewValue : New shared link expiration date.
-	NewValue time.Time `json:"new_value"`
+	NewValue dropbox.DBXTime `json:"new_value"`
 	// IsConsolidationAction : Indicates whether this was a consolidation action
 	// by system.
 	IsConsolidationAction bool `json:"is_consolidation_action,omitempty"`
 }
 
 // NewSharedLinkAddExpiryDetails returns a new SharedLinkAddExpiryDetails instance
-func NewSharedLinkAddExpiryDetails(NewValue time.Time) *SharedLinkAddExpiryDetails {
+func NewSharedLinkAddExpiryDetails(NewValue dropbox.DBXTime) *SharedLinkAddExpiryDetails {
 	s := new(SharedLinkAddExpiryDetails)
 	s.NewValue = NewValue
 	return s
@@ -26522,10 +26521,10 @@ func NewSharedLinkAddExpiryType(Description string) *SharedLinkAddExpiryType {
 type SharedLinkChangeExpiryDetails struct {
 	// NewValue : New shared link expiration date. Might be missing due to
 	// historical data gap.
-	NewValue *time.Time `json:"new_value,omitempty"`
+	NewValue *dropbox.DBXTime `json:"new_value,omitempty"`
 	// PreviousValue : Previous shared link expiration date. Might be missing
 	// due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 	// IsConsolidationAction : Indicates whether this was a consolidation action
 	// by system.
 	IsConsolidationAction bool `json:"is_consolidation_action,omitempty"`
@@ -26791,7 +26790,7 @@ func NewSharedLinkDownloadType(Description string) *SharedLinkDownloadType {
 type SharedLinkRemoveExpiryDetails struct {
 	// PreviousValue : Previous shared link expiration date. Might be missing
 	// due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 }
 
 // NewSharedLinkRemoveExpiryDetails returns a new SharedLinkRemoveExpiryDetails instance
@@ -26845,7 +26844,7 @@ type SharedLinkSettingsAddExpirationDetails struct {
 	SharedContentLink string `json:"shared_content_link,omitempty"`
 	// NewValue : New shared content link expiration date. Might be missing due
 	// to historical data gap.
-	NewValue *time.Time `json:"new_value,omitempty"`
+	NewValue *dropbox.DBXTime `json:"new_value,omitempty"`
 }
 
 // NewSharedLinkSettingsAddExpirationDetails returns a new SharedLinkSettingsAddExpirationDetails instance
@@ -26995,10 +26994,10 @@ type SharedLinkSettingsChangeExpirationDetails struct {
 	SharedContentLink string `json:"shared_content_link,omitempty"`
 	// NewValue : New shared content link expiration date. Might be missing due
 	// to historical data gap.
-	NewValue *time.Time `json:"new_value,omitempty"`
+	NewValue *dropbox.DBXTime `json:"new_value,omitempty"`
 	// PreviousValue : Previous shared content link expiration date. Might be
 	// missing due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 }
 
 // NewSharedLinkSettingsChangeExpirationDetails returns a new SharedLinkSettingsChangeExpirationDetails instance
@@ -27059,7 +27058,7 @@ type SharedLinkSettingsRemoveExpirationDetails struct {
 	SharedContentLink string `json:"shared_content_link,omitempty"`
 	// PreviousValue : Previous shared link expiration date. Might be missing
 	// due to historical data gap.
-	PreviousValue *time.Time `json:"previous_value,omitempty"`
+	PreviousValue *dropbox.DBXTime `json:"previous_value,omitempty"`
 }
 
 // NewSharedLinkSettingsRemoveExpirationDetails returns a new SharedLinkSettingsRemoveExpirationDetails instance
@@ -29296,13 +29295,13 @@ func NewStartedEnterpriseAdminSessionType(Description string) *StartedEnterprise
 // TeamActivityCreateReportDetails : Created team activity report.
 type TeamActivityCreateReportDetails struct {
 	// StartDate : Report start date.
-	StartDate time.Time `json:"start_date"`
+	StartDate dropbox.DBXTime `json:"start_date"`
 	// EndDate : Report end date.
-	EndDate time.Time `json:"end_date"`
+	EndDate dropbox.DBXTime `json:"end_date"`
 }
 
 // NewTeamActivityCreateReportDetails returns a new TeamActivityCreateReportDetails instance
-func NewTeamActivityCreateReportDetails(StartDate time.Time, EndDate time.Time) *TeamActivityCreateReportDetails {
+func NewTeamActivityCreateReportDetails(StartDate dropbox.DBXTime, EndDate dropbox.DBXTime) *TeamActivityCreateReportDetails {
 	s := new(TeamActivityCreateReportDetails)
 	s.StartDate = StartDate
 	s.EndDate = EndDate
@@ -29618,7 +29617,7 @@ func NewTeamEncryptionKeyScheduleKeyDeletionType(Description string) *TeamEncryp
 // TeamEvent : An audit log event.
 type TeamEvent struct {
 	// Timestamp : The Dropbox timestamp representing when the action was taken.
-	Timestamp time.Time `json:"timestamp"`
+	Timestamp dropbox.DBXTime `json:"timestamp"`
 	// EventCategory : The category that this type of action belongs to.
 	EventCategory *EventCategory `json:"event_category"`
 	// Actor : The entity who actually performed the action.
@@ -29650,7 +29649,7 @@ type TeamEvent struct {
 }
 
 // NewTeamEvent returns a new TeamEvent instance
-func NewTeamEvent(Timestamp time.Time, EventCategory *EventCategory, EventType *EventType, Details *EventDetails) *TeamEvent {
+func NewTeamEvent(Timestamp dropbox.DBXTime, EventCategory *EventCategory, EventType *EventType, Details *EventDetails) *TeamEvent {
 	s := new(TeamEvent)
 	s.Timestamp = Timestamp
 	s.EventCategory = EventCategory

--- a/v6/dropbox/time.go
+++ b/v6/dropbox/time.go
@@ -1,0 +1,49 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dropbox
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const dbxTimeFormat = "2006-01-02T15:04:05Z"
+
+// DBXTime wraps time.Time to serialize in the format Dropbox API expects:
+// UTC, second precision, with a literal "Z" suffix.
+type DBXTime time.Time
+
+func (t DBXTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(t).UTC().Truncate(time.Second).Format(dbxTimeFormat))
+}
+
+func (t *DBXTime) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := time.Parse(dbxTimeFormat, s)
+	if err != nil {
+		return err
+	}
+	*t = DBXTime(parsed)
+	return nil
+}

--- a/v6/dropbox/time_test.go
+++ b/v6/dropbox/time_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dropbox
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDBXTimeMarshalUTC(t *testing.T) {
+	// A UTC time with no nanoseconds should serialize cleanly
+	ts := time.Date(2022, 2, 24, 8, 50, 46, 0, time.UTC)
+	dbxTime := DBXTime(ts)
+
+	b, err := json.Marshal(dbxTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `"2022-02-24T08:50:46Z"`
+	if string(b) != want {
+		t.Errorf("got %s, want %s", string(b), want)
+	}
+}
+
+func TestDBXTimeMarshalNonUTCWithNanos(t *testing.T) {
+	// This is the exact bug from issue #109:
+	// time with nanoseconds and non-UTC timezone must be converted to UTC and truncated
+	loc := time.FixedZone("CST", 8*3600)
+	ts := time.Date(2022, 2, 24, 16, 50, 46, 921728694, loc)
+	dbxTime := DBXTime(ts)
+
+	b, err := json.Marshal(dbxTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Must produce UTC, no nanos, Z suffix
+	want := `"2022-02-24T08:50:46Z"`
+	if string(b) != want {
+		t.Errorf("got %s, want %s", string(b), want)
+	}
+}
+
+func TestDBXTimeUnmarshal(t *testing.T) {
+	input := `"2022-02-24T08:50:46Z"`
+	var dbxTime DBXTime
+	if err := json.Unmarshal([]byte(input), &dbxTime); err != nil {
+		t.Fatal(err)
+	}
+
+	got := time.Time(dbxTime)
+	want := time.Date(2022, 2, 24, 8, 50, 46, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDBXTimeRoundTrip(t *testing.T) {
+	loc := time.FixedZone("PST", -8*3600)
+	original := time.Date(2023, 6, 15, 10, 30, 0, 123456789, loc)
+	dbxTime := DBXTime(original)
+
+	b, err := json.Marshal(dbxTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded DBXTime
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	// After roundtrip, should be UTC-truncated
+	got := time.Time(decoded)
+	want := time.Date(2023, 6, 15, 18, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce `dropbox.DBXTime` type that marshals timestamps in the format Dropbox API expects: `2006-01-02T15:04:05Z` (UTC, second precision, literal Z suffix)
- Update generator (`go_helpers.py`) to emit `dropbox.DBXTime` instead of `time.Time` for all `Timestamp` fields
- Fix `io/ioutil` deprecation in generator template (`go_rsrc/sdk.go`)
- Regenerate all SDK types

Fixes #109

## Background

The Go SDK was using `time.Time` which serializes with nanoseconds and timezone offset (e.g. `2022-02-24T16:50:46.921728694+08:00`). The Dropbox API expects `%Y-%m-%dT%H:%M:%SZ` format. This caused `files/upload` and other endpoints to reject requests with `ClientModified` set.

## Test plan

- [x] `TestDBXTimeMarshalUTC` — UTC time serializes correctly
- [x] `TestDBXTimeMarshalNonUTCWithNanos` — reproduces exact bug from #109 (non-UTC + nanoseconds → UTC truncated)
- [x] `TestDBXTimeUnmarshal` — deserialize works
- [x] `TestDBXTimeRoundTrip` — marshal/unmarshal roundtrip preserves value
- [x] All existing tests pass
- [x] `go build ./...` and `go vet ./...` pass