### PR TITLE
Add context.Context support to all API methods

### DIFF
--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -36,35 +36,58 @@ class GoClientBackend(CodeBackend):
                     self.emit(self._generate_route_signature(namespace, route))
             self.emit()
 
+            self.emit('// ContextClient interface describes all routes in this namespace with context support')
+            with self.block('type ContextClient interface'):
+                self.emit('Client')
+                for route in namespace.routes:
+                    generate_doc(self, route, name_override=self._generate_route_name(route, context=True))
+                    self.emit(self._generate_route_signature(namespace, route, context=True))
+            self.emit()
+
             self.emit('type apiImpl dropbox.Context')
             for route in namespace.routes:
                 self._generate_route(namespace, route)
-            self.emit('// New returns a Client implementation for this namespace')
-            with self.block('func New(c dropbox.Config) Client'):
+            self.emit('// NewContext returns a ContextClient implementation for this namespace')
+            with self.block('func NewContext(c dropbox.Config) ContextClient'):
                 self.emit('ctx := apiImpl(dropbox.NewContext(c))')
                 self.emit('return &ctx')
+            self.emit()
+            self.emit('// New returns a Client implementation for this namespace')
+            with self.block('func New(c dropbox.Config) Client'):
+                self.emit('return NewContext(c)')
 
-    def _generate_route_signature(self, namespace, route):
+    def _generate_route_signature(self, namespace, route, context=False):
         req = fmt_type(route.arg_data_type, namespace)
         res = fmt_type(route.result_data_type, namespace, use_interface=True)
+        fn = self._generate_route_name(route, context=context)
+        style = route.attrs.get('style', 'rpc')
+
+        args = []
+        if context:
+            args.append('ctx context.Context')
+        if not is_void_type(route.arg_data_type):
+            args.append('arg %s' % req)
+        if style == 'upload':
+            args.append('content io.Reader')
+
+        rets = []
+        if not is_void_type(route.result_data_type):
+            rets.append('res %s' % res)
+        if style == 'download':
+            rets.append('content io.ReadCloser')
+        rets.append('err error')
+
+        return '{fn}({args}) ({rets})'.format(
+            fn=fn, args=', '.join(args), rets=', '.join(rets))
+
+    def _generate_route_name(self, route, context=False):
         fn = fmt_var(route.name)
         if route.version != 1:
             fn += 'V%d' % route.version
-        style = route.attrs.get('style', 'rpc')
 
-        arg = '' if is_void_type(route.arg_data_type) else 'arg {req}'
-        ret = '(err error)' if is_void_type(route.result_data_type) else \
-            '(res {res}, err error)'
-        signature = '{fn}(' + arg + ') ' + ret
-        if style == 'download':
-            signature = '{fn}(' + arg + \
-                ') (res {res}, content io.ReadCloser, err error)'
-        elif style == 'upload':
-            signature = '{fn}(' + arg + ', content io.Reader) ' + ret
-            if is_void_type(route.arg_data_type):
-                signature = '{fn}(content io.Reader) ' + ret
-        return signature.format(fn=fn, req=req, res=res)
-
+        if context:
+            fn += 'Context'
+        return fn
 
     def _generate_route(self, namespace, route):
         out = self.emit
@@ -72,6 +95,8 @@ class GoClientBackend(CodeBackend):
         route_name = route.name
         if route.version != 1:
             route_name += '_v%d' % route.version
+
+        route_style = route.attrs.get('style', 'rpc')
 
         fn = fmt_var(route.name)
         if route.version != 1:
@@ -85,9 +110,11 @@ class GoClientBackend(CodeBackend):
             out('EndpointError {err} `json:"error"`'.format(err=err))
         out()
 
-        signature = 'func (dbx *apiImpl) ' + self._generate_route_signature(
-            namespace, route)
-        with self.block(signature):
+        # Generate the Context variant (does the real work)
+        generate_doc(self, route, name_override=self._generate_route_name(route, context=True))
+        signature_context = 'func (dbx *apiImpl) ' + self._generate_route_signature(
+            namespace, route, context=True)
+        with self.block(signature_context):
             if route.deprecated is not None:
                 out('log.Printf("WARNING: API `%s` is deprecated")' % fn)
                 if route.deprecated.by is not None:
@@ -102,7 +129,7 @@ class GoClientBackend(CodeBackend):
                 "Namespace": namespace.name,
                 "Route": route_name,
                 "Auth": route.attrs.get('auth', ''),
-                "Style": route.attrs.get('style', 'rpc'),
+                "Style": route_style,
             }
 
             with self.block('req := dropbox.Request'):
@@ -116,13 +143,13 @@ class GoClientBackend(CodeBackend):
 
             out("var resp []byte")
             out("var respBody io.ReadCloser")
-            out("resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, {body})".format(
-                body="content" if route.attrs.get('style', '') == 'upload' else "nil"))
+            out("resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, {body})".format(
+                body="content" if route_style == 'upload' else "nil"))
             with self.block("if err != nil"):
                 out("var appErr {fn}APIError".format(fn=fn))
                 out("err = {auth}ParseError(err, &appErr)".format(
                     auth="auth." if namespace.name != "auth" else ""))
-                with self.block("if err == &appErr"):
+                with self.block("if errors.Is(err, &appErr)"):
                     out("err = appErr")
                 out("return")
             out()
@@ -144,9 +171,21 @@ class GoClientBackend(CodeBackend):
             else:
                 out("_ = resp")
 
-            if route.attrs.get('style', 'rpc') == "download":
+            if route_style == "download":
                 out("content = respBody")
             else:
                 out("_ = respBody")
             out('return')
+        out()
+
+        # Generate the non-context variant (delegates to Context variant)
+        signature = 'func (dbx *apiImpl) ' + self._generate_route_signature(
+            namespace, route, context=False)
+        with self.block(signature):
+            call_args = ['context.Background()']
+            if not is_void_type(route.arg_data_type):
+                call_args.append('arg')
+            if route_style == 'upload':
+                call_args.append('content')
+            out('return dbx.%sContext(%s)' % (fn, ', '.join(call_args)))
         out()

--- a/generator/go_helpers.py
+++ b/generator/go_helpers.py
@@ -122,12 +122,12 @@ def _doc_handler(tag, val):
         raise RuntimeError('Unknown doc ref tag %r' % tag)
 
 
-def generate_doc(code_generator, t):
+def generate_doc(code_generator, t, name_override=None):
     doc = t.doc
     if doc is None:
         doc = 'has no documentation (yet)'
     doc = code_generator.process_doc(doc, _doc_handler)
-    d = '%s : %s' % (fmt_var(t.name), doc)
+    d = '%s : %s' % (name_override or fmt_var(t.name), doc)
     if isinstance(t, ApiNamespace):
         d = 'Package %s : %s' % (t.name, doc)
     code_generator.emit_wrapped_text(d, prefix='// ')

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -166,9 +166,15 @@ type Request struct {
 	ExtraHeaders map[string]string
 }
 
+// Execute executes a Dropbox API request with a background context.
 func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
+	return c.ExecuteContext(context.Background(), req, body)
+}
+
+// ExecuteContext executes a Dropbox API request with the provided context.
+func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
 	url := c.URLGenerator(req.Host, req.Namespace, req.Route)
-	httpReq, err := http.NewRequest("POST", url, body)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/v6/dropbox/account/client.go
+++ b/v6/dropbox/account/client.go
@@ -21,7 +21,9 @@
 package account
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -38,6 +40,17 @@ type Client interface {
 	SetProfilePhoto(arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// DeleteProfilePhotoContext : Deletes the current user's profile photo.
+	DeleteProfilePhotoContext(ctx context.Context, arg *DeleteProfilePhotoArg) (res *DeleteProfilePhotoResult, err error)
+	// GetPhotoContext : This lovely endpoint gets the account photo of a given user.
+	GetPhotoContext(ctx context.Context, arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error)
+	// SetProfilePhotoContext : Sets a user's profile photo.
+	SetProfilePhotoContext(ctx context.Context, arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // DeleteProfilePhotoAPIError is an error-wrapper for the delete_profile_photo route
@@ -46,7 +59,8 @@ type DeleteProfilePhotoAPIError struct {
 	EndpointError *DeleteProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteProfilePhoto(arg *DeleteProfilePhotoArg) (res *DeleteProfilePhotoResult, err error) {
+// DeleteProfilePhotoContext : Deletes the current user's profile photo.
+func (dbx *apiImpl) DeleteProfilePhotoContext(ctx context.Context, arg *DeleteProfilePhotoArg) (res *DeleteProfilePhotoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "account",
@@ -59,11 +73,11 @@ func (dbx *apiImpl) DeleteProfilePhoto(arg *DeleteProfilePhotoArg) (res *DeleteP
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteProfilePhotoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -78,13 +92,18 @@ func (dbx *apiImpl) DeleteProfilePhoto(arg *DeleteProfilePhotoArg) (res *DeleteP
 	return
 }
 
+func (dbx *apiImpl) DeleteProfilePhoto(arg *DeleteProfilePhotoArg) (res *DeleteProfilePhotoResult, err error) {
+	return dbx.DeleteProfilePhotoContext(context.Background(), arg)
+}
+
 // GetPhotoAPIError is an error-wrapper for the get_photo route
 type GetPhotoAPIError struct {
 	dropbox.APIError
 	EndpointError *AccountPhotoGetError `json:"error"`
 }
 
-func (dbx *apiImpl) GetPhoto(arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error) {
+// GetPhotoContext : This lovely endpoint gets the account photo of a given user.
+func (dbx *apiImpl) GetPhotoContext(ctx context.Context, arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "account",
@@ -97,11 +116,11 @@ func (dbx *apiImpl) GetPhoto(arg *AccountPhotoGetArg) (res *AccountPhotoGetResul
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetPhotoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -116,13 +135,18 @@ func (dbx *apiImpl) GetPhoto(arg *AccountPhotoGetArg) (res *AccountPhotoGetResul
 	return
 }
 
+func (dbx *apiImpl) GetPhoto(arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error) {
+	return dbx.GetPhotoContext(context.Background(), arg)
+}
+
 // SetProfilePhotoAPIError is an error-wrapper for the set_profile_photo route
 type SetProfilePhotoAPIError struct {
 	dropbox.APIError
 	EndpointError *SetProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) SetProfilePhoto(arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error) {
+// SetProfilePhotoContext : Sets a user's profile photo.
+func (dbx *apiImpl) SetProfilePhotoContext(ctx context.Context, arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "account",
@@ -135,11 +159,11 @@ func (dbx *apiImpl) SetProfilePhoto(arg *SetProfilePhotoArg) (res *SetProfilePho
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SetProfilePhotoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -154,8 +178,17 @@ func (dbx *apiImpl) SetProfilePhoto(arg *SetProfilePhotoArg) (res *SetProfilePho
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) SetProfilePhoto(arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error) {
+	return dbx.SetProfilePhotoContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/auth/client.go
+++ b/v6/dropbox/auth/client.go
@@ -21,7 +21,9 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 
@@ -41,6 +43,20 @@ type Client interface {
 	TokenRevoke() (err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// TokenFromOauth1Context : Creates an OAuth 2.0 access token from the supplied
+	// OAuth 1.0 access token.
+	// Deprecated:
+	TokenFromOauth1Context(ctx context.Context, arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error)
+	// TokenRevokeContext : Disables the access token used to authenticate the call. If
+	// there is a corresponding refresh token for the access token, this
+	// disables that refresh token, as well as any other access tokens for that
+	// refresh token.
+	TokenRevokeContext(ctx context.Context) (err error)
+}
+
 type apiImpl dropbox.Context
 
 // TokenFromOauth1APIError is an error-wrapper for the token/from_oauth1 route
@@ -49,7 +65,10 @@ type TokenFromOauth1APIError struct {
 	EndpointError *TokenFromOAuth1Error `json:"error"`
 }
 
-func (dbx *apiImpl) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error) {
+// TokenFromOauth1Context : Creates an OAuth 2.0 access token from the supplied
+// OAuth 1.0 access token.
+// Deprecated:
+func (dbx *apiImpl) TokenFromOauth1Context(ctx context.Context, arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error) {
 	log.Printf("WARNING: API `TokenFromOauth1` is deprecated")
 
 	req := dropbox.Request{
@@ -64,11 +83,11 @@ func (dbx *apiImpl) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAut
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TokenFromOauth1APIError
 		err = ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -83,13 +102,21 @@ func (dbx *apiImpl) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAut
 	return
 }
 
+func (dbx *apiImpl) TokenFromOauth1(arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error) {
+	return dbx.TokenFromOauth1Context(context.Background(), arg)
+}
+
 // TokenRevokeAPIError is an error-wrapper for the token/revoke route
 type TokenRevokeAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) TokenRevoke() (err error) {
+// TokenRevokeContext : Disables the access token used to authenticate the call. If
+// there is a corresponding refresh token for the access token, this
+// disables that refresh token, as well as any other access tokens for that
+// refresh token.
+func (dbx *apiImpl) TokenRevokeContext(ctx context.Context) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "auth",
@@ -102,11 +129,11 @@ func (dbx *apiImpl) TokenRevoke() (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TokenRevokeAPIError
 		err = ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -117,8 +144,17 @@ func (dbx *apiImpl) TokenRevoke() (err error) {
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) TokenRevoke() (err error) {
+	return dbx.TokenRevokeContext(context.Background())
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/check/client.go
+++ b/v6/dropbox/check/client.go
@@ -21,7 +21,9 @@
 package check
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -46,6 +48,25 @@ type Client interface {
 	User(arg *EchoArg) (res *EchoResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// AppContext : This endpoint performs App Authentication, validating the supplied
+	// app key and secret, and returns the supplied string, to allow you to test
+	// your code and connection to the Dropbox API. It has no other effect. If
+	// you receive an HTTP 200 response with the supplied query, it indicates at
+	// least part of the Dropbox API infrastructure is working and that the app
+	// key and secret valid.
+	AppContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error)
+	// UserContext : This endpoint performs User Authentication, validating the
+	// supplied access token, and returns the supplied string, to allow you to
+	// test your code and connection to the Dropbox API. It has no other effect.
+	// If you receive an HTTP 200 response with the supplied query, it indicates
+	// at least part of the Dropbox API infrastructure is working and that the
+	// access token is valid.
+	UserContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // AppAPIError is an error-wrapper for the app route
@@ -54,7 +75,13 @@ type AppAPIError struct {
 	EndpointError *EchoError `json:"error"`
 }
 
-func (dbx *apiImpl) App(arg *EchoArg) (res *EchoResult, err error) {
+// AppContext : This endpoint performs App Authentication, validating the supplied
+// app key and secret, and returns the supplied string, to allow you to test
+// your code and connection to the Dropbox API. It has no other effect. If
+// you receive an HTTP 200 response with the supplied query, it indicates at
+// least part of the Dropbox API infrastructure is working and that the app
+// key and secret valid.
+func (dbx *apiImpl) AppContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "check",
@@ -67,11 +94,11 @@ func (dbx *apiImpl) App(arg *EchoArg) (res *EchoResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr AppAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -86,13 +113,23 @@ func (dbx *apiImpl) App(arg *EchoArg) (res *EchoResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) App(arg *EchoArg) (res *EchoResult, err error) {
+	return dbx.AppContext(context.Background(), arg)
+}
+
 // UserAPIError is an error-wrapper for the user route
 type UserAPIError struct {
 	dropbox.APIError
 	EndpointError *EchoError `json:"error"`
 }
 
-func (dbx *apiImpl) User(arg *EchoArg) (res *EchoResult, err error) {
+// UserContext : This endpoint performs User Authentication, validating the
+// supplied access token, and returns the supplied string, to allow you to
+// test your code and connection to the Dropbox API. It has no other effect.
+// If you receive an HTTP 200 response with the supplied query, it indicates
+// at least part of the Dropbox API infrastructure is working and that the
+// access token is valid.
+func (dbx *apiImpl) UserContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "check",
@@ -105,11 +142,11 @@ func (dbx *apiImpl) User(arg *EchoArg) (res *EchoResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -124,8 +161,17 @@ func (dbx *apiImpl) User(arg *EchoArg) (res *EchoResult, err error) {
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) User(arg *EchoArg) (res *EchoResult, err error) {
+	return dbx.UserContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/contacts/client.go
+++ b/v6/dropbox/contacts/client.go
@@ -21,6 +21,8 @@
 package contacts
 
 import (
+	"context"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -38,6 +40,18 @@ type Client interface {
 	DeleteManualContactsBatch(arg *DeleteManualContactsArg) (err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// DeleteManualContactsContext : Removes all manually added contacts. You'll still
+	// keep contacts who are on your team or who you imported. New contacts will
+	// be added when you share.
+	DeleteManualContactsContext(ctx context.Context) (err error)
+	// DeleteManualContactsBatchContext : Removes manually added contacts from the
+	// given list.
+	DeleteManualContactsBatchContext(ctx context.Context, arg *DeleteManualContactsArg) (err error)
+}
+
 type apiImpl dropbox.Context
 
 // DeleteManualContactsAPIError is an error-wrapper for the delete_manual_contacts route
@@ -46,7 +60,10 @@ type DeleteManualContactsAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteManualContacts() (err error) {
+// DeleteManualContactsContext : Removes all manually added contacts. You'll still
+// keep contacts who are on your team or who you imported. New contacts will
+// be added when you share.
+func (dbx *apiImpl) DeleteManualContactsContext(ctx context.Context) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "contacts",
@@ -59,11 +76,11 @@ func (dbx *apiImpl) DeleteManualContacts() (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteManualContactsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -74,13 +91,19 @@ func (dbx *apiImpl) DeleteManualContacts() (err error) {
 	return
 }
 
+func (dbx *apiImpl) DeleteManualContacts() (err error) {
+	return dbx.DeleteManualContactsContext(context.Background())
+}
+
 // DeleteManualContactsBatchAPIError is an error-wrapper for the delete_manual_contacts_batch route
 type DeleteManualContactsBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *DeleteManualContactsError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteManualContactsBatch(arg *DeleteManualContactsArg) (err error) {
+// DeleteManualContactsBatchContext : Removes manually added contacts from the
+// given list.
+func (dbx *apiImpl) DeleteManualContactsBatchContext(ctx context.Context, arg *DeleteManualContactsArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "contacts",
@@ -93,11 +116,11 @@ func (dbx *apiImpl) DeleteManualContactsBatch(arg *DeleteManualContactsArg) (err
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteManualContactsBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -108,8 +131,17 @@ func (dbx *apiImpl) DeleteManualContactsBatch(arg *DeleteManualContactsArg) (err
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) DeleteManualContactsBatch(arg *DeleteManualContactsArg) (err error) {
+	return dbx.DeleteManualContactsBatchContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/file_properties/client.go
+++ b/v6/dropbox/file_properties/client.go
@@ -21,7 +21,9 @@
 package file_properties
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -99,6 +101,78 @@ type Client interface {
 	TemplatesUpdateForUser(arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// PropertiesAddContext : Add property groups to a Dropbox file. See
+	// `templatesAddForUser` or `templatesAddForTeam` to create new templates.
+	PropertiesAddContext(ctx context.Context, arg *AddPropertiesArg) (err error)
+	// PropertiesOverwriteContext : Overwrite property groups associated with a file.
+	// This endpoint should be used instead of `propertiesUpdate` when property
+	// groups are being updated via a "snapshot" instead of via a "delta". In
+	// other words, this endpoint will delete all omitted fields from a property
+	// group, whereas `propertiesUpdate` will only delete fields that are
+	// explicitly marked for deletion.
+	PropertiesOverwriteContext(ctx context.Context, arg *OverwritePropertyGroupArg) (err error)
+	// PropertiesRemoveContext : Permanently removes the specified property group from
+	// the file. To remove specific property field key value pairs, see
+	// `propertiesUpdate`. To update a template, see `templatesUpdateForUser` or
+	// `templatesUpdateForTeam`. To remove a template, see
+	// `templatesRemoveForUser` or `templatesRemoveForTeam`.
+	PropertiesRemoveContext(ctx context.Context, arg *RemovePropertiesArg) (err error)
+	// PropertiesSearchContext : Search across property templates for particular
+	// property field values.
+	PropertiesSearchContext(ctx context.Context, arg *PropertiesSearchArg) (res *PropertiesSearchResult, err error)
+	// PropertiesSearchContinueContext : Once a cursor has been retrieved from
+	// `propertiesSearch`, use this to paginate through all search results.
+	PropertiesSearchContinueContext(ctx context.Context, arg *PropertiesSearchContinueArg) (res *PropertiesSearchResult, err error)
+	// PropertiesUpdateContext : Add, update or remove properties associated with the
+	// supplied file and templates. This endpoint should be used instead of
+	// `propertiesOverwrite` when property groups are being updated via a
+	// "delta" instead of via a "snapshot" . In other words, this endpoint will
+	// not delete any omitted fields from a property group, whereas
+	// `propertiesOverwrite` will delete any fields that are omitted from a
+	// property group.
+	PropertiesUpdateContext(ctx context.Context, arg *UpdatePropertiesArg) (err error)
+	// TemplatesAddForTeamContext : Add a template associated with a team. See
+	// `propertiesAdd` to add properties to a file or folder. Note: this
+	// endpoint will create team-owned templates.
+	TemplatesAddForTeamContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error)
+	// TemplatesAddForUserContext : Add a template associated with a user. See
+	// `propertiesAdd` to add properties to a file. This endpoint can't be
+	// called on a team member or admin's behalf.
+	TemplatesAddForUserContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error)
+	// TemplatesGetForTeamContext : Get the schema for a specified template.
+	TemplatesGetForTeamContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error)
+	// TemplatesGetForUserContext : Get the schema for a specified template. This
+	// endpoint can't be called on a team member or admin's behalf.
+	TemplatesGetForUserContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error)
+	// TemplatesListForTeamContext : Get the template identifiers for a team. To get
+	// the schema of each template use `templatesGetForTeam`.
+	TemplatesListForTeamContext(ctx context.Context) (res *ListTemplateResult, err error)
+	// TemplatesListForUserContext : Get the template identifiers for a team. To get
+	// the schema of each template use `templatesGetForUser`. This endpoint
+	// can't be called on a team member or admin's behalf.
+	TemplatesListForUserContext(ctx context.Context) (res *ListTemplateResult, err error)
+	// TemplatesRemoveForTeamContext : Permanently removes the specified template
+	// created from `templatesAddForUser`. All properties associated with the
+	// template will also be removed. This action cannot be undone.
+	TemplatesRemoveForTeamContext(ctx context.Context, arg *RemoveTemplateArg) (err error)
+	// TemplatesRemoveForUserContext : Permanently removes the specified template
+	// created from `templatesAddForUser`. All properties associated with the
+	// template will also be removed. This action cannot be undone.
+	TemplatesRemoveForUserContext(ctx context.Context, arg *RemoveTemplateArg) (err error)
+	// TemplatesUpdateForTeamContext : Update a template associated with a team. This
+	// route can update the template name, the template description and add
+	// optional properties to templates.
+	TemplatesUpdateForTeamContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error)
+	// TemplatesUpdateForUserContext : Update a template associated with a user. This
+	// route can update the template name, the template description and add
+	// optional properties to templates. This endpoint can't be called on a team
+	// member or admin's behalf.
+	TemplatesUpdateForUserContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // PropertiesAddAPIError is an error-wrapper for the properties/add route
@@ -107,7 +181,9 @@ type PropertiesAddAPIError struct {
 	EndpointError *AddPropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesAdd(arg *AddPropertiesArg) (err error) {
+// PropertiesAddContext : Add property groups to a Dropbox file. See
+// `templatesAddForUser` or `templatesAddForTeam` to create new templates.
+func (dbx *apiImpl) PropertiesAddContext(ctx context.Context, arg *AddPropertiesArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -120,11 +196,11 @@ func (dbx *apiImpl) PropertiesAdd(arg *AddPropertiesArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -135,13 +211,23 @@ func (dbx *apiImpl) PropertiesAdd(arg *AddPropertiesArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) PropertiesAdd(arg *AddPropertiesArg) (err error) {
+	return dbx.PropertiesAddContext(context.Background(), arg)
+}
+
 // PropertiesOverwriteAPIError is an error-wrapper for the properties/overwrite route
 type PropertiesOverwriteAPIError struct {
 	dropbox.APIError
 	EndpointError *InvalidPropertyGroupError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesOverwrite(arg *OverwritePropertyGroupArg) (err error) {
+// PropertiesOverwriteContext : Overwrite property groups associated with a file.
+// This endpoint should be used instead of `propertiesUpdate` when property
+// groups are being updated via a "snapshot" instead of via a "delta". In
+// other words, this endpoint will delete all omitted fields from a property
+// group, whereas `propertiesUpdate` will only delete fields that are
+// explicitly marked for deletion.
+func (dbx *apiImpl) PropertiesOverwriteContext(ctx context.Context, arg *OverwritePropertyGroupArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -154,11 +240,11 @@ func (dbx *apiImpl) PropertiesOverwrite(arg *OverwritePropertyGroupArg) (err err
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesOverwriteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -169,13 +255,22 @@ func (dbx *apiImpl) PropertiesOverwrite(arg *OverwritePropertyGroupArg) (err err
 	return
 }
 
+func (dbx *apiImpl) PropertiesOverwrite(arg *OverwritePropertyGroupArg) (err error) {
+	return dbx.PropertiesOverwriteContext(context.Background(), arg)
+}
+
 // PropertiesRemoveAPIError is an error-wrapper for the properties/remove route
 type PropertiesRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *RemovePropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
+// PropertiesRemoveContext : Permanently removes the specified property group from
+// the file. To remove specific property field key value pairs, see
+// `propertiesUpdate`. To update a template, see `templatesUpdateForUser` or
+// `templatesUpdateForTeam`. To remove a template, see
+// `templatesRemoveForUser` or `templatesRemoveForTeam`.
+func (dbx *apiImpl) PropertiesRemoveContext(ctx context.Context, arg *RemovePropertiesArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -188,11 +283,11 @@ func (dbx *apiImpl) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -203,13 +298,19 @@ func (dbx *apiImpl) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) PropertiesRemove(arg *RemovePropertiesArg) (err error) {
+	return dbx.PropertiesRemoveContext(context.Background(), arg)
+}
+
 // PropertiesSearchAPIError is an error-wrapper for the properties/search route
 type PropertiesSearchAPIError struct {
 	dropbox.APIError
 	EndpointError *PropertiesSearchError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesSearch(arg *PropertiesSearchArg) (res *PropertiesSearchResult, err error) {
+// PropertiesSearchContext : Search across property templates for particular
+// property field values.
+func (dbx *apiImpl) PropertiesSearchContext(ctx context.Context, arg *PropertiesSearchArg) (res *PropertiesSearchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -222,11 +323,11 @@ func (dbx *apiImpl) PropertiesSearch(arg *PropertiesSearchArg) (res *PropertiesS
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesSearchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -241,13 +342,19 @@ func (dbx *apiImpl) PropertiesSearch(arg *PropertiesSearchArg) (res *PropertiesS
 	return
 }
 
+func (dbx *apiImpl) PropertiesSearch(arg *PropertiesSearchArg) (res *PropertiesSearchResult, err error) {
+	return dbx.PropertiesSearchContext(context.Background(), arg)
+}
+
 // PropertiesSearchContinueAPIError is an error-wrapper for the properties/search/continue route
 type PropertiesSearchContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *PropertiesSearchContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesSearchContinue(arg *PropertiesSearchContinueArg) (res *PropertiesSearchResult, err error) {
+// PropertiesSearchContinueContext : Once a cursor has been retrieved from
+// `propertiesSearch`, use this to paginate through all search results.
+func (dbx *apiImpl) PropertiesSearchContinueContext(ctx context.Context, arg *PropertiesSearchContinueArg) (res *PropertiesSearchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -260,11 +367,11 @@ func (dbx *apiImpl) PropertiesSearchContinue(arg *PropertiesSearchContinueArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesSearchContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -279,13 +386,24 @@ func (dbx *apiImpl) PropertiesSearchContinue(arg *PropertiesSearchContinueArg) (
 	return
 }
 
+func (dbx *apiImpl) PropertiesSearchContinue(arg *PropertiesSearchContinueArg) (res *PropertiesSearchResult, err error) {
+	return dbx.PropertiesSearchContinueContext(context.Background(), arg)
+}
+
 // PropertiesUpdateAPIError is an error-wrapper for the properties/update route
 type PropertiesUpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *UpdatePropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesUpdate(arg *UpdatePropertiesArg) (err error) {
+// PropertiesUpdateContext : Add, update or remove properties associated with the
+// supplied file and templates. This endpoint should be used instead of
+// `propertiesOverwrite` when property groups are being updated via a
+// "delta" instead of via a "snapshot" . In other words, this endpoint will
+// not delete any omitted fields from a property group, whereas
+// `propertiesOverwrite` will delete any fields that are omitted from a
+// property group.
+func (dbx *apiImpl) PropertiesUpdateContext(ctx context.Context, arg *UpdatePropertiesArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -298,11 +416,11 @@ func (dbx *apiImpl) PropertiesUpdate(arg *UpdatePropertiesArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesUpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -313,13 +431,20 @@ func (dbx *apiImpl) PropertiesUpdate(arg *UpdatePropertiesArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) PropertiesUpdate(arg *UpdatePropertiesArg) (err error) {
+	return dbx.PropertiesUpdateContext(context.Background(), arg)
+}
+
 // TemplatesAddForTeamAPIError is an error-wrapper for the templates/add_for_team route
 type TemplatesAddForTeamAPIError struct {
 	dropbox.APIError
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesAddForTeam(arg *AddTemplateArg) (res *AddTemplateResult, err error) {
+// TemplatesAddForTeamContext : Add a template associated with a team. See
+// `propertiesAdd` to add properties to a file or folder. Note: this
+// endpoint will create team-owned templates.
+func (dbx *apiImpl) TemplatesAddForTeamContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -332,11 +457,11 @@ func (dbx *apiImpl) TemplatesAddForTeam(arg *AddTemplateArg) (res *AddTemplateRe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesAddForTeamAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -351,13 +476,20 @@ func (dbx *apiImpl) TemplatesAddForTeam(arg *AddTemplateArg) (res *AddTemplateRe
 	return
 }
 
+func (dbx *apiImpl) TemplatesAddForTeam(arg *AddTemplateArg) (res *AddTemplateResult, err error) {
+	return dbx.TemplatesAddForTeamContext(context.Background(), arg)
+}
+
 // TemplatesAddForUserAPIError is an error-wrapper for the templates/add_for_user route
 type TemplatesAddForUserAPIError struct {
 	dropbox.APIError
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesAddForUser(arg *AddTemplateArg) (res *AddTemplateResult, err error) {
+// TemplatesAddForUserContext : Add a template associated with a user. See
+// `propertiesAdd` to add properties to a file. This endpoint can't be
+// called on a team member or admin's behalf.
+func (dbx *apiImpl) TemplatesAddForUserContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -370,11 +502,11 @@ func (dbx *apiImpl) TemplatesAddForUser(arg *AddTemplateArg) (res *AddTemplateRe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesAddForUserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -389,13 +521,18 @@ func (dbx *apiImpl) TemplatesAddForUser(arg *AddTemplateArg) (res *AddTemplateRe
 	return
 }
 
+func (dbx *apiImpl) TemplatesAddForUser(arg *AddTemplateArg) (res *AddTemplateResult, err error) {
+	return dbx.TemplatesAddForUserContext(context.Background(), arg)
+}
+
 // TemplatesGetForTeamAPIError is an error-wrapper for the templates/get_for_team route
 type TemplatesGetForTeamAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesGetForTeam(arg *GetTemplateArg) (res *GetTemplateResult, err error) {
+// TemplatesGetForTeamContext : Get the schema for a specified template.
+func (dbx *apiImpl) TemplatesGetForTeamContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -408,11 +545,11 @@ func (dbx *apiImpl) TemplatesGetForTeam(arg *GetTemplateArg) (res *GetTemplateRe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesGetForTeamAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -427,13 +564,19 @@ func (dbx *apiImpl) TemplatesGetForTeam(arg *GetTemplateArg) (res *GetTemplateRe
 	return
 }
 
+func (dbx *apiImpl) TemplatesGetForTeam(arg *GetTemplateArg) (res *GetTemplateResult, err error) {
+	return dbx.TemplatesGetForTeamContext(context.Background(), arg)
+}
+
 // TemplatesGetForUserAPIError is an error-wrapper for the templates/get_for_user route
 type TemplatesGetForUserAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesGetForUser(arg *GetTemplateArg) (res *GetTemplateResult, err error) {
+// TemplatesGetForUserContext : Get the schema for a specified template. This
+// endpoint can't be called on a team member or admin's behalf.
+func (dbx *apiImpl) TemplatesGetForUserContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -446,11 +589,11 @@ func (dbx *apiImpl) TemplatesGetForUser(arg *GetTemplateArg) (res *GetTemplateRe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesGetForUserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -465,13 +608,19 @@ func (dbx *apiImpl) TemplatesGetForUser(arg *GetTemplateArg) (res *GetTemplateRe
 	return
 }
 
+func (dbx *apiImpl) TemplatesGetForUser(arg *GetTemplateArg) (res *GetTemplateResult, err error) {
+	return dbx.TemplatesGetForUserContext(context.Background(), arg)
+}
+
 // TemplatesListForTeamAPIError is an error-wrapper for the templates/list_for_team route
 type TemplatesListForTeamAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesListForTeam() (res *ListTemplateResult, err error) {
+// TemplatesListForTeamContext : Get the template identifiers for a team. To get
+// the schema of each template use `templatesGetForTeam`.
+func (dbx *apiImpl) TemplatesListForTeamContext(ctx context.Context) (res *ListTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -484,11 +633,11 @@ func (dbx *apiImpl) TemplatesListForTeam() (res *ListTemplateResult, err error) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesListForTeamAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -503,13 +652,20 @@ func (dbx *apiImpl) TemplatesListForTeam() (res *ListTemplateResult, err error) 
 	return
 }
 
+func (dbx *apiImpl) TemplatesListForTeam() (res *ListTemplateResult, err error) {
+	return dbx.TemplatesListForTeamContext(context.Background())
+}
+
 // TemplatesListForUserAPIError is an error-wrapper for the templates/list_for_user route
 type TemplatesListForUserAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesListForUser() (res *ListTemplateResult, err error) {
+// TemplatesListForUserContext : Get the template identifiers for a team. To get
+// the schema of each template use `templatesGetForUser`. This endpoint
+// can't be called on a team member or admin's behalf.
+func (dbx *apiImpl) TemplatesListForUserContext(ctx context.Context) (res *ListTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -522,11 +678,11 @@ func (dbx *apiImpl) TemplatesListForUser() (res *ListTemplateResult, err error) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesListForUserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -541,13 +697,20 @@ func (dbx *apiImpl) TemplatesListForUser() (res *ListTemplateResult, err error) 
 	return
 }
 
+func (dbx *apiImpl) TemplatesListForUser() (res *ListTemplateResult, err error) {
+	return dbx.TemplatesListForUserContext(context.Background())
+}
+
 // TemplatesRemoveForTeamAPIError is an error-wrapper for the templates/remove_for_team route
 type TemplatesRemoveForTeamAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesRemoveForTeam(arg *RemoveTemplateArg) (err error) {
+// TemplatesRemoveForTeamContext : Permanently removes the specified template
+// created from `templatesAddForUser`. All properties associated with the
+// template will also be removed. This action cannot be undone.
+func (dbx *apiImpl) TemplatesRemoveForTeamContext(ctx context.Context, arg *RemoveTemplateArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -560,11 +723,11 @@ func (dbx *apiImpl) TemplatesRemoveForTeam(arg *RemoveTemplateArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesRemoveForTeamAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -575,13 +738,20 @@ func (dbx *apiImpl) TemplatesRemoveForTeam(arg *RemoveTemplateArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) TemplatesRemoveForTeam(arg *RemoveTemplateArg) (err error) {
+	return dbx.TemplatesRemoveForTeamContext(context.Background(), arg)
+}
+
 // TemplatesRemoveForUserAPIError is an error-wrapper for the templates/remove_for_user route
 type TemplatesRemoveForUserAPIError struct {
 	dropbox.APIError
 	EndpointError *TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesRemoveForUser(arg *RemoveTemplateArg) (err error) {
+// TemplatesRemoveForUserContext : Permanently removes the specified template
+// created from `templatesAddForUser`. All properties associated with the
+// template will also be removed. This action cannot be undone.
+func (dbx *apiImpl) TemplatesRemoveForUserContext(ctx context.Context, arg *RemoveTemplateArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -594,11 +764,11 @@ func (dbx *apiImpl) TemplatesRemoveForUser(arg *RemoveTemplateArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesRemoveForUserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -609,13 +779,20 @@ func (dbx *apiImpl) TemplatesRemoveForUser(arg *RemoveTemplateArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) TemplatesRemoveForUser(arg *RemoveTemplateArg) (err error) {
+	return dbx.TemplatesRemoveForUserContext(context.Background(), arg)
+}
+
 // TemplatesUpdateForTeamAPIError is an error-wrapper for the templates/update_for_team route
 type TemplatesUpdateForTeamAPIError struct {
 	dropbox.APIError
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesUpdateForTeam(arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
+// TemplatesUpdateForTeamContext : Update a template associated with a team. This
+// route can update the template name, the template description and add
+// optional properties to templates.
+func (dbx *apiImpl) TemplatesUpdateForTeamContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -628,11 +805,11 @@ func (dbx *apiImpl) TemplatesUpdateForTeam(arg *UpdateTemplateArg) (res *UpdateT
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesUpdateForTeamAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -647,13 +824,21 @@ func (dbx *apiImpl) TemplatesUpdateForTeam(arg *UpdateTemplateArg) (res *UpdateT
 	return
 }
 
+func (dbx *apiImpl) TemplatesUpdateForTeam(arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
+	return dbx.TemplatesUpdateForTeamContext(context.Background(), arg)
+}
+
 // TemplatesUpdateForUserAPIError is an error-wrapper for the templates/update_for_user route
 type TemplatesUpdateForUserAPIError struct {
 	dropbox.APIError
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) TemplatesUpdateForUser(arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
+// TemplatesUpdateForUserContext : Update a template associated with a user. This
+// route can update the template name, the template description and add
+// optional properties to templates. This endpoint can't be called on a team
+// member or admin's behalf.
+func (dbx *apiImpl) TemplatesUpdateForUserContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_properties",
@@ -666,11 +851,11 @@ func (dbx *apiImpl) TemplatesUpdateForUser(arg *UpdateTemplateArg) (res *UpdateT
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TemplatesUpdateForUserAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -685,8 +870,17 @@ func (dbx *apiImpl) TemplatesUpdateForUser(arg *UpdateTemplateArg) (res *UpdateT
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) TemplatesUpdateForUser(arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
+	return dbx.TemplatesUpdateForUserContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/file_requests/client.go
+++ b/v6/dropbox/file_requests/client.go
@@ -21,7 +21,9 @@
 package file_requests
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -57,6 +59,36 @@ type Client interface {
 	Update(arg *UpdateFileRequestArgs) (res *FileRequest, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// CountContext : Returns the total number of file requests owned by this user.
+	// Includes both open and closed file requests.
+	CountContext(ctx context.Context) (res *CountFileRequestsResult, err error)
+	// CreateContext : Creates a file request for this user.
+	CreateContext(ctx context.Context, arg *CreateFileRequestArgs) (res *FileRequest, err error)
+	// DeleteContext : Delete a batch of closed file requests.
+	DeleteContext(ctx context.Context, arg *DeleteFileRequestArgs) (res *DeleteFileRequestsResult, err error)
+	// DeleteAllClosedContext : Delete all closed file requests owned by this user.
+	DeleteAllClosedContext(ctx context.Context) (res *DeleteAllClosedFileRequestsResult, err error)
+	// GetContext : Returns the specified file request.
+	GetContext(ctx context.Context, arg *GetFileRequestArgs) (res *FileRequest, err error)
+	// ListContext : Returns a list of file requests owned by this user. For apps with
+	// the app folder permission, this will only return file requests with
+	// destinations in the app folder.
+	ListContext(ctx context.Context) (res *ListFileRequestsResult, err error)
+	// ListV2Context : Returns a list of file requests owned by this user. For apps with
+	// the app folder permission, this will only return file requests with
+	// destinations in the app folder.
+	ListV2Context(ctx context.Context, arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error)
+	// ListContinueContext : Once a cursor has been retrieved from `list`, use this to
+	// paginate through all file requests. The cursor must come from a previous
+	// call to `list` or `listContinue`.
+	ListContinueContext(ctx context.Context, arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error)
+	// UpdateContext : Update a file request.
+	UpdateContext(ctx context.Context, arg *UpdateFileRequestArgs) (res *FileRequest, err error)
+}
+
 type apiImpl dropbox.Context
 
 // CountAPIError is an error-wrapper for the count route
@@ -65,7 +97,9 @@ type CountAPIError struct {
 	EndpointError *CountFileRequestsError `json:"error"`
 }
 
-func (dbx *apiImpl) Count() (res *CountFileRequestsResult, err error) {
+// CountContext : Returns the total number of file requests owned by this user.
+// Includes both open and closed file requests.
+func (dbx *apiImpl) CountContext(ctx context.Context) (res *CountFileRequestsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -78,11 +112,11 @@ func (dbx *apiImpl) Count() (res *CountFileRequestsResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CountAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -97,13 +131,18 @@ func (dbx *apiImpl) Count() (res *CountFileRequestsResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) Count() (res *CountFileRequestsResult, err error) {
+	return dbx.CountContext(context.Background())
+}
+
 // CreateAPIError is an error-wrapper for the create route
 type CreateAPIError struct {
 	dropbox.APIError
 	EndpointError *CreateFileRequestError `json:"error"`
 }
 
-func (dbx *apiImpl) Create(arg *CreateFileRequestArgs) (res *FileRequest, err error) {
+// CreateContext : Creates a file request for this user.
+func (dbx *apiImpl) CreateContext(ctx context.Context, arg *CreateFileRequestArgs) (res *FileRequest, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -116,11 +155,11 @@ func (dbx *apiImpl) Create(arg *CreateFileRequestArgs) (res *FileRequest, err er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -135,13 +174,18 @@ func (dbx *apiImpl) Create(arg *CreateFileRequestArgs) (res *FileRequest, err er
 	return
 }
 
+func (dbx *apiImpl) Create(arg *CreateFileRequestArgs) (res *FileRequest, err error) {
+	return dbx.CreateContext(context.Background(), arg)
+}
+
 // DeleteAPIError is an error-wrapper for the delete route
 type DeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *DeleteFileRequestError `json:"error"`
 }
 
-func (dbx *apiImpl) Delete(arg *DeleteFileRequestArgs) (res *DeleteFileRequestsResult, err error) {
+// DeleteContext : Delete a batch of closed file requests.
+func (dbx *apiImpl) DeleteContext(ctx context.Context, arg *DeleteFileRequestArgs) (res *DeleteFileRequestsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -154,11 +198,11 @@ func (dbx *apiImpl) Delete(arg *DeleteFileRequestArgs) (res *DeleteFileRequestsR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -173,13 +217,18 @@ func (dbx *apiImpl) Delete(arg *DeleteFileRequestArgs) (res *DeleteFileRequestsR
 	return
 }
 
+func (dbx *apiImpl) Delete(arg *DeleteFileRequestArgs) (res *DeleteFileRequestsResult, err error) {
+	return dbx.DeleteContext(context.Background(), arg)
+}
+
 // DeleteAllClosedAPIError is an error-wrapper for the delete_all_closed route
 type DeleteAllClosedAPIError struct {
 	dropbox.APIError
 	EndpointError *DeleteAllClosedFileRequestsError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteAllClosed() (res *DeleteAllClosedFileRequestsResult, err error) {
+// DeleteAllClosedContext : Delete all closed file requests owned by this user.
+func (dbx *apiImpl) DeleteAllClosedContext(ctx context.Context) (res *DeleteAllClosedFileRequestsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -192,11 +241,11 @@ func (dbx *apiImpl) DeleteAllClosed() (res *DeleteAllClosedFileRequestsResult, e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteAllClosedAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -211,13 +260,18 @@ func (dbx *apiImpl) DeleteAllClosed() (res *DeleteAllClosedFileRequestsResult, e
 	return
 }
 
+func (dbx *apiImpl) DeleteAllClosed() (res *DeleteAllClosedFileRequestsResult, err error) {
+	return dbx.DeleteAllClosedContext(context.Background())
+}
+
 // GetAPIError is an error-wrapper for the get route
 type GetAPIError struct {
 	dropbox.APIError
 	EndpointError *GetFileRequestError `json:"error"`
 }
 
-func (dbx *apiImpl) Get(arg *GetFileRequestArgs) (res *FileRequest, err error) {
+// GetContext : Returns the specified file request.
+func (dbx *apiImpl) GetContext(ctx context.Context, arg *GetFileRequestArgs) (res *FileRequest, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -230,11 +284,11 @@ func (dbx *apiImpl) Get(arg *GetFileRequestArgs) (res *FileRequest, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -249,13 +303,20 @@ func (dbx *apiImpl) Get(arg *GetFileRequestArgs) (res *FileRequest, err error) {
 	return
 }
 
+func (dbx *apiImpl) Get(arg *GetFileRequestArgs) (res *FileRequest, err error) {
+	return dbx.GetContext(context.Background(), arg)
+}
+
 // ListAPIError is an error-wrapper for the list route
 type ListAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFileRequestsError `json:"error"`
 }
 
-func (dbx *apiImpl) List() (res *ListFileRequestsResult, err error) {
+// ListContext : Returns a list of file requests owned by this user. For apps with
+// the app folder permission, this will only return file requests with
+// destinations in the app folder.
+func (dbx *apiImpl) ListContext(ctx context.Context) (res *ListFileRequestsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -268,11 +329,11 @@ func (dbx *apiImpl) List() (res *ListFileRequestsResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -287,13 +348,20 @@ func (dbx *apiImpl) List() (res *ListFileRequestsResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) List() (res *ListFileRequestsResult, err error) {
+	return dbx.ListContext(context.Background())
+}
+
 // ListV2APIError is an error-wrapper for the list_v2 route
 type ListV2APIError struct {
 	dropbox.APIError
 	EndpointError *ListFileRequestsError `json:"error"`
 }
 
-func (dbx *apiImpl) ListV2(arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error) {
+// ListV2Context : Returns a list of file requests owned by this user. For apps with
+// the app folder permission, this will only return file requests with
+// destinations in the app folder.
+func (dbx *apiImpl) ListV2Context(ctx context.Context, arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -306,11 +374,11 @@ func (dbx *apiImpl) ListV2(arg *ListFileRequestsArg) (res *ListFileRequestsV2Res
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -325,13 +393,20 @@ func (dbx *apiImpl) ListV2(arg *ListFileRequestsArg) (res *ListFileRequestsV2Res
 	return
 }
 
+func (dbx *apiImpl) ListV2(arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error) {
+	return dbx.ListV2Context(context.Background(), arg)
+}
+
 // ListContinueAPIError is an error-wrapper for the list/continue route
 type ListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFileRequestsContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListContinue(arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error) {
+// ListContinueContext : Once a cursor has been retrieved from `list`, use this to
+// paginate through all file requests. The cursor must come from a previous
+// call to `list` or `listContinue`.
+func (dbx *apiImpl) ListContinueContext(ctx context.Context, arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -344,11 +419,11 @@ func (dbx *apiImpl) ListContinue(arg *ListFileRequestsContinueArg) (res *ListFil
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -363,13 +438,18 @@ func (dbx *apiImpl) ListContinue(arg *ListFileRequestsContinueArg) (res *ListFil
 	return
 }
 
+func (dbx *apiImpl) ListContinue(arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error) {
+	return dbx.ListContinueContext(context.Background(), arg)
+}
+
 // UpdateAPIError is an error-wrapper for the update route
 type UpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *UpdateFileRequestError `json:"error"`
 }
 
-func (dbx *apiImpl) Update(arg *UpdateFileRequestArgs) (res *FileRequest, err error) {
+// UpdateContext : Update a file request.
+func (dbx *apiImpl) UpdateContext(ctx context.Context, arg *UpdateFileRequestArgs) (res *FileRequest, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "file_requests",
@@ -382,11 +462,11 @@ func (dbx *apiImpl) Update(arg *UpdateFileRequestArgs) (res *FileRequest, err er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -401,8 +481,17 @@ func (dbx *apiImpl) Update(arg *UpdateFileRequestArgs) (res *FileRequest, err er
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) Update(arg *UpdateFileRequestArgs) (res *FileRequest, err error) {
+	return dbx.UpdateContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/files/client.go
+++ b/v6/dropbox/files/client.go
@@ -21,7 +21,9 @@
 package files
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 
@@ -469,6 +471,445 @@ type Client interface {
 	UploadSessionStartBatch(arg *UploadSessionStartBatchArg) (res *UploadSessionStartBatchResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// AlphaGetMetadataContext : Returns the metadata for a file or folder. This is an
+	// alpha endpoint compatible with the properties API. Note: Metadata for the
+	// root folder is unsupported.
+	// Deprecated:
+	AlphaGetMetadataContext(ctx context.Context, arg *AlphaGetMetadataArg) (res IsMetadata, err error)
+	// AlphaUploadContext : Create a new file with the contents provided in the
+	// request. Note that the behavior of this alpha endpoint is unstable and
+	// subject to change. Do not use this to upload a file larger than 150 MiB.
+	// Instead, create an upload session with `uploadSessionStart`.
+	// Deprecated:
+	AlphaUploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error)
+	// CopyContext : Copy a file or folder to a different location in the user's
+	// Dropbox. If the source path is a folder all its contents will be copied.
+	// Deprecated:
+	CopyContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error)
+	// CopyV2Context : Copy a file or folder to a different location in the user's
+	// Dropbox. If the source path is a folder all its contents will be copied.
+	CopyV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error)
+	// CopyBatchContext : Copy multiple files or folders to different locations at once
+	// in the user's Dropbox. This route will return job ID immediately and do
+	// the async copy job in background. Please use `copyBatchCheck` to check
+	// the job status.
+	// Deprecated:
+	CopyBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error)
+	// CopyBatchV2Context : Copy multiple files or folders to different locations at once
+	// in the user's Dropbox. This route will replace `copyBatch`. The main
+	// difference is this route will return status for each entry, while
+	// `copyBatch` raises failure if any entry fails. This route will either
+	// finish synchronously, or return a job ID and do the async copy job in
+	// background. Please use `copyBatchCheck` to check the job status.
+	CopyBatchV2Context(ctx context.Context, arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error)
+	// CopyBatchCheckContext : Returns the status of an asynchronous job for
+	// `copyBatch`. If success, it returns list of results for each entry.
+	// Deprecated:
+	CopyBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *RelocationBatchJobStatus, err error)
+	// CopyBatchCheckV2Context : Returns the status of an asynchronous job for
+	// `copyBatch`. It returns list of results for each entry.
+	CopyBatchCheckV2Context(ctx context.Context, arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error)
+	// CopyReferenceGetContext : Get a copy reference to a file or folder. This
+	// reference string can be used to save that file or folder to another
+	// user's Dropbox by passing it to `copyReferenceSave`.
+	CopyReferenceGetContext(ctx context.Context, arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error)
+	// CopyReferenceSaveContext : Save a copy reference returned by `copyReferenceGet`
+	// to the user's Dropbox.
+	CopyReferenceSaveContext(ctx context.Context, arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error)
+	// CreateFolderContext : Create a folder at a given path.
+	// Deprecated:
+	CreateFolderContext(ctx context.Context, arg *CreateFolderArg) (res *FolderMetadata, err error)
+	// CreateFolderV2Context : Create a folder at a given path.
+	CreateFolderV2Context(ctx context.Context, arg *CreateFolderArg) (res *CreateFolderResult, err error)
+	// CreateFolderBatchContext : Create multiple folders at once. This route is
+	// asynchronous for large batches, which returns a job ID immediately and
+	// runs the create folder batch asynchronously. Otherwise, creates the
+	// folders and returns the result synchronously for smaller inputs. You can
+	// force asynchronous behaviour by using the
+	// CreateFolderBatchArg.force_async flag.  Use `createFolderBatchCheck` to
+	// check the job status.
+	CreateFolderBatchContext(ctx context.Context, arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error)
+	// CreateFolderBatchCheckContext : Returns the status of an asynchronous job for
+	// `createFolderBatch`. If success, it returns list of result for each
+	// entry.
+	CreateFolderBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error)
+	// DeleteContext : Delete the file or folder at a given path. If the path is a
+	// folder, all its contents will be deleted too. A successful response
+	// indicates that the file or folder was deleted. The returned metadata will
+	// be the corresponding FileMetadata or FolderMetadata for the item at time
+	// of deletion, and not a DeletedMetadata object.
+	// Deprecated:
+	DeleteContext(ctx context.Context, arg *DeleteArg) (res IsMetadata, err error)
+	// DeleteV2Context : Delete the file or folder at a given path. If the path is a
+	// folder, all its contents will be deleted too. A successful response
+	// indicates that the file or folder was deleted. The returned metadata will
+	// be the corresponding FileMetadata or FolderMetadata for the item at time
+	// of deletion, and not a DeletedMetadata object.
+	DeleteV2Context(ctx context.Context, arg *DeleteArg) (res *DeleteResult, err error)
+	// DeleteBatchContext : Delete multiple files/folders at once. This route is
+	// asynchronous, which returns a job ID immediately and runs the delete
+	// batch asynchronously. Use `deleteBatchCheck` to check the job status.
+	DeleteBatchContext(ctx context.Context, arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error)
+	// DeleteBatchCheckContext : Returns the status of an asynchronous job for
+	// `deleteBatch`. If success, it returns list of result for each entry.
+	DeleteBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *DeleteBatchJobStatus, err error)
+	// DownloadContext : Download a file from a user's Dropbox.
+	DownloadContext(ctx context.Context, arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error)
+	// DownloadZipContext : Download a folder from the user's Dropbox, as a zip file.
+	// The folder must be less than 20 GB in size and any single file within
+	// must be less than 4 GB in size. The resulting zip must have fewer than
+	// 10,000 total file and folder entries, including the top level folder. The
+	// input cannot be a single file. Note: this endpoint does not support HTTP
+	// range requests.
+	DownloadZipContext(ctx context.Context, arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error)
+	// ExportContext : Export a file from a user's Dropbox. This route only supports
+	// exporting files that cannot be downloaded directly and whose
+	// ExportResult.file_metadata has ExportInfo.export_as populated.
+	ExportContext(ctx context.Context, arg *ExportArg) (res *ExportResult, content io.ReadCloser, err error)
+	// GetFileLockBatchContext : Return the lock metadata for the given list of paths.
+	GetFileLockBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error)
+	// GetMetadataContext : Returns the metadata for a file or folder. Note: Metadata
+	// for the root folder is unsupported.
+	GetMetadataContext(ctx context.Context, arg *GetMetadataArg) (res IsMetadata, err error)
+	// GetPreviewContext : Get a preview for a file. Currently, PDF previews are
+	// generated for files with the following extensions: .ai, .doc, .docm,
+	// .docx, .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx, .ppt,
+	// .pptm, .pptx, .rtf. HTML previews are generated for .csv, .ods, .xls,
+	// .xlsm, .gsheet, .xlsx. Other formats will return an unsupported extension
+	// error.
+	GetPreviewContext(ctx context.Context, arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error)
+	// GetTemporaryLinkContext : Get a temporary link to stream content of a file. This
+	// link will expire in four hours and afterwards you will get 410 Gone. This
+	// URL should not be used to display content directly in the browser. The
+	// Content-Type of the link is determined automatically by the file's mime
+	// type.
+	GetTemporaryLinkContext(ctx context.Context, arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error)
+	// GetTemporaryUploadLinkContext : Get a one-time use temporary upload link to
+	// upload a file to a Dropbox location.  This endpoint acts as a delayed
+	// upload(). The returned temporary upload link may be used to make a POST
+	// request with the data to be uploaded. The upload will then be perfomed
+	// with the CommitInfo previously provided to getTemporaryUploadLink() but
+	// evaluated only upon consumption. Hence, errors stemming from invalid
+	// CommitInfo with respect to the state of the user's Dropbox will only be
+	// communicated at consumption time. Additionally, these errors are surfaced
+	// as generic HTTP 409 Conflict responses, potentially hiding issue details.
+	// The maximum temporary upload link duration is 4 hours. Upon consumption
+	// or expiration, a new link will have to be generated. Multiple links may
+	// exist for a specific upload path at any given time.  The POST request on
+	// the temporary upload link must have its Content-Type set to
+	// "application/octet-stream".  Example temporary upload link consumption
+	// request:  curl -X POST
+	// https://content.dropboxapi.com/apitul/1/bNi2uIYF51cVBND --header
+	// "Content-Type: application/octet-stream" --data-binary @local_file.txt  A
+	// successful temporary upload link consumption request returns the content
+	// hash of the uploaded data in JSON format. Example successful temporary
+	// upload link consumption response: {"content-hash":
+	// "599d71033d700ac892a0e48fa61b125d2f5994"}  An unsuccessful temporary
+	// upload link consumption request returns any of the following status
+	// codes:  HTTP 400 Bad Request: Content-Type is not one of
+	// application/octet-stream and text/plain or request is invalid. HTTP 409
+	// Conflict: The temporary upload link does not exist or is currently
+	// unavailable, the upload failed, or another error happened. HTTP 410 Gone:
+	// The temporary upload link is expired or consumed. Example unsuccessful
+	// temporary upload link consumption response: Temporary upload link has
+	// been recently consumed.
+	GetTemporaryUploadLinkContext(ctx context.Context, arg *GetTemporaryUploadLinkArg) (res *GetTemporaryUploadLinkResult, err error)
+	// GetThumbnailContext : Get a thumbnail for an image. This method currently
+	// supports files with the following file extensions: jpg, jpeg, png, tiff,
+	// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
+	// won't be converted to a thumbnail.
+	GetThumbnailContext(ctx context.Context, arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error)
+	// GetThumbnailV2Context : Get a thumbnail for an image. This method currently
+	// supports files with the following file extensions: jpg, jpeg, png, tiff,
+	// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
+	// won't be converted to a thumbnail.
+	GetThumbnailV2Context(ctx context.Context, arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error)
+	// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow up to
+	// 25 thumbnails in a single batch. This method currently supports files
+	// with the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp,
+	// ppm and bmp. Photos that are larger than 20MB in size won't be converted
+	// to a thumbnail.
+	GetThumbnailBatchContext(ctx context.Context, arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error)
+	// ListFolderContext : Starts returning the contents of a folder. If the result's
+	// `ListFolderResult.has_more` field is true, call `listFolderContinue` with
+	// the returned ListFolderResult.cursor to retrieve more entries. If you're
+	// using ListFolderArg.recursive set to true to keep a local cache of the
+	// contents of a Dropbox account, iterate through each entry in order and
+	// process them as follows to keep your local state in sync: For each
+	// FileMetadata, store the new entry at the given path in your local state.
+	// If the required parent folders don't exist yet, create them. If there's
+	// already something else at the given path, replace it and remove all its
+	// children. For each FolderMetadata, store the new entry at the given path
+	// in your local state. If the required parent folders don't exist yet,
+	// create them. If there's already something else at the given path, replace
+	// it but leave the children as they are. Check the new entry's
+	// FolderSharingInfo.read_only and set all its children's read-only statuses
+	// to match. For each DeletedMetadata, if your local state has something at
+	// the given path, remove it and all its children. If there's nothing at the
+	// given path, ignore this entry. Note: auth.RateLimitError may be returned
+	// if multiple `listFolder` or `listFolderContinue` calls with same
+	// parameters are made simultaneously by same API app for same user. If your
+	// app implements retry logic, please hold off the retry until the previous
+	// request finishes.
+	ListFolderContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderResult, err error)
+	// ListFolderContinueContext : Once a cursor has been retrieved from `listFolder`,
+	// use this to paginate through all files and retrieve updates to the
+	// folder, following the same rules as documented for `listFolder`.
+	ListFolderContinueContext(ctx context.Context, arg *ListFolderContinueArg) (res *ListFolderResult, err error)
+	// ListFolderGetLatestCursorContext : A way to quickly get a cursor for the
+	// folder's state. Unlike `listFolder`, `listFolderGetLatestCursor` doesn't
+	// return any entries. This endpoint is for app which only needs to know
+	// about new files and modifications and doesn't need to know about files
+	// that already exist in Dropbox.
+	ListFolderGetLatestCursorContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error)
+	// ListFolderLongpollContext : A longpoll endpoint to wait for changes on an
+	// account. In conjunction with `listFolderContinue`, this call gives you a
+	// low-latency way to monitor an account for file changes. The connection
+	// will block until there are changes available or a timeout occurs. This
+	// endpoint is useful mostly for client-side apps.
+	ListFolderLongpollContext(ctx context.Context, arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error)
+	// ListRevisionsContext : Returns revisions for files based on a file path or a
+	// file id. The file path or file id is identified from the latest file
+	// entry at the given file path or id. This end point allows your app to
+	// query either by file path or file id by setting the mode parameter
+	// appropriately. In the ListRevisionsMode.path (default) mode, all
+	// revisions at the same file path as the latest file entry are returned. If
+	// revisions with the same file id are desired, then mode must be set to
+	// ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
+	// revisions for a given file across moves or renames.
+	ListRevisionsContext(ctx context.Context, arg *ListRevisionsArg) (res *ListRevisionsResult, err error)
+	// LockFileBatchContext : Lock the files at the given paths. A locked file will be
+	// writable only by the lock holder. A successful response indicates that
+	// the file has been locked. Returns a list of the locked file paths and
+	// their metadata after this operation.
+	LockFileBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error)
+	// MoveContext : Move a file or folder to a different location in the user's
+	// Dropbox. If the source path is a folder all its contents will be moved.
+	// Deprecated:
+	MoveContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error)
+	// MoveV2Context : Move a file or folder to a different location in the user's
+	// Dropbox. If the source path is a folder all its contents will be moved.
+	// Note that we do not currently support case-only renaming.
+	MoveV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error)
+	// MoveBatchContext : Move multiple files or folders to different locations at once
+	// in the user's Dropbox. This route will return job ID immediately and do
+	// the async moving job in background. Please use `moveBatchCheck` to check
+	// the job status.
+	// Deprecated:
+	MoveBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error)
+	// MoveBatchV2Context : Move multiple files or folders to different locations at once
+	// in the user's Dropbox. Note that we do not currently support case-only
+	// renaming. This route will replace `moveBatch`. The main difference is
+	// this route will return status for each entry, while `moveBatch` raises
+	// failure if any entry fails. This route will either finish synchronously,
+	// or return a job ID and do the async move job in background. Please use
+	// `moveBatchCheck` to check the job status.
+	MoveBatchV2Context(ctx context.Context, arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error)
+	// MoveBatchCheckContext : Returns the status of an asynchronous job for
+	// `moveBatch`. If success, it returns list of results for each entry.
+	// Deprecated:
+	MoveBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *RelocationBatchJobStatus, err error)
+	// MoveBatchCheckV2Context : Returns the status of an asynchronous job for
+	// `moveBatch`. It returns list of results for each entry.
+	MoveBatchCheckV2Context(ctx context.Context, arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error)
+	// PaperCreateContext : Creates a new Paper doc with the provided content.
+	PaperCreateContext(ctx context.Context, arg *PaperCreateArg, content io.Reader) (res *PaperCreateResult, err error)
+	// PaperUpdateContext : Updates an existing Paper doc with the provided content.
+	PaperUpdateContext(ctx context.Context, arg *PaperUpdateArg, content io.Reader) (res *PaperUpdateResult, err error)
+	// PermanentlyDeleteContext : Permanently delete the file or folder at a given path
+	// (see https://www.dropbox.com/en/help/40). If the given file or folder is
+	// not yet deleted, this route will first delete it. It is possible for this
+	// route to successfully delete, then fail to permanently delete. Note: This
+	// endpoint is only available for Dropbox Business apps.
+	PermanentlyDeleteContext(ctx context.Context, arg *DeleteArg) (err error)
+	// PropertiesAddContext : Add property groups to a Dropbox file. See
+	// templates/add_for_user or templates/add_for_team to create new templates.
+	// Deprecated:
+	PropertiesAddContext(ctx context.Context, arg *file_properties.AddPropertiesArg) (err error)
+	// PropertiesOverwriteContext : Overwrite property groups associated with a file.
+	// This endpoint should be used instead of properties/update when property
+	// groups are being overwritten rather than updated via a "delta".
+	// Deprecated:
+	PropertiesOverwriteContext(ctx context.Context, arg *file_properties.OverwritePropertyGroupArg) (err error)
+	// PropertiesUpdateContext : Add, update or remove properties associated with the
+	// supplied file and templates. This endpoint should be used instead of
+	// properties/overwrite when property groups are being updated via a "delta"
+	// instead of overwriting all properties of a file.
+	// Deprecated:
+	PropertiesUpdateContext(ctx context.Context, arg *file_properties.UpdatePropertiesArg) (err error)
+	// RestoreContext : Restore a specific revision of a file to the given path.
+	RestoreContext(ctx context.Context, arg *RestoreArg) (res *FileMetadata, err error)
+	// SaveUrlContext : Save the data from a specified URL into a file in user's
+	// Dropbox. Note that the transfer from the URL must complete within 15
+	// minutes, or the operation will time out and the job will fail.
+	SaveUrlContext(ctx context.Context, arg *SaveUrlArg) (res *SaveUrlResult, err error)
+	// SaveUrlCheckJobStatusContext : Check the status of a `saveUrl` job.
+	SaveUrlCheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *SaveUrlJobStatus, err error)
+	// SearchContext : Searches for files and folders. Note: Recent changes will be
+	// reflected in search results within a few seconds and older revisions of
+	// existing files may still match your query for up to a few days.
+	// Deprecated:
+	SearchContext(ctx context.Context, arg *SearchArg) (res *SearchResult, err error)
+	// SearchV2Context : Searches for files and folders. Note: `search` along with
+	// `searchContinue` can only be used to retrieve a maximum of 10,000
+	// matches. Recent changes may not immediately be reflected in search
+	// results due to a short delay in indexing. Duplicate results may be
+	// returned across pages. Some results may not be returned.
+	SearchV2Context(ctx context.Context, arg *SearchV2Arg) (res *SearchV2Result, err error)
+	// SearchContinueV2Context : Fetches the next page of search results returned from
+	// `search`. Note: `search` along with `searchContinue` can only be used to
+	// retrieve a maximum of 10,000 matches. Recent changes may not immediately
+	// be reflected in search results due to a short delay in indexing.
+	// Duplicate results may be returned across pages. Some results may not be
+	// returned.
+	SearchContinueV2Context(ctx context.Context, arg *SearchV2ContinueArg) (res *SearchV2Result, err error)
+	// TagsAddContext : Add a tag to an item. A tag is a string. The strings are
+	// automatically converted to lowercase letters. No more than 20 tags can be
+	// added to a given item.
+	TagsAddContext(ctx context.Context, arg *AddTagArg) (err error)
+	// TagsGetContext : Get list of tags assigned to items.
+	TagsGetContext(ctx context.Context, arg *GetTagsArg) (res *GetTagsResult, err error)
+	// TagsRemoveContext : Remove a tag from an item.
+	TagsRemoveContext(ctx context.Context, arg *RemoveTagArg) (err error)
+	// UnlockFileBatchContext : Unlock the files at the given paths. A locked file can
+	// only be unlocked by the lock holder or, if a business account, a team
+	// admin. A successful response indicates that the file has been unlocked.
+	// Returns a list of the unlocked file paths and their metadata after this
+	// operation.
+	UnlockFileBatchContext(ctx context.Context, arg *UnlockFileBatchArg) (res *LockFileBatchResult, err error)
+	// UploadContext : Create a new file with the contents provided in the request. Do
+	// not use this to upload a file larger than 150 MiB. Instead, create an
+	// upload session with `uploadSessionStart`. Calls to this endpoint will
+	// count as data transport calls for any Dropbox Business teams with a limit
+	// on the number of data transport calls allowed per month. For more
+	// information, see the Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error)
+	// UploadSessionAppendContext : Append more data to an upload session. A single
+	// request should not upload more than 150 MiB. The maximum size of a file
+	// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+	// bytes. Calls to this endpoint will count as data transport calls for any
+	// Dropbox Business teams with a limit on the number of data transport calls
+	// allowed per month. For more information, see the Data transport limit
+	// page https://www.dropbox.com/developers/reference/data-transport-limit.
+	// Deprecated:
+	UploadSessionAppendContext(ctx context.Context, arg *UploadSessionCursor, content io.Reader) (err error)
+	// UploadSessionAppendV2Context : Append more data to an upload session. When the
+	// parameter close is set, this call will close the session. A single
+	// request should not upload more than 150 MiB. The maximum size of a file
+	// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+	// bytes. Calls to this endpoint will count as data transport calls for any
+	// Dropbox Business teams with a limit on the number of data transport calls
+	// allowed per month. For more information, see the Data transport limit
+	// page https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadSessionAppendV2Context(ctx context.Context, arg *UploadSessionAppendArg, content io.Reader) (err error)
+	// UploadSessionAppendBatchContext : Append more data to multiple upload sessions.
+	// Each piece of file content to append to each upload session should be
+	// concatenated in the request body, in the order delineated by
+	// `UploadSessionAppendBatchArg.entries` and their individual lengths
+	// indicated by `UploadSessionAppendBatchArgEntry.length`. A single request
+	// should not upload more than 150 MiB. The maximum size of a file one can
+	// upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+	// Calls to this endpoint will count as data transport calls for any Dropbox
+	// Business teams with a limit on the number of data transport calls allowed
+	// per month. For more information, see the Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadSessionAppendBatchContext(ctx context.Context, arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error)
+	// UploadSessionFinishContext : Finish an upload session and save the uploaded data
+	// to the given file path. A single request should not upload more than 150
+	// MiB. The maximum size of a file one can upload to an upload session is
+	// 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count
+	// as data transport calls for any Dropbox Business teams with a limit on
+	// the number of data transport calls allowed per month. For more
+	// information, see the Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadSessionFinishContext(ctx context.Context, arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error)
+	// UploadSessionFinishBatchContext : This route helps you commit many files at once
+	// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
+	// to upload file contents. We recommend uploading many files in parallel to
+	// increase throughput. Once the file contents have been uploaded, rather
+	// than calling `uploadSessionFinish`, use this route to finish all your
+	// upload sessions in a single request. `UploadSessionStartArg.close` or
+	// `UploadSessionAppendArg.close` needs to be true for the last
+	// `uploadSessionStart` or `uploadSessionAppend` call. The maximum size of a
+	// file one can upload to an upload session is 2^41 - 2^22
+	// (2,199,019,061,248) bytes. This route will return a job_id immediately
+	// and do the async commit job in background. Use
+	// `uploadSessionFinishBatchCheck` to check the job status. For the same
+	// account, this route should be executed serially. That means you should
+	// not start the next job before current job finishes. We allow up to 1000
+	// entries in a single request. Calls to this endpoint will count as data
+	// transport calls for any Dropbox Business teams with a limit on the number
+	// of data transport calls allowed per month. For more information, see the
+	// Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	// Deprecated:
+	UploadSessionFinishBatchContext(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error)
+	// UploadSessionFinishBatchV2Context : This route helps you commit many files at once
+	// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
+	// to upload file contents. We recommend uploading many files in parallel to
+	// increase throughput. Once the file contents have been uploaded, rather
+	// than calling `uploadSessionFinish`, use this route to finish all your
+	// upload sessions in a single request. `UploadSessionStartArg.close` or
+	// `UploadSessionAppendArg.close` needs to be true for the last
+	// `uploadSessionStart` or `uploadSessionAppend` call of each upload
+	// session. The maximum size of a file one can upload to an upload session
+	// is 2^41 - 2^22 (2,199,019,061,248) bytes. We allow up to 1000 entries in
+	// a single request. Calls to this endpoint will count as data transport
+	// calls for any Dropbox Business teams with a limit on the number of data
+	// transport calls allowed per month. For more information, see the Data
+	// transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadSessionFinishBatchV2Context(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error)
+	// UploadSessionFinishBatchCheckContext : Returns the status of an asynchronous job
+	// for `uploadSessionFinishBatch`. If success, it returns list of result for
+	// each entry.
+	UploadSessionFinishBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error)
+	// UploadSessionStartContext : Upload sessions allow you to upload a single file in
+	// one or more requests, for example where the size of the file is greater
+	// than 150 MiB. This call starts a new upload session with the given data.
+	// You can then use `uploadSessionAppend` or `uploadSessionAppendBatch` to
+	// add more data, then `uploadSessionFinish` or `uploadSessionFinishBatch`
+	// to save all the data to a file in Dropbox. A single request should not
+	// upload more than 150 MiB. The maximum size of a file one can upload to an
+	// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. An upload
+	// session can be used for a maximum of 7 days. Attempting to use a
+	// `UploadSessionStartResult.session_id` with `uploadSessionAppend` or other
+	// upload session routes more than 7 days after its creation will return
+	// `UploadSessionLookupError.not_found`. Calls to this endpoint will count
+	// as data transport calls for any Dropbox Business teams with a limit on
+	// the number of data transport calls allowed per month. For more
+	// information, see the Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit. By
+	// default, upload sessions require you to send content of the file in
+	// sequential order via consecutive `uploadSessionStart`,
+	// `uploadSessionAppend`, and `uploadSessionFinish` calls (or their batch
+	// variants). For better performance, you can optionally set
+	// `UploadSessionStartArg.session_type` to `UploadSessionType.concurrent` to
+	// start a concurrent upload session. Concurrent upload sessions may upload
+	// file data in concurrent `uploadSessionAppend` requests, with a few
+	// caveats. After all of the requests are complete, finish the session with
+	// `uploadSessionFinish` as normal. You can not send data in a
+	// `uploadSessionStart` or `uploadSessionFinish` call, only with
+	// `uploadSessionAppend` or `uploadSessionAppendBatch`. Also, the length of
+	// the uploaded data in a call to `uploadSessionAppend` or
+	// `uploadSessionAppendBatch` must be a multiple of 2^22 (4,194,304) bytes,
+	// except for the final append request with `UploadSessionAppendArg.close`
+	// or `UploadSessionAppendBatchArgEntry.close` set to true that may contain
+	// any remaining data.
+	UploadSessionStartContext(ctx context.Context, arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error)
+	// UploadSessionStartBatchContext : Start a batch of upload sessions. See
+	// `uploadSessionStart`. Calls to this endpoint will count as data transport
+	// calls for any Dropbox Business teams with a limit on the number of data
+	// transport calls allowed per month. For more information, see the Data
+	// transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
+	UploadSessionStartBatchContext(ctx context.Context, arg *UploadSessionStartBatchArg) (res *UploadSessionStartBatchResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // AlphaGetMetadataAPIError is an error-wrapper for the alpha/get_metadata route
@@ -477,7 +918,11 @@ type AlphaGetMetadataAPIError struct {
 	EndpointError *AlphaGetMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
+// AlphaGetMetadataContext : Returns the metadata for a file or folder. This is an
+// alpha endpoint compatible with the properties API. Note: Metadata for the
+// root folder is unsupported.
+// Deprecated:
+func (dbx *apiImpl) AlphaGetMetadataContext(ctx context.Context, arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
 	log.Printf("WARNING: API `AlphaGetMetadata` is deprecated")
 
 	req := dropbox.Request{
@@ -492,11 +937,11 @@ func (dbx *apiImpl) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr AlphaGetMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -522,13 +967,22 @@ func (dbx *apiImpl) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, 
 	return
 }
 
+func (dbx *apiImpl) AlphaGetMetadata(arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
+	return dbx.AlphaGetMetadataContext(context.Background(), arg)
+}
+
 // AlphaUploadAPIError is an error-wrapper for the alpha/upload route
 type AlphaUploadAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadError `json:"error"`
 }
 
-func (dbx *apiImpl) AlphaUpload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
+// AlphaUploadContext : Create a new file with the contents provided in the
+// request. Note that the behavior of this alpha endpoint is unstable and
+// subject to change. Do not use this to upload a file larger than 150 MiB.
+// Instead, create an upload session with `uploadSessionStart`.
+// Deprecated:
+func (dbx *apiImpl) AlphaUploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
 	log.Printf("WARNING: API `AlphaUpload` is deprecated")
 
 	req := dropbox.Request{
@@ -543,11 +997,11 @@ func (dbx *apiImpl) AlphaUpload(arg *UploadArg, content io.Reader) (res *FileMet
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr AlphaUploadAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -562,13 +1016,20 @@ func (dbx *apiImpl) AlphaUpload(arg *UploadArg, content io.Reader) (res *FileMet
 	return
 }
 
+func (dbx *apiImpl) AlphaUpload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
+	return dbx.AlphaUploadContext(context.Background(), arg, content)
+}
+
 // CopyAPIError is an error-wrapper for the copy route
 type CopyAPIError struct {
 	dropbox.APIError
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) Copy(arg *RelocationArg) (res IsMetadata, err error) {
+// CopyContext : Copy a file or folder to a different location in the user's
+// Dropbox. If the source path is a folder all its contents will be copied.
+// Deprecated:
+func (dbx *apiImpl) CopyContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error) {
 	log.Printf("WARNING: API `Copy` is deprecated")
 
 	req := dropbox.Request{
@@ -583,11 +1044,11 @@ func (dbx *apiImpl) Copy(arg *RelocationArg) (res IsMetadata, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -613,13 +1074,19 @@ func (dbx *apiImpl) Copy(arg *RelocationArg) (res IsMetadata, err error) {
 	return
 }
 
+func (dbx *apiImpl) Copy(arg *RelocationArg) (res IsMetadata, err error) {
+	return dbx.CopyContext(context.Background(), arg)
+}
+
 // CopyV2APIError is an error-wrapper for the copy_v2 route
 type CopyV2APIError struct {
 	dropbox.APIError
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyV2(arg *RelocationArg) (res *RelocationResult, err error) {
+// CopyV2Context : Copy a file or folder to a different location in the user's
+// Dropbox. If the source path is a folder all its contents will be copied.
+func (dbx *apiImpl) CopyV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -632,11 +1099,11 @@ func (dbx *apiImpl) CopyV2(arg *RelocationArg) (res *RelocationResult, err error
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -651,13 +1118,22 @@ func (dbx *apiImpl) CopyV2(arg *RelocationArg) (res *RelocationResult, err error
 	return
 }
 
+func (dbx *apiImpl) CopyV2(arg *RelocationArg) (res *RelocationResult, err error) {
+	return dbx.CopyV2Context(context.Background(), arg)
+}
+
 // CopyBatchAPIError is an error-wrapper for the copy_batch route
 type CopyBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+// CopyBatchContext : Copy multiple files or folders to different locations at once
+// in the user's Dropbox. This route will return job ID immediately and do
+// the async copy job in background. Please use `copyBatchCheck` to check
+// the job status.
+// Deprecated:
+func (dbx *apiImpl) CopyBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	log.Printf("WARNING: API `CopyBatch` is deprecated")
 
 	req := dropbox.Request{
@@ -672,11 +1148,11 @@ func (dbx *apiImpl) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaun
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -691,13 +1167,23 @@ func (dbx *apiImpl) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaun
 	return
 }
 
+func (dbx *apiImpl) CopyBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+	return dbx.CopyBatchContext(context.Background(), arg)
+}
+
 // CopyBatchV2APIError is an error-wrapper for the copy_batch_v2 route
 type CopyBatchV2APIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatchV2(arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error) {
+// CopyBatchV2Context : Copy multiple files or folders to different locations at once
+// in the user's Dropbox. This route will replace `copyBatch`. The main
+// difference is this route will return status for each entry, while
+// `copyBatch` raises failure if any entry fails. This route will either
+// finish synchronously, or return a job ID and do the async copy job in
+// background. Please use `copyBatchCheck` to check the job status.
+func (dbx *apiImpl) CopyBatchV2Context(ctx context.Context, arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -710,11 +1196,11 @@ func (dbx *apiImpl) CopyBatchV2(arg *RelocationBatchArgBase) (res *RelocationBat
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyBatchV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -729,13 +1215,20 @@ func (dbx *apiImpl) CopyBatchV2(arg *RelocationBatchArgBase) (res *RelocationBat
 	return
 }
 
+func (dbx *apiImpl) CopyBatchV2(arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error) {
+	return dbx.CopyBatchV2Context(context.Background(), arg)
+}
+
 // CopyBatchCheckAPIError is an error-wrapper for the copy_batch/check route
 type CopyBatchCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+// CopyBatchCheckContext : Returns the status of an asynchronous job for
+// `copyBatch`. If success, it returns list of results for each entry.
+// Deprecated:
+func (dbx *apiImpl) CopyBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
 	log.Printf("WARNING: API `CopyBatchCheck` is deprecated")
 
 	req := dropbox.Request{
@@ -750,11 +1243,11 @@ func (dbx *apiImpl) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobS
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyBatchCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -769,13 +1262,19 @@ func (dbx *apiImpl) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobS
 	return
 }
 
+func (dbx *apiImpl) CopyBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+	return dbx.CopyBatchCheckContext(context.Background(), arg)
+}
+
 // CopyBatchCheckV2APIError is an error-wrapper for the copy_batch/check_v2 route
 type CopyBatchCheckV2APIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
+// CopyBatchCheckV2Context : Returns the status of an asynchronous job for
+// `copyBatch`. It returns list of results for each entry.
+func (dbx *apiImpl) CopyBatchCheckV2Context(ctx context.Context, arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -788,11 +1287,11 @@ func (dbx *apiImpl) CopyBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyBatchCheckV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -807,13 +1306,20 @@ func (dbx *apiImpl) CopyBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2
 	return
 }
 
+func (dbx *apiImpl) CopyBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
+	return dbx.CopyBatchCheckV2Context(context.Background(), arg)
+}
+
 // CopyReferenceGetAPIError is an error-wrapper for the copy_reference/get route
 type CopyReferenceGetAPIError struct {
 	dropbox.APIError
 	EndpointError *GetCopyReferenceError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
+// CopyReferenceGetContext : Get a copy reference to a file or folder. This
+// reference string can be used to save that file or folder to another
+// user's Dropbox by passing it to `copyReferenceSave`.
+func (dbx *apiImpl) CopyReferenceGetContext(ctx context.Context, arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -826,11 +1332,11 @@ func (dbx *apiImpl) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyRefe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyReferenceGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -845,13 +1351,19 @@ func (dbx *apiImpl) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyRefe
 	return
 }
 
+func (dbx *apiImpl) CopyReferenceGet(arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
+	return dbx.CopyReferenceGetContext(context.Background(), arg)
+}
+
 // CopyReferenceSaveAPIError is an error-wrapper for the copy_reference/save route
 type CopyReferenceSaveAPIError struct {
 	dropbox.APIError
 	EndpointError *SaveCopyReferenceError `json:"error"`
 }
 
-func (dbx *apiImpl) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
+// CopyReferenceSaveContext : Save a copy reference returned by `copyReferenceGet`
+// to the user's Dropbox.
+func (dbx *apiImpl) CopyReferenceSaveContext(ctx context.Context, arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -864,11 +1376,11 @@ func (dbx *apiImpl) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CopyReferenceSaveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -883,13 +1395,19 @@ func (dbx *apiImpl) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyR
 	return
 }
 
+func (dbx *apiImpl) CopyReferenceSave(arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
+	return dbx.CopyReferenceSaveContext(context.Background(), arg)
+}
+
 // CreateFolderAPIError is an error-wrapper for the create_folder route
 type CreateFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *CreateFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err error) {
+// CreateFolderContext : Create a folder at a given path.
+// Deprecated:
+func (dbx *apiImpl) CreateFolderContext(ctx context.Context, arg *CreateFolderArg) (res *FolderMetadata, err error) {
 	log.Printf("WARNING: API `CreateFolder` is deprecated")
 
 	req := dropbox.Request{
@@ -904,11 +1422,11 @@ func (dbx *apiImpl) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -923,13 +1441,18 @@ func (dbx *apiImpl) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err
 	return
 }
 
+func (dbx *apiImpl) CreateFolder(arg *CreateFolderArg) (res *FolderMetadata, err error) {
+	return dbx.CreateFolderContext(context.Background(), arg)
+}
+
 // CreateFolderV2APIError is an error-wrapper for the create_folder_v2 route
 type CreateFolderV2APIError struct {
 	dropbox.APIError
 	EndpointError *CreateFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateFolderV2(arg *CreateFolderArg) (res *CreateFolderResult, err error) {
+// CreateFolderV2Context : Create a folder at a given path.
+func (dbx *apiImpl) CreateFolderV2Context(ctx context.Context, arg *CreateFolderArg) (res *CreateFolderResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -942,11 +1465,11 @@ func (dbx *apiImpl) CreateFolderV2(arg *CreateFolderArg) (res *CreateFolderResul
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateFolderV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -961,13 +1484,24 @@ func (dbx *apiImpl) CreateFolderV2(arg *CreateFolderArg) (res *CreateFolderResul
 	return
 }
 
+func (dbx *apiImpl) CreateFolderV2(arg *CreateFolderArg) (res *CreateFolderResult, err error) {
+	return dbx.CreateFolderV2Context(context.Background(), arg)
+}
+
 // CreateFolderBatchAPIError is an error-wrapper for the create_folder_batch route
 type CreateFolderBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) CreateFolderBatch(arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error) {
+// CreateFolderBatchContext : Create multiple folders at once. This route is
+// asynchronous for large batches, which returns a job ID immediately and
+// runs the create folder batch asynchronously. Otherwise, creates the
+// folders and returns the result synchronously for smaller inputs. You can
+// force asynchronous behaviour by using the
+// CreateFolderBatchArg.force_async flag.  Use `createFolderBatchCheck` to
+// check the job status.
+func (dbx *apiImpl) CreateFolderBatchContext(ctx context.Context, arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -980,11 +1514,11 @@ func (dbx *apiImpl) CreateFolderBatch(arg *CreateFolderBatchArg) (res *CreateFol
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateFolderBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -999,13 +1533,20 @@ func (dbx *apiImpl) CreateFolderBatch(arg *CreateFolderBatchArg) (res *CreateFol
 	return
 }
 
+func (dbx *apiImpl) CreateFolderBatch(arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error) {
+	return dbx.CreateFolderBatchContext(context.Background(), arg)
+}
+
 // CreateFolderBatchCheckAPIError is an error-wrapper for the create_folder_batch/check route
 type CreateFolderBatchCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateFolderBatchCheck(arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error) {
+// CreateFolderBatchCheckContext : Returns the status of an asynchronous job for
+// `createFolderBatch`. If success, it returns list of result for each
+// entry.
+func (dbx *apiImpl) CreateFolderBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1018,11 +1559,11 @@ func (dbx *apiImpl) CreateFolderBatchCheck(arg *async.PollArg) (res *CreateFolde
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateFolderBatchCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1037,13 +1578,23 @@ func (dbx *apiImpl) CreateFolderBatchCheck(arg *async.PollArg) (res *CreateFolde
 	return
 }
 
+func (dbx *apiImpl) CreateFolderBatchCheck(arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error) {
+	return dbx.CreateFolderBatchCheckContext(context.Background(), arg)
+}
+
 // DeleteAPIError is an error-wrapper for the delete route
 type DeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *DeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) Delete(arg *DeleteArg) (res IsMetadata, err error) {
+// DeleteContext : Delete the file or folder at a given path. If the path is a
+// folder, all its contents will be deleted too. A successful response
+// indicates that the file or folder was deleted. The returned metadata will
+// be the corresponding FileMetadata or FolderMetadata for the item at time
+// of deletion, and not a DeletedMetadata object.
+// Deprecated:
+func (dbx *apiImpl) DeleteContext(ctx context.Context, arg *DeleteArg) (res IsMetadata, err error) {
 	log.Printf("WARNING: API `Delete` is deprecated")
 
 	req := dropbox.Request{
@@ -1058,11 +1609,11 @@ func (dbx *apiImpl) Delete(arg *DeleteArg) (res IsMetadata, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1088,13 +1639,22 @@ func (dbx *apiImpl) Delete(arg *DeleteArg) (res IsMetadata, err error) {
 	return
 }
 
+func (dbx *apiImpl) Delete(arg *DeleteArg) (res IsMetadata, err error) {
+	return dbx.DeleteContext(context.Background(), arg)
+}
+
 // DeleteV2APIError is an error-wrapper for the delete_v2 route
 type DeleteV2APIError struct {
 	dropbox.APIError
 	EndpointError *DeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteV2(arg *DeleteArg) (res *DeleteResult, err error) {
+// DeleteV2Context : Delete the file or folder at a given path. If the path is a
+// folder, all its contents will be deleted too. A successful response
+// indicates that the file or folder was deleted. The returned metadata will
+// be the corresponding FileMetadata or FolderMetadata for the item at time
+// of deletion, and not a DeletedMetadata object.
+func (dbx *apiImpl) DeleteV2Context(ctx context.Context, arg *DeleteArg) (res *DeleteResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1107,11 +1667,11 @@ func (dbx *apiImpl) DeleteV2(arg *DeleteArg) (res *DeleteResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1126,13 +1686,20 @@ func (dbx *apiImpl) DeleteV2(arg *DeleteArg) (res *DeleteResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) DeleteV2(arg *DeleteArg) (res *DeleteResult, err error) {
+	return dbx.DeleteV2Context(context.Background(), arg)
+}
+
 // DeleteBatchAPIError is an error-wrapper for the delete_batch route
 type DeleteBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
+// DeleteBatchContext : Delete multiple files/folders at once. This route is
+// asynchronous, which returns a job ID immediately and runs the delete
+// batch asynchronously. Use `deleteBatchCheck` to check the job status.
+func (dbx *apiImpl) DeleteBatchContext(ctx context.Context, arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1145,11 +1712,11 @@ func (dbx *apiImpl) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1164,13 +1731,19 @@ func (dbx *apiImpl) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, er
 	return
 }
 
+func (dbx *apiImpl) DeleteBatch(arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
+	return dbx.DeleteBatchContext(context.Background(), arg)
+}
+
 // DeleteBatchCheckAPIError is an error-wrapper for the delete_batch/check route
 type DeleteBatchCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobStatus, err error) {
+// DeleteBatchCheckContext : Returns the status of an asynchronous job for
+// `deleteBatch`. If success, it returns list of result for each entry.
+func (dbx *apiImpl) DeleteBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *DeleteBatchJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1183,11 +1756,11 @@ func (dbx *apiImpl) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobSta
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DeleteBatchCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1202,13 +1775,18 @@ func (dbx *apiImpl) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobSta
 	return
 }
 
+func (dbx *apiImpl) DeleteBatchCheck(arg *async.PollArg) (res *DeleteBatchJobStatus, err error) {
+	return dbx.DeleteBatchCheckContext(context.Background(), arg)
+}
+
 // DownloadAPIError is an error-wrapper for the download route
 type DownloadAPIError struct {
 	dropbox.APIError
 	EndpointError *DownloadError `json:"error"`
 }
 
-func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error) {
+// DownloadContext : Download a file from a user's Dropbox.
+func (dbx *apiImpl) DownloadContext(ctx context.Context, arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1221,11 +1799,11 @@ func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.Re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DownloadAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1240,13 +1818,23 @@ func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.Re
 	return
 }
 
+func (dbx *apiImpl) Download(arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error) {
+	return dbx.DownloadContext(context.Background(), arg)
+}
+
 // DownloadZipAPIError is an error-wrapper for the download_zip route
 type DownloadZipAPIError struct {
 	dropbox.APIError
 	EndpointError *DownloadZipError `json:"error"`
 }
 
-func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error) {
+// DownloadZipContext : Download a folder from the user's Dropbox, as a zip file.
+// The folder must be less than 20 GB in size and any single file within
+// must be less than 4 GB in size. The resulting zip must have fewer than
+// 10,000 total file and folder entries, including the top level folder. The
+// input cannot be a single file. Note: this endpoint does not support HTTP
+// range requests.
+func (dbx *apiImpl) DownloadZipContext(ctx context.Context, arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1259,11 +1847,11 @@ func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, co
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DownloadZipAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1278,13 +1866,20 @@ func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, co
 	return
 }
 
+func (dbx *apiImpl) DownloadZip(arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error) {
+	return dbx.DownloadZipContext(context.Background(), arg)
+}
+
 // ExportAPIError is an error-wrapper for the export route
 type ExportAPIError struct {
 	dropbox.APIError
 	EndpointError *ExportError `json:"error"`
 }
 
-func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCloser, err error) {
+// ExportContext : Export a file from a user's Dropbox. This route only supports
+// exporting files that cannot be downloaded directly and whose
+// ExportResult.file_metadata has ExportInfo.export_as populated.
+func (dbx *apiImpl) ExportContext(ctx context.Context, arg *ExportArg) (res *ExportResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1297,11 +1892,11 @@ func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCl
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ExportAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1316,13 +1911,18 @@ func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCl
 	return
 }
 
+func (dbx *apiImpl) Export(arg *ExportArg) (res *ExportResult, content io.ReadCloser, err error) {
+	return dbx.ExportContext(context.Background(), arg)
+}
+
 // GetFileLockBatchAPIError is an error-wrapper for the get_file_lock_batch route
 type GetFileLockBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *LockFileError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFileLockBatch(arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
+// GetFileLockBatchContext : Return the lock metadata for the given list of paths.
+func (dbx *apiImpl) GetFileLockBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1335,11 +1935,11 @@ func (dbx *apiImpl) GetFileLockBatch(arg *LockFileBatchArg) (res *LockFileBatchR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetFileLockBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1354,13 +1954,19 @@ func (dbx *apiImpl) GetFileLockBatch(arg *LockFileBatchArg) (res *LockFileBatchR
 	return
 }
 
+func (dbx *apiImpl) GetFileLockBatch(arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
+	return dbx.GetFileLockBatchContext(context.Background(), arg)
+}
+
 // GetMetadataAPIError is an error-wrapper for the get_metadata route
 type GetMetadataAPIError struct {
 	dropbox.APIError
 	EndpointError *GetMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
+// GetMetadataContext : Returns the metadata for a file or folder. Note: Metadata
+// for the root folder is unsupported.
+func (dbx *apiImpl) GetMetadataContext(ctx context.Context, arg *GetMetadataArg) (res IsMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1373,11 +1979,11 @@ func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1403,13 +2009,23 @@ func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error)
 	return
 }
 
+func (dbx *apiImpl) GetMetadata(arg *GetMetadataArg) (res IsMetadata, err error) {
+	return dbx.GetMetadataContext(context.Background(), arg)
+}
+
 // GetPreviewAPIError is an error-wrapper for the get_preview route
 type GetPreviewAPIError struct {
 	dropbox.APIError
 	EndpointError *PreviewError `json:"error"`
 }
 
-func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
+// GetPreviewContext : Get a preview for a file. Currently, PDF previews are
+// generated for files with the following extensions: .ai, .doc, .docm,
+// .docx, .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx, .ppt,
+// .pptm, .pptx, .rtf. HTML previews are generated for .csv, .ods, .xls,
+// .xlsm, .gsheet, .xlsx. Other formats will return an unsupported extension
+// error.
+func (dbx *apiImpl) GetPreviewContext(ctx context.Context, arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1422,11 +2038,11 @@ func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.R
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetPreviewAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1441,13 +2057,22 @@ func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.R
 	return
 }
 
+func (dbx *apiImpl) GetPreview(arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
+	return dbx.GetPreviewContext(context.Background(), arg)
+}
+
 // GetTemporaryLinkAPIError is an error-wrapper for the get_temporary_link route
 type GetTemporaryLinkAPIError struct {
 	dropbox.APIError
 	EndpointError *GetTemporaryLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
+// GetTemporaryLinkContext : Get a temporary link to stream content of a file. This
+// link will expire in four hours and afterwards you will get 410 Gone. This
+// URL should not be used to display content directly in the browser. The
+// Content-Type of the link is determined automatically by the file's mime
+// type.
+func (dbx *apiImpl) GetTemporaryLinkContext(ctx context.Context, arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1460,11 +2085,11 @@ func (dbx *apiImpl) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporar
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetTemporaryLinkAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1479,13 +2104,46 @@ func (dbx *apiImpl) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporar
 	return
 }
 
+func (dbx *apiImpl) GetTemporaryLink(arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
+	return dbx.GetTemporaryLinkContext(context.Background(), arg)
+}
+
 // GetTemporaryUploadLinkAPIError is an error-wrapper for the get_temporary_upload_link route
 type GetTemporaryUploadLinkAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetTemporaryUploadLink(arg *GetTemporaryUploadLinkArg) (res *GetTemporaryUploadLinkResult, err error) {
+// GetTemporaryUploadLinkContext : Get a one-time use temporary upload link to
+// upload a file to a Dropbox location.  This endpoint acts as a delayed
+// upload(). The returned temporary upload link may be used to make a POST
+// request with the data to be uploaded. The upload will then be perfomed
+// with the CommitInfo previously provided to getTemporaryUploadLink() but
+// evaluated only upon consumption. Hence, errors stemming from invalid
+// CommitInfo with respect to the state of the user's Dropbox will only be
+// communicated at consumption time. Additionally, these errors are surfaced
+// as generic HTTP 409 Conflict responses, potentially hiding issue details.
+// The maximum temporary upload link duration is 4 hours. Upon consumption
+// or expiration, a new link will have to be generated. Multiple links may
+// exist for a specific upload path at any given time.  The POST request on
+// the temporary upload link must have its Content-Type set to
+// "application/octet-stream".  Example temporary upload link consumption
+// request:  curl -X POST
+// https://content.dropboxapi.com/apitul/1/bNi2uIYF51cVBND --header
+// "Content-Type: application/octet-stream" --data-binary @local_file.txt  A
+// successful temporary upload link consumption request returns the content
+// hash of the uploaded data in JSON format. Example successful temporary
+// upload link consumption response: {"content-hash":
+// "599d71033d700ac892a0e48fa61b125d2f5994"}  An unsuccessful temporary
+// upload link consumption request returns any of the following status
+// codes:  HTTP 400 Bad Request: Content-Type is not one of
+// application/octet-stream and text/plain or request is invalid. HTTP 409
+// Conflict: The temporary upload link does not exist or is currently
+// unavailable, the upload failed, or another error happened. HTTP 410 Gone:
+// The temporary upload link is expired or consumed. Example unsuccessful
+// temporary upload link consumption response: Temporary upload link has
+// been recently consumed.
+func (dbx *apiImpl) GetTemporaryUploadLinkContext(ctx context.Context, arg *GetTemporaryUploadLinkArg) (res *GetTemporaryUploadLinkResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1498,11 +2156,11 @@ func (dbx *apiImpl) GetTemporaryUploadLink(arg *GetTemporaryUploadLinkArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetTemporaryUploadLinkAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1517,13 +2175,21 @@ func (dbx *apiImpl) GetTemporaryUploadLink(arg *GetTemporaryUploadLinkArg) (res 
 	return
 }
 
+func (dbx *apiImpl) GetTemporaryUploadLink(arg *GetTemporaryUploadLinkArg) (res *GetTemporaryUploadLinkResult, err error) {
+	return dbx.GetTemporaryUploadLinkContext(context.Background(), arg)
+}
+
 // GetThumbnailAPIError is an error-wrapper for the get_thumbnail route
 type GetThumbnailAPIError struct {
 	dropbox.APIError
 	EndpointError *ThumbnailError `json:"error"`
 }
 
-func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
+// GetThumbnailContext : Get a thumbnail for an image. This method currently
+// supports files with the following file extensions: jpg, jpeg, png, tiff,
+// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
+// won't be converted to a thumbnail.
+func (dbx *apiImpl) GetThumbnailContext(ctx context.Context, arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1536,11 +2202,11 @@ func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetThumbnailAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1555,13 +2221,21 @@ func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content 
 	return
 }
 
+func (dbx *apiImpl) GetThumbnail(arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
+	return dbx.GetThumbnailContext(context.Background(), arg)
+}
+
 // GetThumbnailV2APIError is an error-wrapper for the get_thumbnail_v2 route
 type GetThumbnailV2APIError struct {
 	dropbox.APIError
 	EndpointError *ThumbnailV2Error `json:"error"`
 }
 
-func (dbx *apiImpl) GetThumbnailV2(arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error) {
+// GetThumbnailV2Context : Get a thumbnail for an image. This method currently
+// supports files with the following file extensions: jpg, jpeg, png, tiff,
+// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
+// won't be converted to a thumbnail.
+func (dbx *apiImpl) GetThumbnailV2Context(ctx context.Context, arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1574,11 +2248,11 @@ func (dbx *apiImpl) GetThumbnailV2(arg *ThumbnailV2Arg) (res *PreviewResult, con
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetThumbnailV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1593,13 +2267,22 @@ func (dbx *apiImpl) GetThumbnailV2(arg *ThumbnailV2Arg) (res *PreviewResult, con
 	return
 }
 
+func (dbx *apiImpl) GetThumbnailV2(arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error) {
+	return dbx.GetThumbnailV2Context(context.Background(), arg)
+}
+
 // GetThumbnailBatchAPIError is an error-wrapper for the get_thumbnail_batch route
 type GetThumbnailBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *GetThumbnailBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) GetThumbnailBatch(arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error) {
+// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow up to
+// 25 thumbnails in a single batch. This method currently supports files
+// with the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp,
+// ppm and bmp. Photos that are larger than 20MB in size won't be converted
+// to a thumbnail.
+func (dbx *apiImpl) GetThumbnailBatchContext(ctx context.Context, arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -1612,11 +2295,11 @@ func (dbx *apiImpl) GetThumbnailBatch(arg *GetThumbnailBatchArg) (res *GetThumbn
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetThumbnailBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1631,13 +2314,38 @@ func (dbx *apiImpl) GetThumbnailBatch(arg *GetThumbnailBatchArg) (res *GetThumbn
 	return
 }
 
+func (dbx *apiImpl) GetThumbnailBatch(arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error) {
+	return dbx.GetThumbnailBatchContext(context.Background(), arg)
+}
+
 // ListFolderAPIError is an error-wrapper for the list_folder route
 type ListFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err error) {
+// ListFolderContext : Starts returning the contents of a folder. If the result's
+// `ListFolderResult.has_more` field is true, call `listFolderContinue` with
+// the returned ListFolderResult.cursor to retrieve more entries. If you're
+// using ListFolderArg.recursive set to true to keep a local cache of the
+// contents of a Dropbox account, iterate through each entry in order and
+// process them as follows to keep your local state in sync: For each
+// FileMetadata, store the new entry at the given path in your local state.
+// If the required parent folders don't exist yet, create them. If there's
+// already something else at the given path, replace it and remove all its
+// children. For each FolderMetadata, store the new entry at the given path
+// in your local state. If the required parent folders don't exist yet,
+// create them. If there's already something else at the given path, replace
+// it but leave the children as they are. Check the new entry's
+// FolderSharingInfo.read_only and set all its children's read-only statuses
+// to match. For each DeletedMetadata, if your local state has something at
+// the given path, remove it and all its children. If there's nothing at the
+// given path, ignore this entry. Note: auth.RateLimitError may be returned
+// if multiple `listFolder` or `listFolderContinue` calls with same
+// parameters are made simultaneously by same API app for same user. If your
+// app implements retry logic, please hold off the retry until the previous
+// request finishes.
+func (dbx *apiImpl) ListFolderContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1650,11 +2358,11 @@ func (dbx *apiImpl) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1669,13 +2377,20 @@ func (dbx *apiImpl) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err e
 	return
 }
 
+func (dbx *apiImpl) ListFolder(arg *ListFolderArg) (res *ListFolderResult, err error) {
+	return dbx.ListFolderContext(context.Background(), arg)
+}
+
 // ListFolderContinueAPIError is an error-wrapper for the list_folder/continue route
 type ListFolderContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFolderContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
+// ListFolderContinueContext : Once a cursor has been retrieved from `listFolder`,
+// use this to paginate through all files and retrieve updates to the
+// folder, following the same rules as documented for `listFolder`.
+func (dbx *apiImpl) ListFolderContinueContext(ctx context.Context, arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1688,11 +2403,11 @@ func (dbx *apiImpl) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFol
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1707,13 +2422,22 @@ func (dbx *apiImpl) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFol
 	return
 }
 
+func (dbx *apiImpl) ListFolderContinue(arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
+	return dbx.ListFolderContinueContext(context.Background(), arg)
+}
+
 // ListFolderGetLatestCursorAPIError is an error-wrapper for the list_folder/get_latest_cursor route
 type ListFolderGetLatestCursorAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
+// ListFolderGetLatestCursorContext : A way to quickly get a cursor for the
+// folder's state. Unlike `listFolder`, `listFolderGetLatestCursor` doesn't
+// return any entries. This endpoint is for app which only needs to know
+// about new files and modifications and doesn't need to know about files
+// that already exist in Dropbox.
+func (dbx *apiImpl) ListFolderGetLatestCursorContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1726,11 +2450,11 @@ func (dbx *apiImpl) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFold
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderGetLatestCursorAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1745,13 +2469,22 @@ func (dbx *apiImpl) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFold
 	return
 }
 
+func (dbx *apiImpl) ListFolderGetLatestCursor(arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
+	return dbx.ListFolderGetLatestCursorContext(context.Background(), arg)
+}
+
 // ListFolderLongpollAPIError is an error-wrapper for the list_folder/longpoll route
 type ListFolderLongpollAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFolderLongpollError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
+// ListFolderLongpollContext : A longpoll endpoint to wait for changes on an
+// account. In conjunction with `listFolderContinue`, this call gives you a
+// low-latency way to monitor an account for file changes. The connection
+// will block until there are changes available or a timeout occurs. This
+// endpoint is useful mostly for client-side apps.
+func (dbx *apiImpl) ListFolderLongpollContext(ctx context.Context, arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
 	req := dropbox.Request{
 		Host:         "notify",
 		Namespace:    "files",
@@ -1764,11 +2497,11 @@ func (dbx *apiImpl) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFol
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderLongpollAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1783,13 +2516,26 @@ func (dbx *apiImpl) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFol
 	return
 }
 
+func (dbx *apiImpl) ListFolderLongpoll(arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
+	return dbx.ListFolderLongpollContext(context.Background(), arg)
+}
+
 // ListRevisionsAPIError is an error-wrapper for the list_revisions route
 type ListRevisionsAPIError struct {
 	dropbox.APIError
 	EndpointError *ListRevisionsError `json:"error"`
 }
 
-func (dbx *apiImpl) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
+// ListRevisionsContext : Returns revisions for files based on a file path or a
+// file id. The file path or file id is identified from the latest file
+// entry at the given file path or id. This end point allows your app to
+// query either by file path or file id by setting the mode parameter
+// appropriately. In the ListRevisionsMode.path (default) mode, all
+// revisions at the same file path as the latest file entry are returned. If
+// revisions with the same file id are desired, then mode must be set to
+// ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
+// revisions for a given file across moves or renames.
+func (dbx *apiImpl) ListRevisionsContext(ctx context.Context, arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1802,11 +2548,11 @@ func (dbx *apiImpl) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResu
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListRevisionsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1821,13 +2567,21 @@ func (dbx *apiImpl) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResu
 	return
 }
 
+func (dbx *apiImpl) ListRevisions(arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
+	return dbx.ListRevisionsContext(context.Background(), arg)
+}
+
 // LockFileBatchAPIError is an error-wrapper for the lock_file_batch route
 type LockFileBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *LockFileError `json:"error"`
 }
 
-func (dbx *apiImpl) LockFileBatch(arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
+// LockFileBatchContext : Lock the files at the given paths. A locked file will be
+// writable only by the lock holder. A successful response indicates that
+// the file has been locked. Returns a list of the locked file paths and
+// their metadata after this operation.
+func (dbx *apiImpl) LockFileBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1840,11 +2594,11 @@ func (dbx *apiImpl) LockFileBatch(arg *LockFileBatchArg) (res *LockFileBatchResu
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LockFileBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1859,13 +2613,20 @@ func (dbx *apiImpl) LockFileBatch(arg *LockFileBatchArg) (res *LockFileBatchResu
 	return
 }
 
+func (dbx *apiImpl) LockFileBatch(arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
+	return dbx.LockFileBatchContext(context.Background(), arg)
+}
+
 // MoveAPIError is an error-wrapper for the move route
 type MoveAPIError struct {
 	dropbox.APIError
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) Move(arg *RelocationArg) (res IsMetadata, err error) {
+// MoveContext : Move a file or folder to a different location in the user's
+// Dropbox. If the source path is a folder all its contents will be moved.
+// Deprecated:
+func (dbx *apiImpl) MoveContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error) {
 	log.Printf("WARNING: API `Move` is deprecated")
 
 	req := dropbox.Request{
@@ -1880,11 +2641,11 @@ func (dbx *apiImpl) Move(arg *RelocationArg) (res IsMetadata, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1910,13 +2671,20 @@ func (dbx *apiImpl) Move(arg *RelocationArg) (res IsMetadata, err error) {
 	return
 }
 
+func (dbx *apiImpl) Move(arg *RelocationArg) (res IsMetadata, err error) {
+	return dbx.MoveContext(context.Background(), arg)
+}
+
 // MoveV2APIError is an error-wrapper for the move_v2 route
 type MoveV2APIError struct {
 	dropbox.APIError
 	EndpointError *RelocationError `json:"error"`
 }
 
-func (dbx *apiImpl) MoveV2(arg *RelocationArg) (res *RelocationResult, err error) {
+// MoveV2Context : Move a file or folder to a different location in the user's
+// Dropbox. If the source path is a folder all its contents will be moved.
+// Note that we do not currently support case-only renaming.
+func (dbx *apiImpl) MoveV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -1929,11 +2697,11 @@ func (dbx *apiImpl) MoveV2(arg *RelocationArg) (res *RelocationResult, err error
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1948,13 +2716,22 @@ func (dbx *apiImpl) MoveV2(arg *RelocationArg) (res *RelocationResult, err error
 	return
 }
 
+func (dbx *apiImpl) MoveV2(arg *RelocationArg) (res *RelocationResult, err error) {
+	return dbx.MoveV2Context(context.Background(), arg)
+}
+
 // MoveBatchAPIError is an error-wrapper for the move_batch route
 type MoveBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+// MoveBatchContext : Move multiple files or folders to different locations at once
+// in the user's Dropbox. This route will return job ID immediately and do
+// the async moving job in background. Please use `moveBatchCheck` to check
+// the job status.
+// Deprecated:
+func (dbx *apiImpl) MoveBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	log.Printf("WARNING: API `MoveBatch` is deprecated")
 
 	req := dropbox.Request{
@@ -1969,11 +2746,11 @@ func (dbx *apiImpl) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaun
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1988,13 +2765,24 @@ func (dbx *apiImpl) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaun
 	return
 }
 
+func (dbx *apiImpl) MoveBatch(arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
+	return dbx.MoveBatchContext(context.Background(), arg)
+}
+
 // MoveBatchV2APIError is an error-wrapper for the move_batch_v2 route
 type MoveBatchV2APIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatchV2(arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error) {
+// MoveBatchV2Context : Move multiple files or folders to different locations at once
+// in the user's Dropbox. Note that we do not currently support case-only
+// renaming. This route will replace `moveBatch`. The main difference is
+// this route will return status for each entry, while `moveBatch` raises
+// failure if any entry fails. This route will either finish synchronously,
+// or return a job ID and do the async move job in background. Please use
+// `moveBatchCheck` to check the job status.
+func (dbx *apiImpl) MoveBatchV2Context(ctx context.Context, arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2007,11 +2795,11 @@ func (dbx *apiImpl) MoveBatchV2(arg *MoveBatchArg) (res *RelocationBatchV2Launch
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveBatchV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2026,13 +2814,20 @@ func (dbx *apiImpl) MoveBatchV2(arg *MoveBatchArg) (res *RelocationBatchV2Launch
 	return
 }
 
+func (dbx *apiImpl) MoveBatchV2(arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error) {
+	return dbx.MoveBatchV2Context(context.Background(), arg)
+}
+
 // MoveBatchCheckAPIError is an error-wrapper for the move_batch/check route
 type MoveBatchCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+// MoveBatchCheckContext : Returns the status of an asynchronous job for
+// `moveBatch`. If success, it returns list of results for each entry.
+// Deprecated:
+func (dbx *apiImpl) MoveBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
 	log.Printf("WARNING: API `MoveBatchCheck` is deprecated")
 
 	req := dropbox.Request{
@@ -2047,11 +2842,11 @@ func (dbx *apiImpl) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobS
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveBatchCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2066,13 +2861,19 @@ func (dbx *apiImpl) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobS
 	return
 }
 
+func (dbx *apiImpl) MoveBatchCheck(arg *async.PollArg) (res *RelocationBatchJobStatus, err error) {
+	return dbx.MoveBatchCheckContext(context.Background(), arg)
+}
+
 // MoveBatchCheckV2APIError is an error-wrapper for the move_batch/check_v2 route
 type MoveBatchCheckV2APIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MoveBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
+// MoveBatchCheckV2Context : Returns the status of an asynchronous job for
+// `moveBatch`. It returns list of results for each entry.
+func (dbx *apiImpl) MoveBatchCheckV2Context(ctx context.Context, arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2085,11 +2886,11 @@ func (dbx *apiImpl) MoveBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MoveBatchCheckV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2104,13 +2905,18 @@ func (dbx *apiImpl) MoveBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2
 	return
 }
 
+func (dbx *apiImpl) MoveBatchCheckV2(arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error) {
+	return dbx.MoveBatchCheckV2Context(context.Background(), arg)
+}
+
 // PaperCreateAPIError is an error-wrapper for the paper/create route
 type PaperCreateAPIError struct {
 	dropbox.APIError
 	EndpointError *PaperCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) PaperCreate(arg *PaperCreateArg, content io.Reader) (res *PaperCreateResult, err error) {
+// PaperCreateContext : Creates a new Paper doc with the provided content.
+func (dbx *apiImpl) PaperCreateContext(ctx context.Context, arg *PaperCreateArg, content io.Reader) (res *PaperCreateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2123,11 +2929,11 @@ func (dbx *apiImpl) PaperCreate(arg *PaperCreateArg, content io.Reader) (res *Pa
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr PaperCreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2142,13 +2948,18 @@ func (dbx *apiImpl) PaperCreate(arg *PaperCreateArg, content io.Reader) (res *Pa
 	return
 }
 
+func (dbx *apiImpl) PaperCreate(arg *PaperCreateArg, content io.Reader) (res *PaperCreateResult, err error) {
+	return dbx.PaperCreateContext(context.Background(), arg, content)
+}
+
 // PaperUpdateAPIError is an error-wrapper for the paper/update route
 type PaperUpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *PaperUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) PaperUpdate(arg *PaperUpdateArg, content io.Reader) (res *PaperUpdateResult, err error) {
+// PaperUpdateContext : Updates an existing Paper doc with the provided content.
+func (dbx *apiImpl) PaperUpdateContext(ctx context.Context, arg *PaperUpdateArg, content io.Reader) (res *PaperUpdateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2161,11 +2972,11 @@ func (dbx *apiImpl) PaperUpdate(arg *PaperUpdateArg, content io.Reader) (res *Pa
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr PaperUpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2180,13 +2991,22 @@ func (dbx *apiImpl) PaperUpdate(arg *PaperUpdateArg, content io.Reader) (res *Pa
 	return
 }
 
+func (dbx *apiImpl) PaperUpdate(arg *PaperUpdateArg, content io.Reader) (res *PaperUpdateResult, err error) {
+	return dbx.PaperUpdateContext(context.Background(), arg, content)
+}
+
 // PermanentlyDeleteAPIError is an error-wrapper for the permanently_delete route
 type PermanentlyDeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *DeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) PermanentlyDelete(arg *DeleteArg) (err error) {
+// PermanentlyDeleteContext : Permanently delete the file or folder at a given path
+// (see https://www.dropbox.com/en/help/40). If the given file or folder is
+// not yet deleted, this route will first delete it. It is possible for this
+// route to successfully delete, then fail to permanently delete. Note: This
+// endpoint is only available for Dropbox Business apps.
+func (dbx *apiImpl) PermanentlyDeleteContext(ctx context.Context, arg *DeleteArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2199,11 +3019,11 @@ func (dbx *apiImpl) PermanentlyDelete(arg *DeleteArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PermanentlyDeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2214,13 +3034,20 @@ func (dbx *apiImpl) PermanentlyDelete(arg *DeleteArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) PermanentlyDelete(arg *DeleteArg) (err error) {
+	return dbx.PermanentlyDeleteContext(context.Background(), arg)
+}
+
 // PropertiesAddAPIError is an error-wrapper for the properties/add route
 type PropertiesAddAPIError struct {
 	dropbox.APIError
 	EndpointError *file_properties.AddPropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesAdd(arg *file_properties.AddPropertiesArg) (err error) {
+// PropertiesAddContext : Add property groups to a Dropbox file. See
+// templates/add_for_user or templates/add_for_team to create new templates.
+// Deprecated:
+func (dbx *apiImpl) PropertiesAddContext(ctx context.Context, arg *file_properties.AddPropertiesArg) (err error) {
 	log.Printf("WARNING: API `PropertiesAdd` is deprecated")
 
 	req := dropbox.Request{
@@ -2235,11 +3062,11 @@ func (dbx *apiImpl) PropertiesAdd(arg *file_properties.AddPropertiesArg) (err er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2250,13 +3077,21 @@ func (dbx *apiImpl) PropertiesAdd(arg *file_properties.AddPropertiesArg) (err er
 	return
 }
 
+func (dbx *apiImpl) PropertiesAdd(arg *file_properties.AddPropertiesArg) (err error) {
+	return dbx.PropertiesAddContext(context.Background(), arg)
+}
+
 // PropertiesOverwriteAPIError is an error-wrapper for the properties/overwrite route
 type PropertiesOverwriteAPIError struct {
 	dropbox.APIError
 	EndpointError *file_properties.InvalidPropertyGroupError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesOverwrite(arg *file_properties.OverwritePropertyGroupArg) (err error) {
+// PropertiesOverwriteContext : Overwrite property groups associated with a file.
+// This endpoint should be used instead of properties/update when property
+// groups are being overwritten rather than updated via a "delta".
+// Deprecated:
+func (dbx *apiImpl) PropertiesOverwriteContext(ctx context.Context, arg *file_properties.OverwritePropertyGroupArg) (err error) {
 	log.Printf("WARNING: API `PropertiesOverwrite` is deprecated")
 
 	req := dropbox.Request{
@@ -2271,11 +3106,11 @@ func (dbx *apiImpl) PropertiesOverwrite(arg *file_properties.OverwritePropertyGr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesOverwriteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2286,13 +3121,22 @@ func (dbx *apiImpl) PropertiesOverwrite(arg *file_properties.OverwritePropertyGr
 	return
 }
 
+func (dbx *apiImpl) PropertiesOverwrite(arg *file_properties.OverwritePropertyGroupArg) (err error) {
+	return dbx.PropertiesOverwriteContext(context.Background(), arg)
+}
+
 // PropertiesUpdateAPIError is an error-wrapper for the properties/update route
 type PropertiesUpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *file_properties.UpdatePropertiesError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesUpdate(arg *file_properties.UpdatePropertiesArg) (err error) {
+// PropertiesUpdateContext : Add, update or remove properties associated with the
+// supplied file and templates. This endpoint should be used instead of
+// properties/overwrite when property groups are being updated via a "delta"
+// instead of overwriting all properties of a file.
+// Deprecated:
+func (dbx *apiImpl) PropertiesUpdateContext(ctx context.Context, arg *file_properties.UpdatePropertiesArg) (err error) {
 	log.Printf("WARNING: API `PropertiesUpdate` is deprecated")
 
 	req := dropbox.Request{
@@ -2307,11 +3151,11 @@ func (dbx *apiImpl) PropertiesUpdate(arg *file_properties.UpdatePropertiesArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesUpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2322,13 +3166,18 @@ func (dbx *apiImpl) PropertiesUpdate(arg *file_properties.UpdatePropertiesArg) (
 	return
 }
 
+func (dbx *apiImpl) PropertiesUpdate(arg *file_properties.UpdatePropertiesArg) (err error) {
+	return dbx.PropertiesUpdateContext(context.Background(), arg)
+}
+
 // RestoreAPIError is an error-wrapper for the restore route
 type RestoreAPIError struct {
 	dropbox.APIError
 	EndpointError *RestoreError `json:"error"`
 }
 
-func (dbx *apiImpl) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
+// RestoreContext : Restore a specific revision of a file to the given path.
+func (dbx *apiImpl) RestoreContext(ctx context.Context, arg *RestoreArg) (res *FileMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2341,11 +3190,11 @@ func (dbx *apiImpl) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RestoreAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2360,13 +3209,20 @@ func (dbx *apiImpl) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
 	return
 }
 
+func (dbx *apiImpl) Restore(arg *RestoreArg) (res *FileMetadata, err error) {
+	return dbx.RestoreContext(context.Background(), arg)
+}
+
 // SaveUrlAPIError is an error-wrapper for the save_url route
 type SaveUrlAPIError struct {
 	dropbox.APIError
 	EndpointError *SaveUrlError `json:"error"`
 }
 
-func (dbx *apiImpl) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
+// SaveUrlContext : Save the data from a specified URL into a file in user's
+// Dropbox. Note that the transfer from the URL must complete within 15
+// minutes, or the operation will time out and the job will fail.
+func (dbx *apiImpl) SaveUrlContext(ctx context.Context, arg *SaveUrlArg) (res *SaveUrlResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2379,11 +3235,11 @@ func (dbx *apiImpl) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SaveUrlAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2398,13 +3254,18 @@ func (dbx *apiImpl) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) SaveUrl(arg *SaveUrlArg) (res *SaveUrlResult, err error) {
+	return dbx.SaveUrlContext(context.Background(), arg)
+}
+
 // SaveUrlCheckJobStatusAPIError is an error-wrapper for the save_url/check_job_status route
 type SaveUrlCheckJobStatusAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobStatus, err error) {
+// SaveUrlCheckJobStatusContext : Check the status of a `saveUrl` job.
+func (dbx *apiImpl) SaveUrlCheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *SaveUrlJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2417,11 +3278,11 @@ func (dbx *apiImpl) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobSt
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SaveUrlCheckJobStatusAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2436,13 +3297,21 @@ func (dbx *apiImpl) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobSt
 	return
 }
 
+func (dbx *apiImpl) SaveUrlCheckJobStatus(arg *async.PollArg) (res *SaveUrlJobStatus, err error) {
+	return dbx.SaveUrlCheckJobStatusContext(context.Background(), arg)
+}
+
 // SearchAPIError is an error-wrapper for the search route
 type SearchAPIError struct {
 	dropbox.APIError
 	EndpointError *SearchError `json:"error"`
 }
 
-func (dbx *apiImpl) Search(arg *SearchArg) (res *SearchResult, err error) {
+// SearchContext : Searches for files and folders. Note: Recent changes will be
+// reflected in search results within a few seconds and older revisions of
+// existing files may still match your query for up to a few days.
+// Deprecated:
+func (dbx *apiImpl) SearchContext(ctx context.Context, arg *SearchArg) (res *SearchResult, err error) {
 	log.Printf("WARNING: API `Search` is deprecated")
 
 	req := dropbox.Request{
@@ -2457,11 +3326,11 @@ func (dbx *apiImpl) Search(arg *SearchArg) (res *SearchResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SearchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2476,13 +3345,22 @@ func (dbx *apiImpl) Search(arg *SearchArg) (res *SearchResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) Search(arg *SearchArg) (res *SearchResult, err error) {
+	return dbx.SearchContext(context.Background(), arg)
+}
+
 // SearchV2APIError is an error-wrapper for the search_v2 route
 type SearchV2APIError struct {
 	dropbox.APIError
 	EndpointError *SearchError `json:"error"`
 }
 
-func (dbx *apiImpl) SearchV2(arg *SearchV2Arg) (res *SearchV2Result, err error) {
+// SearchV2Context : Searches for files and folders. Note: `search` along with
+// `searchContinue` can only be used to retrieve a maximum of 10,000
+// matches. Recent changes may not immediately be reflected in search
+// results due to a short delay in indexing. Duplicate results may be
+// returned across pages. Some results may not be returned.
+func (dbx *apiImpl) SearchV2Context(ctx context.Context, arg *SearchV2Arg) (res *SearchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2495,11 +3373,11 @@ func (dbx *apiImpl) SearchV2(arg *SearchV2Arg) (res *SearchV2Result, err error) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SearchV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2514,13 +3392,23 @@ func (dbx *apiImpl) SearchV2(arg *SearchV2Arg) (res *SearchV2Result, err error) 
 	return
 }
 
+func (dbx *apiImpl) SearchV2(arg *SearchV2Arg) (res *SearchV2Result, err error) {
+	return dbx.SearchV2Context(context.Background(), arg)
+}
+
 // SearchContinueV2APIError is an error-wrapper for the search/continue_v2 route
 type SearchContinueV2APIError struct {
 	dropbox.APIError
 	EndpointError *SearchError `json:"error"`
 }
 
-func (dbx *apiImpl) SearchContinueV2(arg *SearchV2ContinueArg) (res *SearchV2Result, err error) {
+// SearchContinueV2Context : Fetches the next page of search results returned from
+// `search`. Note: `search` along with `searchContinue` can only be used to
+// retrieve a maximum of 10,000 matches. Recent changes may not immediately
+// be reflected in search results due to a short delay in indexing.
+// Duplicate results may be returned across pages. Some results may not be
+// returned.
+func (dbx *apiImpl) SearchContinueV2Context(ctx context.Context, arg *SearchV2ContinueArg) (res *SearchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2533,11 +3421,11 @@ func (dbx *apiImpl) SearchContinueV2(arg *SearchV2ContinueArg) (res *SearchV2Res
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SearchContinueV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2552,13 +3440,20 @@ func (dbx *apiImpl) SearchContinueV2(arg *SearchV2ContinueArg) (res *SearchV2Res
 	return
 }
 
+func (dbx *apiImpl) SearchContinueV2(arg *SearchV2ContinueArg) (res *SearchV2Result, err error) {
+	return dbx.SearchContinueV2Context(context.Background(), arg)
+}
+
 // TagsAddAPIError is an error-wrapper for the tags/add route
 type TagsAddAPIError struct {
 	dropbox.APIError
 	EndpointError *AddTagError `json:"error"`
 }
 
-func (dbx *apiImpl) TagsAdd(arg *AddTagArg) (err error) {
+// TagsAddContext : Add a tag to an item. A tag is a string. The strings are
+// automatically converted to lowercase letters. No more than 20 tags can be
+// added to a given item.
+func (dbx *apiImpl) TagsAddContext(ctx context.Context, arg *AddTagArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2571,11 +3466,11 @@ func (dbx *apiImpl) TagsAdd(arg *AddTagArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TagsAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2586,13 +3481,18 @@ func (dbx *apiImpl) TagsAdd(arg *AddTagArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) TagsAdd(arg *AddTagArg) (err error) {
+	return dbx.TagsAddContext(context.Background(), arg)
+}
+
 // TagsGetAPIError is an error-wrapper for the tags/get route
 type TagsGetAPIError struct {
 	dropbox.APIError
 	EndpointError *BaseTagError `json:"error"`
 }
 
-func (dbx *apiImpl) TagsGet(arg *GetTagsArg) (res *GetTagsResult, err error) {
+// TagsGetContext : Get list of tags assigned to items.
+func (dbx *apiImpl) TagsGetContext(ctx context.Context, arg *GetTagsArg) (res *GetTagsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2605,11 +3505,11 @@ func (dbx *apiImpl) TagsGet(arg *GetTagsArg) (res *GetTagsResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TagsGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2624,13 +3524,18 @@ func (dbx *apiImpl) TagsGet(arg *GetTagsArg) (res *GetTagsResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) TagsGet(arg *GetTagsArg) (res *GetTagsResult, err error) {
+	return dbx.TagsGetContext(context.Background(), arg)
+}
+
 // TagsRemoveAPIError is an error-wrapper for the tags/remove route
 type TagsRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *RemoveTagError `json:"error"`
 }
 
-func (dbx *apiImpl) TagsRemove(arg *RemoveTagArg) (err error) {
+// TagsRemoveContext : Remove a tag from an item.
+func (dbx *apiImpl) TagsRemoveContext(ctx context.Context, arg *RemoveTagArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2643,11 +3548,11 @@ func (dbx *apiImpl) TagsRemove(arg *RemoveTagArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TagsRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2658,13 +3563,22 @@ func (dbx *apiImpl) TagsRemove(arg *RemoveTagArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) TagsRemove(arg *RemoveTagArg) (err error) {
+	return dbx.TagsRemoveContext(context.Background(), arg)
+}
+
 // UnlockFileBatchAPIError is an error-wrapper for the unlock_file_batch route
 type UnlockFileBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *LockFileError `json:"error"`
 }
 
-func (dbx *apiImpl) UnlockFileBatch(arg *UnlockFileBatchArg) (res *LockFileBatchResult, err error) {
+// UnlockFileBatchContext : Unlock the files at the given paths. A locked file can
+// only be unlocked by the lock holder or, if a business account, a team
+// admin. A successful response indicates that the file has been unlocked.
+// Returns a list of the unlocked file paths and their metadata after this
+// operation.
+func (dbx *apiImpl) UnlockFileBatchContext(ctx context.Context, arg *UnlockFileBatchArg) (res *LockFileBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2677,11 +3591,11 @@ func (dbx *apiImpl) UnlockFileBatch(arg *UnlockFileBatchArg) (res *LockFileBatch
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UnlockFileBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2696,13 +3610,24 @@ func (dbx *apiImpl) UnlockFileBatch(arg *UnlockFileBatchArg) (res *LockFileBatch
 	return
 }
 
+func (dbx *apiImpl) UnlockFileBatch(arg *UnlockFileBatchArg) (res *LockFileBatchResult, err error) {
+	return dbx.UnlockFileBatchContext(context.Background(), arg)
+}
+
 // UploadAPIError is an error-wrapper for the upload route
 type UploadAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadError `json:"error"`
 }
 
-func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
+// UploadContext : Create a new file with the contents provided in the request. Do
+// not use this to upload a file larger than 150 MiB. Instead, create an
+// upload session with `uploadSessionStart`. Calls to this endpoint will
+// count as data transport calls for any Dropbox Business teams with a limit
+// on the number of data transport calls allowed per month. For more
+// information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -2715,11 +3640,11 @@ func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2734,13 +3659,25 @@ func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata
 	return
 }
 
+func (dbx *apiImpl) Upload(arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
+	return dbx.UploadContext(context.Background(), arg, content)
+}
+
 // UploadSessionAppendAPIError is an error-wrapper for the upload_session/append route
 type UploadSessionAppendAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadSessionAppendError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Reader) (err error) {
+// UploadSessionAppendContext : Append more data to an upload session. A single
+// request should not upload more than 150 MiB. The maximum size of a file
+// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+// bytes. Calls to this endpoint will count as data transport calls for any
+// Dropbox Business teams with a limit on the number of data transport calls
+// allowed per month. For more information, see the Data transport limit
+// page https://www.dropbox.com/developers/reference/data-transport-limit.
+// Deprecated:
+func (dbx *apiImpl) UploadSessionAppendContext(ctx context.Context, arg *UploadSessionCursor, content io.Reader) (err error) {
 	log.Printf("WARNING: API `UploadSessionAppend` is deprecated")
 
 	req := dropbox.Request{
@@ -2755,11 +3692,11 @@ func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Rea
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadSessionAppendAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2770,13 +3707,25 @@ func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Rea
 	return
 }
 
+func (dbx *apiImpl) UploadSessionAppend(arg *UploadSessionCursor, content io.Reader) (err error) {
+	return dbx.UploadSessionAppendContext(context.Background(), arg, content)
+}
+
 // UploadSessionAppendV2APIError is an error-wrapper for the upload_session/append_v2 route
 type UploadSessionAppendV2APIError struct {
 	dropbox.APIError
 	EndpointError *UploadSessionAppendError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content io.Reader) (err error) {
+// UploadSessionAppendV2Context : Append more data to an upload session. When the
+// parameter close is set, this call will close the session. A single
+// request should not upload more than 150 MiB. The maximum size of a file
+// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+// bytes. Calls to this endpoint will count as data transport calls for any
+// Dropbox Business teams with a limit on the number of data transport calls
+// allowed per month. For more information, see the Data transport limit
+// page https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadSessionAppendV2Context(ctx context.Context, arg *UploadSessionAppendArg, content io.Reader) (err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -2789,11 +3738,11 @@ func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content i
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadSessionAppendV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2804,13 +3753,28 @@ func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content i
 	return
 }
 
+func (dbx *apiImpl) UploadSessionAppendV2(arg *UploadSessionAppendArg, content io.Reader) (err error) {
+	return dbx.UploadSessionAppendV2Context(context.Background(), arg, content)
+}
+
 // UploadSessionAppendBatchAPIError is an error-wrapper for the upload_session/append_batch route
 type UploadSessionAppendBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadSessionAppendBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionAppendBatch(arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error) {
+// UploadSessionAppendBatchContext : Append more data to multiple upload sessions.
+// Each piece of file content to append to each upload session should be
+// concatenated in the request body, in the order delineated by
+// `UploadSessionAppendBatchArg.entries` and their individual lengths
+// indicated by `UploadSessionAppendBatchArgEntry.length`. A single request
+// should not upload more than 150 MiB. The maximum size of a file one can
+// upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+// Calls to this endpoint will count as data transport calls for any Dropbox
+// Business teams with a limit on the number of data transport calls allowed
+// per month. For more information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadSessionAppendBatchContext(ctx context.Context, arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -2823,11 +3787,11 @@ func (dbx *apiImpl) UploadSessionAppendBatch(arg *UploadSessionAppendBatchArg, c
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadSessionAppendBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2842,13 +3806,25 @@ func (dbx *apiImpl) UploadSessionAppendBatch(arg *UploadSessionAppendBatchArg, c
 	return
 }
 
+func (dbx *apiImpl) UploadSessionAppendBatch(arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error) {
+	return dbx.UploadSessionAppendBatchContext(context.Background(), arg, content)
+}
+
 // UploadSessionFinishAPIError is an error-wrapper for the upload_session/finish route
 type UploadSessionFinishAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadSessionFinishError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
+// UploadSessionFinishContext : Finish an upload session and save the uploaded data
+// to the given file path. A single request should not upload more than 150
+// MiB. The maximum size of a file one can upload to an upload session is
+// 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count
+// as data transport calls for any Dropbox Business teams with a limit on
+// the number of data transport calls allowed per month. For more
+// information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadSessionFinishContext(ctx context.Context, arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -2861,11 +3837,11 @@ func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadSessionFinishAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2880,13 +3856,37 @@ func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.
 	return
 }
 
+func (dbx *apiImpl) UploadSessionFinish(arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
+	return dbx.UploadSessionFinishContext(context.Background(), arg, content)
+}
+
 // UploadSessionFinishBatchAPIError is an error-wrapper for the upload_session/finish_batch route
 type UploadSessionFinishBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
+// UploadSessionFinishBatchContext : This route helps you commit many files at once
+// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
+// to upload file contents. We recommend uploading many files in parallel to
+// increase throughput. Once the file contents have been uploaded, rather
+// than calling `uploadSessionFinish`, use this route to finish all your
+// upload sessions in a single request. `UploadSessionStartArg.close` or
+// `UploadSessionAppendArg.close` needs to be true for the last
+// `uploadSessionStart` or `uploadSessionAppend` call. The maximum size of a
+// file one can upload to an upload session is 2^41 - 2^22
+// (2,199,019,061,248) bytes. This route will return a job_id immediately
+// and do the async commit job in background. Use
+// `uploadSessionFinishBatchCheck` to check the job status. For the same
+// account, this route should be executed serially. That means you should
+// not start the next job before current job finishes. We allow up to 1000
+// entries in a single request. Calls to this endpoint will count as data
+// transport calls for any Dropbox Business teams with a limit on the number
+// of data transport calls allowed per month. For more information, see the
+// Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+// Deprecated:
+func (dbx *apiImpl) UploadSessionFinishBatchContext(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
 	log.Printf("WARNING: API `UploadSessionFinishBatch` is deprecated")
 
 	req := dropbox.Request{
@@ -2901,11 +3901,11 @@ func (dbx *apiImpl) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UploadSessionFinishBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2920,13 +3920,32 @@ func (dbx *apiImpl) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (
 	return
 }
 
+func (dbx *apiImpl) UploadSessionFinishBatch(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
+	return dbx.UploadSessionFinishBatchContext(context.Background(), arg)
+}
+
 // UploadSessionFinishBatchV2APIError is an error-wrapper for the upload_session/finish_batch_v2 route
 type UploadSessionFinishBatchV2APIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinishBatchV2(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error) {
+// UploadSessionFinishBatchV2Context : This route helps you commit many files at once
+// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
+// to upload file contents. We recommend uploading many files in parallel to
+// increase throughput. Once the file contents have been uploaded, rather
+// than calling `uploadSessionFinish`, use this route to finish all your
+// upload sessions in a single request. `UploadSessionStartArg.close` or
+// `UploadSessionAppendArg.close` needs to be true for the last
+// `uploadSessionStart` or `uploadSessionAppend` call of each upload
+// session. The maximum size of a file one can upload to an upload session
+// is 2^41 - 2^22 (2,199,019,061,248) bytes. We allow up to 1000 entries in
+// a single request. Calls to this endpoint will count as data transport
+// calls for any Dropbox Business teams with a limit on the number of data
+// transport calls allowed per month. For more information, see the Data
+// transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadSessionFinishBatchV2Context(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2939,11 +3958,11 @@ func (dbx *apiImpl) UploadSessionFinishBatchV2(arg *UploadSessionFinishBatchArg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UploadSessionFinishBatchV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2958,13 +3977,20 @@ func (dbx *apiImpl) UploadSessionFinishBatchV2(arg *UploadSessionFinishBatchArg)
 	return
 }
 
+func (dbx *apiImpl) UploadSessionFinishBatchV2(arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error) {
+	return dbx.UploadSessionFinishBatchV2Context(context.Background(), arg)
+}
+
 // UploadSessionFinishBatchCheckAPIError is an error-wrapper for the upload_session/finish_batch/check route
 type UploadSessionFinishBatchCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
+// UploadSessionFinishBatchCheckContext : Returns the status of an asynchronous job
+// for `uploadSessionFinishBatch`. If success, it returns list of result for
+// each entry.
+func (dbx *apiImpl) UploadSessionFinishBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -2977,11 +4003,11 @@ func (dbx *apiImpl) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *Uplo
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UploadSessionFinishBatchCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2996,13 +4022,49 @@ func (dbx *apiImpl) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *Uplo
 	return
 }
 
+func (dbx *apiImpl) UploadSessionFinishBatchCheck(arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
+	return dbx.UploadSessionFinishBatchCheckContext(context.Background(), arg)
+}
+
 // UploadSessionStartAPIError is an error-wrapper for the upload_session/start route
 type UploadSessionStartAPIError struct {
 	dropbox.APIError
 	EndpointError *UploadSessionStartError `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
+// UploadSessionStartContext : Upload sessions allow you to upload a single file in
+// one or more requests, for example where the size of the file is greater
+// than 150 MiB. This call starts a new upload session with the given data.
+// You can then use `uploadSessionAppend` or `uploadSessionAppendBatch` to
+// add more data, then `uploadSessionFinish` or `uploadSessionFinishBatch`
+// to save all the data to a file in Dropbox. A single request should not
+// upload more than 150 MiB. The maximum size of a file one can upload to an
+// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. An upload
+// session can be used for a maximum of 7 days. Attempting to use a
+// `UploadSessionStartResult.session_id` with `uploadSessionAppend` or other
+// upload session routes more than 7 days after its creation will return
+// `UploadSessionLookupError.not_found`. Calls to this endpoint will count
+// as data transport calls for any Dropbox Business teams with a limit on
+// the number of data transport calls allowed per month. For more
+// information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit. By
+// default, upload sessions require you to send content of the file in
+// sequential order via consecutive `uploadSessionStart`,
+// `uploadSessionAppend`, and `uploadSessionFinish` calls (or their batch
+// variants). For better performance, you can optionally set
+// `UploadSessionStartArg.session_type` to `UploadSessionType.concurrent` to
+// start a concurrent upload session. Concurrent upload sessions may upload
+// file data in concurrent `uploadSessionAppend` requests, with a few
+// caveats. After all of the requests are complete, finish the session with
+// `uploadSessionFinish` as normal. You can not send data in a
+// `uploadSessionStart` or `uploadSessionFinish` call, only with
+// `uploadSessionAppend` or `uploadSessionAppendBatch`. Also, the length of
+// the uploaded data in a call to `uploadSessionAppend` or
+// `uploadSessionAppendBatch` must be a multiple of 2^22 (4,194,304) bytes,
+// except for the final append request with `UploadSessionAppendArg.close`
+// or `UploadSessionAppendBatchArgEntry.close` set to true that may contain
+// any remaining data.
+func (dbx *apiImpl) UploadSessionStartContext(ctx context.Context, arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -3015,11 +4077,11 @@ func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr UploadSessionStartAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3034,13 +4096,23 @@ func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Re
 	return
 }
 
+func (dbx *apiImpl) UploadSessionStart(arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
+	return dbx.UploadSessionStartContext(context.Background(), arg, content)
+}
+
 // UploadSessionStartBatchAPIError is an error-wrapper for the upload_session/start_batch route
 type UploadSessionStartBatchAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) UploadSessionStartBatch(arg *UploadSessionStartBatchArg) (res *UploadSessionStartBatchResult, err error) {
+// UploadSessionStartBatchContext : Start a batch of upload sessions. See
+// `uploadSessionStart`. Calls to this endpoint will count as data transport
+// calls for any Dropbox Business teams with a limit on the number of data
+// transport calls allowed per month. For more information, see the Data
+// transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
+func (dbx *apiImpl) UploadSessionStartBatchContext(ctx context.Context, arg *UploadSessionStartBatchArg) (res *UploadSessionStartBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "files",
@@ -3053,11 +4125,11 @@ func (dbx *apiImpl) UploadSessionStartBatch(arg *UploadSessionStartBatchArg) (re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UploadSessionStartBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3072,8 +4144,17 @@ func (dbx *apiImpl) UploadSessionStartBatch(arg *UploadSessionStartBatchArg) (re
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) UploadSessionStartBatch(arg *UploadSessionStartBatchArg) (res *UploadSessionStartBatchResult, err error) {
+	return dbx.UploadSessionStartBatchContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/openid/client.go
+++ b/v6/dropbox/openid/client.go
@@ -21,7 +21,9 @@
 package openid
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -36,6 +38,15 @@ type Client interface {
 	Userinfo(arg *UserInfoArgs) (res *UserInfoResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// UserinfoContext : This route is used for refreshing the info that is found in
+	// the id_token during the OIDC flow. This route doesn't require any
+	// arguments and will use the scopes approved for the given access token.
+	UserinfoContext(ctx context.Context, arg *UserInfoArgs) (res *UserInfoResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // UserinfoAPIError is an error-wrapper for the userinfo route
@@ -44,7 +55,10 @@ type UserinfoAPIError struct {
 	EndpointError *UserInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) Userinfo(arg *UserInfoArgs) (res *UserInfoResult, err error) {
+// UserinfoContext : This route is used for refreshing the info that is found in
+// the id_token during the OIDC flow. This route doesn't require any
+// arguments and will use the scopes approved for the given access token.
+func (dbx *apiImpl) UserinfoContext(ctx context.Context, arg *UserInfoArgs) (res *UserInfoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "openid",
@@ -57,11 +71,11 @@ func (dbx *apiImpl) Userinfo(arg *UserInfoArgs) (res *UserInfoResult, err error)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UserinfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -76,8 +90,17 @@ func (dbx *apiImpl) Userinfo(arg *UserInfoArgs) (res *UserInfoResult, err error)
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) Userinfo(arg *UserInfoArgs) (res *UserInfoResult, err error) {
+	return dbx.UserinfoContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/paper/client.go
+++ b/v6/dropbox/paper/client.go
@@ -21,7 +21,9 @@
 package paper
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 
@@ -230,6 +232,208 @@ type Client interface {
 	FoldersCreate(arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// DocsArchiveContext : Marks the given Paper doc as archived. This action can be
+	// performed or undone by anyone with edit permissions to the doc. Note that
+	// this endpoint will continue to work for content created by users on the
+	// older version of Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. This endpoint will be
+	// retired in September 2020. Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for more information.
+	// Deprecated:
+	DocsArchiveContext(ctx context.Context, arg *RefPaperDoc) (err error)
+	// DocsCreateContext : Creates a new Paper doc with the provided content. Note that
+	// this endpoint will continue to work for content created by users on the
+	// older version of Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. This endpoint will be
+	// retired in September 2020. Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for more information.
+	// Deprecated:
+	DocsCreateContext(ctx context.Context, arg *PaperDocCreateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error)
+	// DocsDownloadContext : Exports and downloads Paper doc either as HTML or
+	// markdown. Note that this endpoint will continue to work for content
+	// created by users on the older version of Paper. To check which version of
+	// Paper a user is on, use /users/features/get_values. If the paper_as_files
+	// feature is enabled, then the user is running the new version of Paper.
+	// Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsDownloadContext(ctx context.Context, arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error)
+	// DocsFolderUsersListContext : Lists the users who are explicitly invited to the
+	// Paper folder in which the Paper doc is contained. For private folders all
+	// users (including owner) shared on the folder are listed and for team
+	// folders all non-team users shared on the folder are returned. Note that
+	// this endpoint will continue to work for content created by users on the
+	// older version of Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsFolderUsersListContext(ctx context.Context, arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error)
+	// DocsFolderUsersListContinueContext : Once a cursor has been retrieved from
+	// `docsFolderUsersList`, use this to paginate through all users on the
+	// Paper folder. Note that this endpoint will continue to work for content
+	// created by users on the older version of Paper. To check which version of
+	// Paper a user is on, use /users/features/get_values. If the paper_as_files
+	// feature is enabled, then the user is running the new version of Paper.
+	// Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsFolderUsersListContinueContext(ctx context.Context, arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error)
+	// DocsGetFolderInfoContext : Retrieves folder information for the given Paper doc.
+	// This includes: - folder sharing policy; permissions for subfolders are
+	// set by the top-level folder. - full 'filepath', i.e. the list of folders
+	// (both folderId and folderName) from the root folder to the folder
+	// directly containing the Paper doc. If the Paper doc is not in any folder
+	// (aka unfiled) the response will be empty. Note that this endpoint will
+	// continue to work for content created by users on the older version of
+	// Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsGetFolderInfoContext(ctx context.Context, arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error)
+	// DocsGetMetadataContext : Returns metadata for a Paper doc or Cloud Doc.
+	DocsGetMetadataContext(ctx context.Context, arg *GetDocMetadataArg) (res *PaperDocGetMetadataResult, err error)
+	// DocsListContext : Return the list of all Paper docs according to the argument
+	// specifications. To iterate over through the full pagination, pass the
+	// cursor to `docsListContinue`. Note that this endpoint will continue to
+	// work for content created by users on the older version of Paper. To check
+	// which version of Paper a user is on, use /users/features/get_values. If
+	// the paper_as_files feature is enabled, then the user is running the new
+	// version of Paper. Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsListContext(ctx context.Context, arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error)
+	// DocsListContinueContext : Once a cursor has been retrieved from `docsList`, use
+	// this to paginate through all Paper doc. Note that this endpoint will
+	// continue to work for content created by users on the older version of
+	// Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsListContinueContext(ctx context.Context, arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error)
+	// DocsPermanentlyDeleteContext : Permanently deletes the given Paper doc. This
+	// operation is final as the doc cannot be recovered. This action can be
+	// performed only by the doc owner. Note that this endpoint will continue to
+	// work for content created by users on the older version of Paper. To check
+	// which version of Paper a user is on, use /users/features/get_values. If
+	// the paper_as_files feature is enabled, then the user is running the new
+	// version of Paper. Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsPermanentlyDeleteContext(ctx context.Context, arg *RefPaperDoc) (err error)
+	// DocsSharingPolicyGetContext : Gets the default sharing policy for the given
+	// Paper doc. Note that this endpoint will continue to work for content
+	// created by users on the older version of Paper. To check which version of
+	// Paper a user is on, use /users/features/get_values. If the paper_as_files
+	// feature is enabled, then the user is running the new version of Paper.
+	// Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsSharingPolicyGetContext(ctx context.Context, arg *RefPaperDoc) (res *SharingPolicy, err error)
+	// DocsSharingPolicySetContext : Sets the default sharing policy for the given
+	// Paper doc. The default 'team_sharing_policy' can be changed only by
+	// teams, omit this field for personal accounts. The 'public_sharing_policy'
+	// policy can't be set to the value 'disabled' because this setting can be
+	// changed only via the team admin console. Note that this endpoint will
+	// continue to work for content created by users on the older version of
+	// Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsSharingPolicySetContext(ctx context.Context, arg *PaperDocSharingPolicy) (err error)
+	// DocsUpdateContext : Updates an existing Paper doc with the provided content.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. This
+	// endpoint will be retired in September 2020. Refer to the `Paper Migration
+	// Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for more information.
+	// Deprecated:
+	DocsUpdateContext(ctx context.Context, arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error)
+	// DocsUsersAddContext : Allows an owner or editor to add users to a Paper doc or
+	// change their permissions using their email address or Dropbox account ID.
+	// The doc owner's permissions cannot be changed. Note that this endpoint
+	// will continue to work for content created by users on the older version
+	// of Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsUsersAddContext(ctx context.Context, arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error)
+	// DocsUsersListContext : Lists all users who visited the Paper doc or users with
+	// explicit access. This call excludes users who have been removed. The list
+	// is sorted by the date of the visit or the share date. The list will
+	// include both users, the explicitly shared ones as well as those who came
+	// in using the Paper url link. Note that this endpoint will continue to
+	// work for content created by users on the older version of Paper. To check
+	// which version of Paper a user is on, use /users/features/get_values. If
+	// the paper_as_files feature is enabled, then the user is running the new
+	// version of Paper. Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsUsersListContext(ctx context.Context, arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error)
+	// DocsUsersListContinueContext : Once a cursor has been retrieved from
+	// `docsUsersList`, use this to paginate through all users on the Paper doc.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. Refer to
+	// the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsUsersListContinueContext(ctx context.Context, arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error)
+	// DocsUsersRemoveContext : Allows an owner or editor to remove users from a Paper
+	// doc using their email address or Dropbox account ID. The doc owner cannot
+	// be removed. Note that this endpoint will continue to work for content
+	// created by users on the older version of Paper. To check which version of
+	// Paper a user is on, use /users/features/get_values. If the paper_as_files
+	// feature is enabled, then the user is running the new version of Paper.
+	// Refer to the `Paper Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	DocsUsersRemoveContext(ctx context.Context, arg *RemovePaperDocUser) (err error)
+	// FoldersCreateContext : Create a new Paper folder with the provided info. Note
+	// that this endpoint will continue to work for content created by users on
+	// the older version of Paper. To check which version of Paper a user is on,
+	// use /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
+	FoldersCreateContext(ctx context.Context, arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // DocsArchiveAPIError is an error-wrapper for the docs/archive route
@@ -238,7 +442,17 @@ type DocsArchiveAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsArchive(arg *RefPaperDoc) (err error) {
+// DocsArchiveContext : Marks the given Paper doc as archived. This action can be
+// performed or undone by anyone with edit permissions to the doc. Note that
+// this endpoint will continue to work for content created by users on the
+// older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. This endpoint will be
+// retired in September 2020. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for more information.
+// Deprecated:
+func (dbx *apiImpl) DocsArchiveContext(ctx context.Context, arg *RefPaperDoc) (err error) {
 	log.Printf("WARNING: API `DocsArchive` is deprecated")
 
 	req := dropbox.Request{
@@ -253,11 +467,11 @@ func (dbx *apiImpl) DocsArchive(arg *RefPaperDoc) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsArchiveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -268,13 +482,26 @@ func (dbx *apiImpl) DocsArchive(arg *RefPaperDoc) (err error) {
 	return
 }
 
+func (dbx *apiImpl) DocsArchive(arg *RefPaperDoc) (err error) {
+	return dbx.DocsArchiveContext(context.Background(), arg)
+}
+
 // DocsCreateAPIError is an error-wrapper for the docs/create route
 type DocsCreateAPIError struct {
 	dropbox.APIError
 	EndpointError *PaperDocCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsCreate(arg *PaperDocCreateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
+// DocsCreateContext : Creates a new Paper doc with the provided content. Note that
+// this endpoint will continue to work for content created by users on the
+// older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. This endpoint will be
+// retired in September 2020. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for more information.
+// Deprecated:
+func (dbx *apiImpl) DocsCreateContext(ctx context.Context, arg *PaperDocCreateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
 	log.Printf("WARNING: API `DocsCreate` is deprecated")
 
 	req := dropbox.Request{
@@ -289,11 +516,11 @@ func (dbx *apiImpl) DocsCreate(arg *PaperDocCreateArgs, content io.Reader) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr DocsCreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -308,13 +535,26 @@ func (dbx *apiImpl) DocsCreate(arg *PaperDocCreateArgs, content io.Reader) (res 
 	return
 }
 
+func (dbx *apiImpl) DocsCreate(arg *PaperDocCreateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
+	return dbx.DocsCreateContext(context.Background(), arg, content)
+}
+
 // DocsDownloadAPIError is an error-wrapper for the docs/download route
 type DocsDownloadAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
+// DocsDownloadContext : Exports and downloads Paper doc either as HTML or
+// markdown. Note that this endpoint will continue to work for content
+// created by users on the older version of Paper. To check which version of
+// Paper a user is on, use /users/features/get_values. If the paper_as_files
+// feature is enabled, then the user is running the new version of Paper.
+// Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsDownloadContext(ctx context.Context, arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
 	log.Printf("WARNING: API `DocsDownload` is deprecated")
 
 	req := dropbox.Request{
@@ -329,11 +569,11 @@ func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsDownloadAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -348,13 +588,29 @@ func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult
 	return
 }
 
+func (dbx *apiImpl) DocsDownload(arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
+	return dbx.DocsDownloadContext(context.Background(), arg)
+}
+
 // DocsFolderUsersListAPIError is an error-wrapper for the docs/folder_users/list route
 type DocsFolderUsersListAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
+// DocsFolderUsersListContext : Lists the users who are explicitly invited to the
+// Paper folder in which the Paper doc is contained. For private folders all
+// users (including owner) shared on the folder are listed and for team
+// folders all non-team users shared on the folder are returned. Note that
+// this endpoint will continue to work for content created by users on the
+// older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsFolderUsersListContext(ctx context.Context, arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
 	log.Printf("WARNING: API `DocsFolderUsersList` is deprecated")
 
 	req := dropbox.Request{
@@ -369,11 +625,11 @@ func (dbx *apiImpl) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUs
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsFolderUsersListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -388,13 +644,27 @@ func (dbx *apiImpl) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUs
 	return
 }
 
+func (dbx *apiImpl) DocsFolderUsersList(arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
+	return dbx.DocsFolderUsersListContext(context.Background(), arg)
+}
+
 // DocsFolderUsersListContinueAPIError is an error-wrapper for the docs/folder_users/list/continue route
 type DocsFolderUsersListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListUsersCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
+// DocsFolderUsersListContinueContext : Once a cursor has been retrieved from
+// `docsFolderUsersList`, use this to paginate through all users on the
+// Paper folder. Note that this endpoint will continue to work for content
+// created by users on the older version of Paper. To check which version of
+// Paper a user is on, use /users/features/get_values. If the paper_as_files
+// feature is enabled, then the user is running the new version of Paper.
+// Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsFolderUsersListContinueContext(ctx context.Context, arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
 	log.Printf("WARNING: API `DocsFolderUsersListContinue` is deprecated")
 
 	req := dropbox.Request{
@@ -409,11 +679,11 @@ func (dbx *apiImpl) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueAr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsFolderUsersListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -428,13 +698,31 @@ func (dbx *apiImpl) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueAr
 	return
 }
 
+func (dbx *apiImpl) DocsFolderUsersListContinue(arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
+	return dbx.DocsFolderUsersListContinueContext(context.Background(), arg)
+}
+
 // DocsGetFolderInfoAPIError is an error-wrapper for the docs/get_folder_info route
 type DocsGetFolderInfoAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
+// DocsGetFolderInfoContext : Retrieves folder information for the given Paper doc.
+// This includes: - folder sharing policy; permissions for subfolders are
+// set by the top-level folder. - full 'filepath', i.e. the list of folders
+// (both folderId and folderName) from the root folder to the folder
+// directly containing the Paper doc. If the Paper doc is not in any folder
+// (aka unfiled) the response will be empty. Note that this endpoint will
+// continue to work for content created by users on the older version of
+// Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsGetFolderInfoContext(ctx context.Context, arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
 	log.Printf("WARNING: API `DocsGetFolderInfo` is deprecated")
 
 	req := dropbox.Request{
@@ -449,11 +737,11 @@ func (dbx *apiImpl) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingP
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsGetFolderInfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -468,13 +756,18 @@ func (dbx *apiImpl) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingP
 	return
 }
 
+func (dbx *apiImpl) DocsGetFolderInfo(arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
+	return dbx.DocsGetFolderInfoContext(context.Background(), arg)
+}
+
 // DocsGetMetadataAPIError is an error-wrapper for the docs/get_metadata route
 type DocsGetMetadataAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsGetMetadata(arg *GetDocMetadataArg) (res *PaperDocGetMetadataResult, err error) {
+// DocsGetMetadataContext : Returns metadata for a Paper doc or Cloud Doc.
+func (dbx *apiImpl) DocsGetMetadataContext(ctx context.Context, arg *GetDocMetadataArg) (res *PaperDocGetMetadataResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "paper",
@@ -487,11 +780,11 @@ func (dbx *apiImpl) DocsGetMetadata(arg *GetDocMetadataArg) (res *PaperDocGetMet
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsGetMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -506,13 +799,27 @@ func (dbx *apiImpl) DocsGetMetadata(arg *GetDocMetadataArg) (res *PaperDocGetMet
 	return
 }
 
+func (dbx *apiImpl) DocsGetMetadata(arg *GetDocMetadataArg) (res *PaperDocGetMetadataResult, err error) {
+	return dbx.DocsGetMetadataContext(context.Background(), arg)
+}
+
 // DocsListAPIError is an error-wrapper for the docs/list route
 type DocsListAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
+// DocsListContext : Return the list of all Paper docs according to the argument
+// specifications. To iterate over through the full pagination, pass the
+// cursor to `docsListContinue`. Note that this endpoint will continue to
+// work for content created by users on the older version of Paper. To check
+// which version of Paper a user is on, use /users/features/get_values. If
+// the paper_as_files feature is enabled, then the user is running the new
+// version of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsListContext(ctx context.Context, arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
 	log.Printf("WARNING: API `DocsList` is deprecated")
 
 	req := dropbox.Request{
@@ -527,11 +834,11 @@ func (dbx *apiImpl) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -546,13 +853,27 @@ func (dbx *apiImpl) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse
 	return
 }
 
+func (dbx *apiImpl) DocsList(arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
+	return dbx.DocsListContext(context.Background(), arg)
+}
+
 // DocsListContinueAPIError is an error-wrapper for the docs/list/continue route
 type DocsListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListDocsCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
+// DocsListContinueContext : Once a cursor has been retrieved from `docsList`, use
+// this to paginate through all Paper doc. Note that this endpoint will
+// continue to work for content created by users on the older version of
+// Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsListContinueContext(ctx context.Context, arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
 	log.Printf("WARNING: API `DocsListContinue` is deprecated")
 
 	req := dropbox.Request{
@@ -567,11 +888,11 @@ func (dbx *apiImpl) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListP
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -586,13 +907,27 @@ func (dbx *apiImpl) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListP
 	return
 }
 
+func (dbx *apiImpl) DocsListContinue(arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
+	return dbx.DocsListContinueContext(context.Background(), arg)
+}
+
 // DocsPermanentlyDeleteAPIError is an error-wrapper for the docs/permanently_delete route
 type DocsPermanentlyDeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
+// DocsPermanentlyDeleteContext : Permanently deletes the given Paper doc. This
+// operation is final as the doc cannot be recovered. This action can be
+// performed only by the doc owner. Note that this endpoint will continue to
+// work for content created by users on the older version of Paper. To check
+// which version of Paper a user is on, use /users/features/get_values. If
+// the paper_as_files feature is enabled, then the user is running the new
+// version of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsPermanentlyDeleteContext(ctx context.Context, arg *RefPaperDoc) (err error) {
 	log.Printf("WARNING: API `DocsPermanentlyDelete` is deprecated")
 
 	req := dropbox.Request{
@@ -607,11 +942,11 @@ func (dbx *apiImpl) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsPermanentlyDeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -622,13 +957,26 @@ func (dbx *apiImpl) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
 	return
 }
 
+func (dbx *apiImpl) DocsPermanentlyDelete(arg *RefPaperDoc) (err error) {
+	return dbx.DocsPermanentlyDeleteContext(context.Background(), arg)
+}
+
 // DocsSharingPolicyGetAPIError is an error-wrapper for the docs/sharing_policy/get route
 type DocsSharingPolicyGetAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, err error) {
+// DocsSharingPolicyGetContext : Gets the default sharing policy for the given
+// Paper doc. Note that this endpoint will continue to work for content
+// created by users on the older version of Paper. To check which version of
+// Paper a user is on, use /users/features/get_values. If the paper_as_files
+// feature is enabled, then the user is running the new version of Paper.
+// Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsSharingPolicyGetContext(ctx context.Context, arg *RefPaperDoc) (res *SharingPolicy, err error) {
 	log.Printf("WARNING: API `DocsSharingPolicyGet` is deprecated")
 
 	req := dropbox.Request{
@@ -643,11 +991,11 @@ func (dbx *apiImpl) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsSharingPolicyGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -662,13 +1010,30 @@ func (dbx *apiImpl) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, 
 	return
 }
 
+func (dbx *apiImpl) DocsSharingPolicyGet(arg *RefPaperDoc) (res *SharingPolicy, err error) {
+	return dbx.DocsSharingPolicyGetContext(context.Background(), arg)
+}
+
 // DocsSharingPolicySetAPIError is an error-wrapper for the docs/sharing_policy/set route
 type DocsSharingPolicySetAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error) {
+// DocsSharingPolicySetContext : Sets the default sharing policy for the given
+// Paper doc. The default 'team_sharing_policy' can be changed only by
+// teams, omit this field for personal accounts. The 'public_sharing_policy'
+// policy can't be set to the value 'disabled' because this setting can be
+// changed only via the team admin console. Note that this endpoint will
+// continue to work for content created by users on the older version of
+// Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsSharingPolicySetContext(ctx context.Context, arg *PaperDocSharingPolicy) (err error) {
 	log.Printf("WARNING: API `DocsSharingPolicySet` is deprecated")
 
 	req := dropbox.Request{
@@ -683,11 +1048,11 @@ func (dbx *apiImpl) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsSharingPolicySetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -698,13 +1063,27 @@ func (dbx *apiImpl) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error)
 	return
 }
 
+func (dbx *apiImpl) DocsSharingPolicySet(arg *PaperDocSharingPolicy) (err error) {
+	return dbx.DocsSharingPolicySetContext(context.Background(), arg)
+}
+
 // DocsUpdateAPIError is an error-wrapper for the docs/update route
 type DocsUpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *PaperDocUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUpdate(arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
+// DocsUpdateContext : Updates an existing Paper doc with the provided content.
+// Note that this endpoint will continue to work for content created by
+// users on the older version of Paper. To check which version of Paper a
+// user is on, use /users/features/get_values. If the paper_as_files feature
+// is enabled, then the user is running the new version of Paper. This
+// endpoint will be retired in September 2020. Refer to the `Paper Migration
+// Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for more information.
+// Deprecated:
+func (dbx *apiImpl) DocsUpdateContext(ctx context.Context, arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
 	log.Printf("WARNING: API `DocsUpdate` is deprecated")
 
 	req := dropbox.Request{
@@ -719,11 +1098,11 @@ func (dbx *apiImpl) DocsUpdate(arg *PaperDocUpdateArgs, content io.Reader) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, content)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, content)
 	if err != nil {
 		var appErr DocsUpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -738,13 +1117,28 @@ func (dbx *apiImpl) DocsUpdate(arg *PaperDocUpdateArgs, content io.Reader) (res 
 	return
 }
 
+func (dbx *apiImpl) DocsUpdate(arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
+	return dbx.DocsUpdateContext(context.Background(), arg, content)
+}
+
 // DocsUsersAddAPIError is an error-wrapper for the docs/users/add route
 type DocsUsersAddAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
+// DocsUsersAddContext : Allows an owner or editor to add users to a Paper doc or
+// change their permissions using their email address or Dropbox account ID.
+// The doc owner's permissions cannot be changed. Note that this endpoint
+// will continue to work for content created by users on the older version
+// of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsUsersAddContext(ctx context.Context, arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
 	log.Printf("WARNING: API `DocsUsersAdd` is deprecated")
 
 	req := dropbox.Request{
@@ -759,11 +1153,11 @@ func (dbx *apiImpl) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsUsersAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -778,13 +1172,29 @@ func (dbx *apiImpl) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMe
 	return
 }
 
+func (dbx *apiImpl) DocsUsersAdd(arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
+	return dbx.DocsUsersAddContext(context.Background(), arg)
+}
+
 // DocsUsersListAPIError is an error-wrapper for the docs/users/list route
 type DocsUsersListAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
+// DocsUsersListContext : Lists all users who visited the Paper doc or users with
+// explicit access. This call excludes users who have been removed. The list
+// is sorted by the date of the visit or the share date. The list will
+// include both users, the explicitly shared ones as well as those who came
+// in using the Paper url link. Note that this endpoint will continue to
+// work for content created by users on the older version of Paper. To check
+// which version of Paper a user is on, use /users/features/get_values. If
+// the paper_as_files feature is enabled, then the user is running the new
+// version of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsUsersListContext(ctx context.Context, arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	log.Printf("WARNING: API `DocsUsersList` is deprecated")
 
 	req := dropbox.Request{
@@ -799,11 +1209,11 @@ func (dbx *apiImpl) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersO
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsUsersListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -818,13 +1228,27 @@ func (dbx *apiImpl) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersO
 	return
 }
 
+func (dbx *apiImpl) DocsUsersList(arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
+	return dbx.DocsUsersListContext(context.Background(), arg)
+}
+
 // DocsUsersListContinueAPIError is an error-wrapper for the docs/users/list/continue route
 type DocsUsersListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListUsersCursorError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
+// DocsUsersListContinueContext : Once a cursor has been retrieved from
+// `docsUsersList`, use this to paginate through all users on the Paper doc.
+// Note that this endpoint will continue to work for content created by
+// users on the older version of Paper. To check which version of Paper a
+// user is on, use /users/features/get_values. If the paper_as_files feature
+// is enabled, then the user is running the new version of Paper. Refer to
+// the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsUsersListContinueContext(ctx context.Context, arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	log.Printf("WARNING: API `DocsUsersListContinue` is deprecated")
 
 	req := dropbox.Request{
@@ -839,11 +1263,11 @@ func (dbx *apiImpl) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsUsersListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -858,13 +1282,27 @@ func (dbx *apiImpl) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) 
 	return
 }
 
+func (dbx *apiImpl) DocsUsersListContinue(arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
+	return dbx.DocsUsersListContinueContext(context.Background(), arg)
+}
+
 // DocsUsersRemoveAPIError is an error-wrapper for the docs/users/remove route
 type DocsUsersRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *DocLookupError `json:"error"`
 }
 
-func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
+// DocsUsersRemoveContext : Allows an owner or editor to remove users from a Paper
+// doc using their email address or Dropbox account ID. The doc owner cannot
+// be removed. Note that this endpoint will continue to work for content
+// created by users on the older version of Paper. To check which version of
+// Paper a user is on, use /users/features/get_values. If the paper_as_files
+// feature is enabled, then the user is running the new version of Paper.
+// Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) DocsUsersRemoveContext(ctx context.Context, arg *RemovePaperDocUser) (err error) {
 	log.Printf("WARNING: API `DocsUsersRemove` is deprecated")
 
 	req := dropbox.Request{
@@ -879,11 +1317,11 @@ func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DocsUsersRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -894,13 +1332,26 @@ func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
 	return
 }
 
+func (dbx *apiImpl) DocsUsersRemove(arg *RemovePaperDocUser) (err error) {
+	return dbx.DocsUsersRemoveContext(context.Background(), arg)
+}
+
 // FoldersCreateAPIError is an error-wrapper for the folders/create route
 type FoldersCreateAPIError struct {
 	dropbox.APIError
 	EndpointError *PaperFolderCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) FoldersCreate(arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error) {
+// FoldersCreateContext : Create a new Paper folder with the provided info. Note
+// that this endpoint will continue to work for content created by users on
+// the older version of Paper. To check which version of Paper a user is on,
+// use /users/features/get_values. If the paper_as_files feature is enabled,
+// then the user is running the new version of Paper. Refer to the `Paper
+// Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+// for migration information.
+// Deprecated:
+func (dbx *apiImpl) FoldersCreateContext(ctx context.Context, arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error) {
 	log.Printf("WARNING: API `FoldersCreate` is deprecated")
 
 	req := dropbox.Request{
@@ -915,11 +1366,11 @@ func (dbx *apiImpl) FoldersCreate(arg *PaperFolderCreateArg) (res *PaperFolderCr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr FoldersCreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -934,8 +1385,17 @@ func (dbx *apiImpl) FoldersCreate(arg *PaperFolderCreateArg) (res *PaperFolderCr
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) FoldersCreate(arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error) {
+	return dbx.FoldersCreateContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/riviera/client.go
+++ b/v6/dropbox/riviera/client.go
@@ -21,7 +21,9 @@
 package riviera
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -45,6 +47,23 @@ type Client interface {
 	GetTranscriptAsyncCheck(arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// GetMarkdownAsyncContext : Asynchronous document-to-markdown conversion for
+	// supported file formats.
+	GetMarkdownAsyncContext(ctx context.Context, arg *GetMarkdownArgs) (res *async.LaunchResultBase, err error)
+	// GetMarkdownAsyncCheckContext : Returns the status or result of specified
+	// get_markdown_async task.
+	GetMarkdownAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error)
+	// GetTranscriptAsyncContext : Asynchronous transcript generation for audio and
+	// video files.
+	GetTranscriptAsyncContext(ctx context.Context, arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error)
+	// GetTranscriptAsyncCheckContext : Returns the status or result of specified
+	// get_transcript_async task.
+	GetTranscriptAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // GetMarkdownAsyncAPIError is an error-wrapper for the get_markdown_async route
@@ -53,7 +72,9 @@ type GetMarkdownAsyncAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetMarkdownAsync(arg *GetMarkdownArgs) (res *async.LaunchResultBase, err error) {
+// GetMarkdownAsyncContext : Asynchronous document-to-markdown conversion for
+// supported file formats.
+func (dbx *apiImpl) GetMarkdownAsyncContext(ctx context.Context, arg *GetMarkdownArgs) (res *async.LaunchResultBase, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "riviera",
@@ -66,11 +87,11 @@ func (dbx *apiImpl) GetMarkdownAsync(arg *GetMarkdownArgs) (res *async.LaunchRes
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetMarkdownAsyncAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -85,13 +106,19 @@ func (dbx *apiImpl) GetMarkdownAsync(arg *GetMarkdownArgs) (res *async.LaunchRes
 	return
 }
 
+func (dbx *apiImpl) GetMarkdownAsync(arg *GetMarkdownArgs) (res *async.LaunchResultBase, err error) {
+	return dbx.GetMarkdownAsyncContext(context.Background(), arg)
+}
+
 // GetMarkdownAsyncCheckAPIError is an error-wrapper for the get_markdown_async/check route
 type GetMarkdownAsyncCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error) {
+// GetMarkdownAsyncCheckContext : Returns the status or result of specified
+// get_markdown_async task.
+func (dbx *apiImpl) GetMarkdownAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "riviera",
@@ -104,11 +131,11 @@ func (dbx *apiImpl) GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetMarkdownAsyncCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -123,13 +150,19 @@ func (dbx *apiImpl) GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownA
 	return
 }
 
+func (dbx *apiImpl) GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error) {
+	return dbx.GetMarkdownAsyncCheckContext(context.Background(), arg)
+}
+
 // GetTranscriptAsyncAPIError is an error-wrapper for the get_transcript_async route
 type GetTranscriptAsyncAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetTranscriptAsync(arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error) {
+// GetTranscriptAsyncContext : Asynchronous transcript generation for audio and
+// video files.
+func (dbx *apiImpl) GetTranscriptAsyncContext(ctx context.Context, arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "riviera",
@@ -142,11 +175,11 @@ func (dbx *apiImpl) GetTranscriptAsync(arg *GetTranscriptArgs) (res *async.Launc
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetTranscriptAsyncAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -161,13 +194,19 @@ func (dbx *apiImpl) GetTranscriptAsync(arg *GetTranscriptArgs) (res *async.Launc
 	return
 }
 
+func (dbx *apiImpl) GetTranscriptAsync(arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error) {
+	return dbx.GetTranscriptAsyncContext(context.Background(), arg)
+}
+
 // GetTranscriptAsyncCheckAPIError is an error-wrapper for the get_transcript_async/check route
 type GetTranscriptAsyncCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) GetTranscriptAsyncCheck(arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error) {
+// GetTranscriptAsyncCheckContext : Returns the status or result of specified
+// get_transcript_async task.
+func (dbx *apiImpl) GetTranscriptAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "riviera",
@@ -180,11 +219,11 @@ func (dbx *apiImpl) GetTranscriptAsyncCheck(arg *async.PollArg) (res *GetTranscr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetTranscriptAsyncCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -199,8 +238,17 @@ func (dbx *apiImpl) GetTranscriptAsyncCheck(arg *async.PollArg) (res *GetTranscr
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) GetTranscriptAsyncCheck(arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error) {
+	return dbx.GetTranscriptAsyncCheckContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -166,9 +166,15 @@ type Request struct {
 	ExtraHeaders map[string]string
 }
 
+// Execute executes a Dropbox API request with a background context.
 func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
+	return c.ExecuteContext(context.Background(), req, body)
+}
+
+// ExecuteContext executes a Dropbox API request with the provided context.
+func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
 	url := c.URLGenerator(req.Host, req.Namespace, req.Route)
-	httpReq, err := http.NewRequest("POST", url, body)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/v6/dropbox/sdk_test.go
+++ b/v6/dropbox/sdk_test.go
@@ -21,6 +21,7 @@
 package dropbox_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,6 +36,32 @@ import (
 
 func generateURL(base string, namespace string, route string) string {
 	return fmt.Sprintf("%s/%s/%s", base, namespace, route)
+}
+
+type legacyUsersClient struct{}
+
+var _ users.Client = legacyUsersClient{}
+var _ func(dropbox.Config) users.Client = users.New
+var _ func(dropbox.Config) users.ContextClient = users.NewContext
+
+func (legacyUsersClient) FeaturesGetValues(arg *users.UserFeaturesGetValuesBatchArg) (*users.UserFeaturesGetValuesBatchResult, error) {
+	return nil, nil
+}
+
+func (legacyUsersClient) GetAccount(arg *users.GetAccountArg) (*users.BasicAccount, error) {
+	return nil, nil
+}
+
+func (legacyUsersClient) GetAccountBatch(arg *users.GetAccountBatchArg) ([]*users.BasicAccount, error) {
+	return nil, nil
+}
+
+func (legacyUsersClient) GetCurrentAccount() (*users.FullAccount, error) {
+	return nil, nil
+}
+
+func (legacyUsersClient) GetSpaceUsage() (*users.SpaceUsage, error) {
+	return nil, nil
 }
 
 func TestInternalError(t *testing.T) {
@@ -219,5 +246,60 @@ func TestHTTPHeaderSafeJSON(t *testing.T) {
 				t.Errorf("Want %q got %q", test.want, got)
 			}
 		})
+	}
+}
+
+func TestExecuteBackwardCompatibility(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resp) != "{}" {
+		t.Errorf("unexpected response: %s", string(resp))
+	}
+	if respBody != nil {
+		t.Errorf("unexpected response body: %v", respBody)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	client := users.NewContext(config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetCurrentAccountContext(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected context canceled error, got: %v", err)
 	}
 }

--- a/v6/dropbox/sharing/client.go
+++ b/v6/dropbox/sharing/client.go
@@ -21,7 +21,9 @@
 package sharing
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 
@@ -212,6 +214,189 @@ type Client interface {
 	UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// AddFileMemberContext : Adds specified members to a file.
+	AddFileMemberContext(ctx context.Context, arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error)
+	// AddFolderMemberContext : Allows an owner or editor (if the ACL update policy
+	// allows) of a shared folder to add another member. For the new member to
+	// get access to all the functionality for this folder, you will need to
+	// call `mountFolder` on their behalf.
+	AddFolderMemberContext(ctx context.Context, arg *AddFolderMemberArg) (err error)
+	// CheckJobStatusContext : Returns the status of an asynchronous job.
+	CheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *JobStatus, err error)
+	// CheckRemoveMemberJobStatusContext : Returns the status of an asynchronous job
+	// for sharing a folder.
+	CheckRemoveMemberJobStatusContext(ctx context.Context, arg *async.PollArg) (res *RemoveMemberJobStatus, err error)
+	// CheckShareJobStatusContext : Returns the status of an asynchronous job for
+	// sharing a folder.
+	CheckShareJobStatusContext(ctx context.Context, arg *async.PollArg) (res *ShareFolderJobStatus, err error)
+	// CreateSharedLinkContext : Create a shared link. If a shared link already exists
+	// for the given path, that link is returned. Previously, it was technically
+	// possible to break a shared link by moving or renaming the corresponding
+	// file or folder. In the future, this will no longer be the case, so your
+	// app shouldn't rely on this behavior. Instead, if your app needs to revoke
+	// a shared link, use revoke_shared_link. DEPRECATED: Use
+	// create_shared_link_with_settings instead.
+	// Deprecated:
+	CreateSharedLinkContext(ctx context.Context, arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error)
+	// CreateSharedLinkWithSettingsContext : Create a shared link with custom settings.
+	// If no settings are given then the default visibility is
+	// RequestedVisibility.public (The resolved visibility, though, may depend
+	// on other aspects such as team and shared folder settings).
+	CreateSharedLinkWithSettingsContext(ctx context.Context, arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error)
+	// GetFileMetadataContext : Returns shared file metadata.
+	GetFileMetadataContext(ctx context.Context, arg *GetFileMetadataArg) (res *SharedFileMetadata, err error)
+	// GetFileMetadataBatchContext : Returns shared file metadata.
+	GetFileMetadataBatchContext(ctx context.Context, arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error)
+	// GetFolderMetadataContext : Returns shared folder metadata by its folder ID.
+	GetFolderMetadataContext(ctx context.Context, arg *GetMetadataArgs) (res *SharedFolderMetadata, err error)
+	// GetSharedLinkFileContext : Download the shared link's file from a user's
+	// Dropbox. This is a download-style endpoint that returns the file content.
+	GetSharedLinkFileContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error)
+	// GetSharedLinkMetadataContext : Get the shared link's metadata.
+	GetSharedLinkMetadataContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error)
+	// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This endpoint
+	// will be retired in October 2026. Returns a list of `LinkMetadata` objects
+	// for this user, including collection links. If no path is given, returns a
+	// list of all shared links for the current user, including collection
+	// links, up to a maximum of 1000 links. If a non-empty path is given,
+	// returns a list of all shared links that allow access to the given path.
+	// Collection links are never returned in this case.
+	// Deprecated:
+	GetSharedLinksContext(ctx context.Context, arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error)
+	// ListFileMembersContext : Use to obtain the members who have been invited to a
+	// file, both inherited and uninherited members.
+	ListFileMembersContext(ctx context.Context, arg *ListFileMembersArg) (res *SharedFileMembers, err error)
+	// ListFileMembersBatchContext : Get members of multiple files at once. The
+	// arguments to this route are more limited, and the limit on query result
+	// size per file is more strict. To customize the results more, use the
+	// individual file endpoint. Inherited users and groups are not included in
+	// the result, and permissions are not returned for this endpoint.
+	ListFileMembersBatchContext(ctx context.Context, arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error)
+	// ListFileMembersContinueContext : Once a cursor has been retrieved from
+	// `listFileMembers` or `listFileMembersBatch`, use this to paginate through
+	// all shared file members.
+	ListFileMembersContinueContext(ctx context.Context, arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error)
+	// ListFolderMembersContext : Returns shared folder membership by its folder ID.
+	ListFolderMembersContext(ctx context.Context, arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error)
+	// ListFolderMembersContinueContext : Once a cursor has been retrieved from
+	// `listFolderMembers`, use this to paginate through all shared folder
+	// members.
+	ListFolderMembersContinueContext(ctx context.Context, arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error)
+	// ListFoldersContext : Return the list of all shared folders the current user has
+	// access to.
+	ListFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error)
+	// ListFoldersContinueContext : Once a cursor has been retrieved from
+	// `listFolders`, use this to paginate through all shared folders. The
+	// cursor must come from a previous call to `listFolders` or
+	// `listFoldersContinue`.
+	ListFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error)
+	// ListMountableFoldersContext : Return the list of all shared folders the current
+	// user can mount or unmount.
+	ListMountableFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error)
+	// ListMountableFoldersContinueContext : Once a cursor has been retrieved from
+	// `listMountableFolders`, use this to paginate through all mountable shared
+	// folders. The cursor must come from a previous call to
+	// `listMountableFolders` or `listMountableFoldersContinue`.
+	ListMountableFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error)
+	// ListReceivedFilesContext : Returns a list of all files shared with current user.
+	ListReceivedFilesContext(ctx context.Context, arg *ListFilesArg) (res *ListFilesResult, err error)
+	// ListReceivedFilesContinueContext : Get more results with a cursor from
+	// `listReceivedFiles`.
+	ListReceivedFilesContinueContext(ctx context.Context, arg *ListFilesContinueArg) (res *ListFilesResult, err error)
+	// ListSharedLinksContext : List shared links of this user. If no path is given,
+	// returns a list of all shared links for the current user. For members of
+	// business teams using team space and member folders, returns all shared
+	// links in the team member's home folder unless the team space ID is
+	// specified in the request header. If a non-empty path is given, returns a
+	// list of all shared links that allow access to the given path - direct
+	// links to the given path and links to parent folders of the given path.
+	// Links to parent folders can be suppressed by setting direct_only to true.
+	ListSharedLinksContext(ctx context.Context, arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error)
+	// ModifySharedLinkSettingsContext : Modify the shared link's settings. If the
+	// requested visibility conflict with the shared links policy of the team or
+	// the shared folder (in case the linked file is part of a shared folder)
+	// then the LinkPermissions.resolved_visibility of the returned
+	// SharedLinkMetadata will reflect the actual visibility of the shared link
+	// and the LinkPermissions.requested_visibility will reflect the requested
+	// visibility.
+	ModifySharedLinkSettingsContext(ctx context.Context, arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error)
+	// MountFolderContext : The current user mounts the designated folder. Mount a
+	// shared folder for a user after they have been added as a member. Once
+	// mounted, the shared folder will appear in their Dropbox.
+	MountFolderContext(ctx context.Context, arg *MountFolderArg) (res *SharedFolderMetadata, err error)
+	// RelinquishAccessContext : Removes all self-removable access from a file or
+	// folder for the current user. Best-effort and idempotent: attempts to drop
+	// link-visitor associations and explicit ACL membership.
+	RelinquishAccessContext(ctx context.Context, arg *RelinquishAccessArg) (res *RelinquishAccessResult, err error)
+	// RelinquishFileMembershipContext : The current user relinquishes their membership
+	// in the designated file.
+	RelinquishFileMembershipContext(ctx context.Context, arg *RelinquishFileMembershipArg) (err error)
+	// RelinquishFolderMembershipContext : The current user relinquishes their
+	// membership in the designated shared folder and will no longer have access
+	// to the folder.  A folder owner cannot relinquish membership in their own
+	// folder. This will run synchronously if leave_a_copy is false, and
+	// asynchronously if leave_a_copy is true.
+	RelinquishFolderMembershipContext(ctx context.Context, arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error)
+	// RemoveFileMemberContext : Identical to remove_file_member_2 but with less
+	// information returned.
+	// Deprecated:
+	RemoveFileMemberContext(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error)
+	// RemoveFileMember2Context : Removes a specified member from the file.
+	RemoveFileMember2Context(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error)
+	// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update policy
+	// allows) of a shared folder to remove another member.
+	RemoveFolderMemberContext(ctx context.Context, arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error)
+	// RevokeSharedLinkContext : Revoke a shared link. Note that even after revoking a
+	// shared link to a file, the file may be accessible if there are shared
+	// links leading to any of the file parent folders. To list all shared links
+	// that enable access to a specific file, you can use the list_shared_links
+	// with the file as the ListSharedLinksArg.path argument.
+	RevokeSharedLinkContext(ctx context.Context, arg *RevokeSharedLinkArg) (err error)
+	// SetAccessInheritanceContext : Change the inheritance policy of an existing
+	// Shared Folder. Only permitted for shared folders in a shared team root.
+	// If a `ShareFolderLaunch.async_job_id` is returned, you'll need to call
+	// `checkShareJobStatus` until the action completes to get the metadata for
+	// the folder.
+	SetAccessInheritanceContext(ctx context.Context, arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error)
+	// ShareFolderContext : Share a folder with collaborators. Most sharing will be
+	// completed synchronously. Large folders will be completed asynchronously.
+	// To make testing the async case repeatable, set
+	// `ShareFolderArg.force_async`. If a `ShareFolderLaunch.async_job_id` is
+	// returned, you'll need to call `checkShareJobStatus` until the action
+	// completes to get the metadata for the folder.
+	ShareFolderContext(ctx context.Context, arg *ShareFolderArg) (res *ShareFolderLaunch, err error)
+	// TransferFolderContext : Transfer ownership of a shared folder to a member of the
+	// shared folder. User must have `AccessLevel.owner` access to the shared
+	// folder to perform a transfer.
+	TransferFolderContext(ctx context.Context, arg *TransferFolderArg) (err error)
+	// UnmountFolderContext : The current user unmounts the designated folder. They can
+	// re-mount the folder at a later time using `mountFolder`.
+	UnmountFolderContext(ctx context.Context, arg *UnmountFolderArg) (err error)
+	// UnshareFileContext : Remove all members from this file. Does not remove
+	// inherited members.
+	UnshareFileContext(ctx context.Context, arg *UnshareFileArg) (err error)
+	// UnshareFolderContext : Allows a shared folder owner to unshare the folder.
+	// Unshare will not work in following cases: The shared folder contains
+	// shared folders OR the shared folder is inside another shared folder.
+	// You'll need to call `checkJobStatus` to determine if the action has
+	// completed successfully.
+	UnshareFolderContext(ctx context.Context, arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error)
+	// UpdateFileMemberContext : Changes a member's access on a shared file.
+	UpdateFileMemberContext(ctx context.Context, arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error)
+	// UpdateFilePolicyContext : Update the viewer info policy of a file.
+	UpdateFilePolicyContext(ctx context.Context, arg *UpdateFilePolicyArg) (res *SharedFileMetadata, err error)
+	// UpdateFolderMemberContext : Allows an owner or editor of a shared folder to
+	// update another member's permissions.
+	UpdateFolderMemberContext(ctx context.Context, arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error)
+	// UpdateFolderPolicyContext : Update the sharing policies for a shared folder.
+	// User must have `AccessLevel.owner` access to the shared folder to update
+	// its policies.
+	UpdateFolderPolicyContext(ctx context.Context, arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error)
+}
+
 type apiImpl dropbox.Context
 
 // AddFileMemberAPIError is an error-wrapper for the add_file_member route
@@ -220,7 +405,8 @@ type AddFileMemberAPIError struct {
 	EndpointError *AddFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error) {
+// AddFileMemberContext : Adds specified members to a file.
+func (dbx *apiImpl) AddFileMemberContext(ctx context.Context, arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -233,11 +419,11 @@ func (dbx *apiImpl) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActi
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr AddFileMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -252,13 +438,21 @@ func (dbx *apiImpl) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActi
 	return
 }
 
+func (dbx *apiImpl) AddFileMember(arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error) {
+	return dbx.AddFileMemberContext(context.Background(), arg)
+}
+
 // AddFolderMemberAPIError is an error-wrapper for the add_folder_member route
 type AddFolderMemberAPIError struct {
 	dropbox.APIError
 	EndpointError *AddFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) AddFolderMember(arg *AddFolderMemberArg) (err error) {
+// AddFolderMemberContext : Allows an owner or editor (if the ACL update policy
+// allows) of a shared folder to add another member. For the new member to
+// get access to all the functionality for this folder, you will need to
+// call `mountFolder` on their behalf.
+func (dbx *apiImpl) AddFolderMemberContext(ctx context.Context, arg *AddFolderMemberArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -271,11 +465,11 @@ func (dbx *apiImpl) AddFolderMember(arg *AddFolderMemberArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr AddFolderMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -286,13 +480,18 @@ func (dbx *apiImpl) AddFolderMember(arg *AddFolderMemberArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) AddFolderMember(arg *AddFolderMemberArg) (err error) {
+	return dbx.AddFolderMemberContext(context.Background(), arg)
+}
+
 // CheckJobStatusAPIError is an error-wrapper for the check_job_status route
 type CheckJobStatusAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err error) {
+// CheckJobStatusContext : Returns the status of an asynchronous job.
+func (dbx *apiImpl) CheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *JobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -305,11 +504,11 @@ func (dbx *apiImpl) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err erro
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CheckJobStatusAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -324,13 +523,19 @@ func (dbx *apiImpl) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err erro
 	return
 }
 
+func (dbx *apiImpl) CheckJobStatus(arg *async.PollArg) (res *JobStatus, err error) {
+	return dbx.CheckJobStatusContext(context.Background(), arg)
+}
+
 // CheckRemoveMemberJobStatusAPIError is an error-wrapper for the check_remove_member_job_status route
 type CheckRemoveMemberJobStatusAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveMemberJobStatus, err error) {
+// CheckRemoveMemberJobStatusContext : Returns the status of an asynchronous job
+// for sharing a folder.
+func (dbx *apiImpl) CheckRemoveMemberJobStatusContext(ctx context.Context, arg *async.PollArg) (res *RemoveMemberJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -343,11 +548,11 @@ func (dbx *apiImpl) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveM
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CheckRemoveMemberJobStatusAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -362,13 +567,19 @@ func (dbx *apiImpl) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveM
 	return
 }
 
+func (dbx *apiImpl) CheckRemoveMemberJobStatus(arg *async.PollArg) (res *RemoveMemberJobStatus, err error) {
+	return dbx.CheckRemoveMemberJobStatusContext(context.Background(), arg)
+}
+
 // CheckShareJobStatusAPIError is an error-wrapper for the check_share_job_status route
 type CheckShareJobStatusAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJobStatus, err error) {
+// CheckShareJobStatusContext : Returns the status of an asynchronous job for
+// sharing a folder.
+func (dbx *apiImpl) CheckShareJobStatusContext(ctx context.Context, arg *async.PollArg) (res *ShareFolderJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -381,11 +592,11 @@ func (dbx *apiImpl) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJob
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CheckShareJobStatusAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -400,13 +611,25 @@ func (dbx *apiImpl) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJob
 	return
 }
 
+func (dbx *apiImpl) CheckShareJobStatus(arg *async.PollArg) (res *ShareFolderJobStatus, err error) {
+	return dbx.CheckShareJobStatusContext(context.Background(), arg)
+}
+
 // CreateSharedLinkAPIError is an error-wrapper for the create_shared_link route
 type CreateSharedLinkAPIError struct {
 	dropbox.APIError
 	EndpointError *CreateSharedLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
+// CreateSharedLinkContext : Create a shared link. If a shared link already exists
+// for the given path, that link is returned. Previously, it was technically
+// possible to break a shared link by moving or renaming the corresponding
+// file or folder. In the future, this will no longer be the case, so your
+// app shouldn't rely on this behavior. Instead, if your app needs to revoke
+// a shared link, use revoke_shared_link. DEPRECATED: Use
+// create_shared_link_with_settings instead.
+// Deprecated:
+func (dbx *apiImpl) CreateSharedLinkContext(ctx context.Context, arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
 	log.Printf("WARNING: API `CreateSharedLink` is deprecated")
 
 	req := dropbox.Request{
@@ -421,11 +644,11 @@ func (dbx *apiImpl) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMet
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateSharedLinkAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -440,13 +663,21 @@ func (dbx *apiImpl) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMet
 	return
 }
 
+func (dbx *apiImpl) CreateSharedLink(arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
+	return dbx.CreateSharedLinkContext(context.Background(), arg)
+}
+
 // CreateSharedLinkWithSettingsAPIError is an error-wrapper for the create_shared_link_with_settings route
 type CreateSharedLinkWithSettingsAPIError struct {
 	dropbox.APIError
 	EndpointError *CreateSharedLinkWithSettingsError `json:"error"`
 }
 
-func (dbx *apiImpl) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
+// CreateSharedLinkWithSettingsContext : Create a shared link with custom settings.
+// If no settings are given then the default visibility is
+// RequestedVisibility.public (The resolved visibility, though, may depend
+// on other aspects such as team and shared folder settings).
+func (dbx *apiImpl) CreateSharedLinkWithSettingsContext(ctx context.Context, arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -459,11 +690,11 @@ func (dbx *apiImpl) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettin
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr CreateSharedLinkWithSettingsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -486,13 +717,18 @@ func (dbx *apiImpl) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettin
 	return
 }
 
+func (dbx *apiImpl) CreateSharedLinkWithSettings(arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
+	return dbx.CreateSharedLinkWithSettingsContext(context.Background(), arg)
+}
+
 // GetFileMetadataAPIError is an error-wrapper for the get_file_metadata route
 type GetFileMetadataAPIError struct {
 	dropbox.APIError
 	EndpointError *GetFileMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMetadata, err error) {
+// GetFileMetadataContext : Returns shared file metadata.
+func (dbx *apiImpl) GetFileMetadataContext(ctx context.Context, arg *GetFileMetadataArg) (res *SharedFileMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -505,11 +741,11 @@ func (dbx *apiImpl) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMet
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetFileMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -524,13 +760,18 @@ func (dbx *apiImpl) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMet
 	return
 }
 
+func (dbx *apiImpl) GetFileMetadata(arg *GetFileMetadataArg) (res *SharedFileMetadata, err error) {
+	return dbx.GetFileMetadataContext(context.Background(), arg)
+}
+
 // GetFileMetadataBatchAPIError is an error-wrapper for the get_file_metadata/batch route
 type GetFileMetadataBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error) {
+// GetFileMetadataBatchContext : Returns shared file metadata.
+func (dbx *apiImpl) GetFileMetadataBatchContext(ctx context.Context, arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -543,11 +784,11 @@ func (dbx *apiImpl) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*G
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetFileMetadataBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -562,13 +803,18 @@ func (dbx *apiImpl) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*G
 	return
 }
 
+func (dbx *apiImpl) GetFileMetadataBatch(arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error) {
+	return dbx.GetFileMetadataBatchContext(context.Background(), arg)
+}
+
 // GetFolderMetadataAPIError is an error-wrapper for the get_folder_metadata route
 type GetFolderMetadataAPIError struct {
 	dropbox.APIError
 	EndpointError *SharedFolderAccessError `json:"error"`
 }
 
-func (dbx *apiImpl) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMetadata, err error) {
+// GetFolderMetadataContext : Returns shared folder metadata by its folder ID.
+func (dbx *apiImpl) GetFolderMetadataContext(ctx context.Context, arg *GetMetadataArgs) (res *SharedFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -581,11 +827,11 @@ func (dbx *apiImpl) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetFolderMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -600,13 +846,19 @@ func (dbx *apiImpl) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMe
 	return
 }
 
+func (dbx *apiImpl) GetFolderMetadata(arg *GetMetadataArgs) (res *SharedFolderMetadata, err error) {
+	return dbx.GetFolderMetadataContext(context.Background(), arg)
+}
+
 // GetSharedLinkFileAPIError is an error-wrapper for the get_shared_link_file route
 type GetSharedLinkFileAPIError struct {
 	dropbox.APIError
 	EndpointError *GetSharedLinkFileError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error) {
+// GetSharedLinkFileContext : Download the shared link's file from a user's
+// Dropbox. This is a download-style endpoint that returns the file content.
+func (dbx *apiImpl) GetSharedLinkFileContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "sharing",
@@ -619,11 +871,11 @@ func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsShar
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetSharedLinkFileAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -646,13 +898,18 @@ func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsShar
 	return
 }
 
+func (dbx *apiImpl) GetSharedLinkFile(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error) {
+	return dbx.GetSharedLinkFileContext(context.Background(), arg)
+}
+
 // GetSharedLinkMetadataAPIError is an error-wrapper for the get_shared_link_metadata route
 type GetSharedLinkMetadataAPIError struct {
 	dropbox.APIError
 	EndpointError *SharedLinkMetadataError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error) {
+// GetSharedLinkMetadataContext : Get the shared link's metadata.
+func (dbx *apiImpl) GetSharedLinkMetadataContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -665,11 +922,11 @@ func (dbx *apiImpl) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res Is
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetSharedLinkMetadataAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -692,13 +949,25 @@ func (dbx *apiImpl) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res Is
 	return
 }
 
+func (dbx *apiImpl) GetSharedLinkMetadata(arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error) {
+	return dbx.GetSharedLinkMetadataContext(context.Background(), arg)
+}
+
 // GetSharedLinksAPIError is an error-wrapper for the get_shared_links route
 type GetSharedLinksAPIError struct {
 	dropbox.APIError
 	EndpointError *GetSharedLinksError `json:"error"`
 }
 
-func (dbx *apiImpl) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
+// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This endpoint
+// will be retired in October 2026. Returns a list of `LinkMetadata` objects
+// for this user, including collection links. If no path is given, returns a
+// list of all shared links for the current user, including collection
+// links, up to a maximum of 1000 links. If a non-empty path is given,
+// returns a list of all shared links that allow access to the given path.
+// Collection links are never returned in this case.
+// Deprecated:
+func (dbx *apiImpl) GetSharedLinksContext(ctx context.Context, arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
 	log.Printf("WARNING: API `GetSharedLinks` is deprecated")
 
 	req := dropbox.Request{
@@ -713,11 +982,11 @@ func (dbx *apiImpl) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetSharedLinksAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -732,13 +1001,19 @@ func (dbx *apiImpl) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksR
 	return
 }
 
+func (dbx *apiImpl) GetSharedLinks(arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
+	return dbx.GetSharedLinksContext(context.Background(), arg)
+}
+
 // ListFileMembersAPIError is an error-wrapper for the list_file_members route
 type ListFileMembersAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFileMembersError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMembers, err error) {
+// ListFileMembersContext : Use to obtain the members who have been invited to a
+// file, both inherited and uninherited members.
+func (dbx *apiImpl) ListFileMembersContext(ctx context.Context, arg *ListFileMembersArg) (res *SharedFileMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -751,11 +1026,11 @@ func (dbx *apiImpl) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMem
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFileMembersAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -770,13 +1045,22 @@ func (dbx *apiImpl) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMem
 	return
 }
 
+func (dbx *apiImpl) ListFileMembers(arg *ListFileMembersArg) (res *SharedFileMembers, err error) {
+	return dbx.ListFileMembersContext(context.Background(), arg)
+}
+
 // ListFileMembersBatchAPIError is an error-wrapper for the list_file_members/batch route
 type ListFileMembersBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
+// ListFileMembersBatchContext : Get members of multiple files at once. The
+// arguments to this route are more limited, and the limit on query result
+// size per file is more strict. To customize the results more, use the
+// individual file endpoint. Inherited users and groups are not included in
+// the result, and permissions are not returned for this endpoint.
+func (dbx *apiImpl) ListFileMembersBatchContext(ctx context.Context, arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -789,11 +1073,11 @@ func (dbx *apiImpl) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*L
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFileMembersBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -808,13 +1092,20 @@ func (dbx *apiImpl) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*L
 	return
 }
 
+func (dbx *apiImpl) ListFileMembersBatch(arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
+	return dbx.ListFileMembersBatchContext(context.Background(), arg)
+}
+
 // ListFileMembersContinueAPIError is an error-wrapper for the list_file_members/continue route
 type ListFileMembersContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFileMembersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFileMembersContinue(arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
+// ListFileMembersContinueContext : Once a cursor has been retrieved from
+// `listFileMembers` or `listFileMembersBatch`, use this to paginate through
+// all shared file members.
+func (dbx *apiImpl) ListFileMembersContinueContext(ctx context.Context, arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -827,11 +1118,11 @@ func (dbx *apiImpl) ListFileMembersContinue(arg *ListFileMembersContinueArg) (re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFileMembersContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -846,13 +1137,18 @@ func (dbx *apiImpl) ListFileMembersContinue(arg *ListFileMembersContinueArg) (re
 	return
 }
 
+func (dbx *apiImpl) ListFileMembersContinue(arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
+	return dbx.ListFileMembersContinueContext(context.Background(), arg)
+}
+
 // ListFolderMembersAPIError is an error-wrapper for the list_folder_members route
 type ListFolderMembersAPIError struct {
 	dropbox.APIError
 	EndpointError *SharedFolderAccessError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error) {
+// ListFolderMembersContext : Returns shared folder membership by its folder ID.
+func (dbx *apiImpl) ListFolderMembersContext(ctx context.Context, arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -865,11 +1161,11 @@ func (dbx *apiImpl) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFo
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderMembersAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -884,13 +1180,20 @@ func (dbx *apiImpl) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFo
 	return
 }
 
+func (dbx *apiImpl) ListFolderMembers(arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error) {
+	return dbx.ListFolderMembersContext(context.Background(), arg)
+}
+
 // ListFolderMembersContinueAPIError is an error-wrapper for the list_folder_members/continue route
 type ListFolderMembersContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFolderMembersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolderMembersContinue(arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
+// ListFolderMembersContinueContext : Once a cursor has been retrieved from
+// `listFolderMembers`, use this to paginate through all shared folder
+// members.
+func (dbx *apiImpl) ListFolderMembersContinueContext(ctx context.Context, arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -903,11 +1206,11 @@ func (dbx *apiImpl) ListFolderMembersContinue(arg *ListFolderMembersContinueArg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFolderMembersContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -922,13 +1225,19 @@ func (dbx *apiImpl) ListFolderMembersContinue(arg *ListFolderMembersContinueArg)
 	return
 }
 
+func (dbx *apiImpl) ListFolderMembersContinue(arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
+	return dbx.ListFolderMembersContinueContext(context.Background(), arg)
+}
+
 // ListFoldersAPIError is an error-wrapper for the list_folders route
 type ListFoldersAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+// ListFoldersContext : Return the list of all shared folders the current user has
+// access to.
+func (dbx *apiImpl) ListFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -941,11 +1250,11 @@ func (dbx *apiImpl) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFoldersAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -960,13 +1269,21 @@ func (dbx *apiImpl) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, e
 	return
 }
 
+func (dbx *apiImpl) ListFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+	return dbx.ListFoldersContext(context.Background(), arg)
+}
+
 // ListFoldersContinueAPIError is an error-wrapper for the list_folders/continue route
 type ListFoldersContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFoldersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+// ListFoldersContinueContext : Once a cursor has been retrieved from
+// `listFolders`, use this to paginate through all shared folders. The
+// cursor must come from a previous call to `listFolders` or
+// `listFoldersContinue`.
+func (dbx *apiImpl) ListFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -979,11 +1296,11 @@ func (dbx *apiImpl) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListF
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListFoldersContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -998,13 +1315,19 @@ func (dbx *apiImpl) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListF
 	return
 }
 
+func (dbx *apiImpl) ListFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+	return dbx.ListFoldersContinueContext(context.Background(), arg)
+}
+
 // ListMountableFoldersAPIError is an error-wrapper for the list_mountable_folders route
 type ListMountableFoldersAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) ListMountableFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+// ListMountableFoldersContext : Return the list of all shared folders the current
+// user can mount or unmount.
+func (dbx *apiImpl) ListMountableFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1017,11 +1340,11 @@ func (dbx *apiImpl) ListMountableFolders(arg *ListFoldersArgs) (res *ListFolders
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListMountableFoldersAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1036,13 +1359,21 @@ func (dbx *apiImpl) ListMountableFolders(arg *ListFoldersArgs) (res *ListFolders
 	return
 }
 
+func (dbx *apiImpl) ListMountableFolders(arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
+	return dbx.ListMountableFoldersContext(context.Background(), arg)
+}
+
 // ListMountableFoldersContinueAPIError is an error-wrapper for the list_mountable_folders/continue route
 type ListMountableFoldersContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFoldersContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+// ListMountableFoldersContinueContext : Once a cursor has been retrieved from
+// `listMountableFolders`, use this to paginate through all mountable shared
+// folders. The cursor must come from a previous call to
+// `listMountableFolders` or `listMountableFoldersContinue`.
+func (dbx *apiImpl) ListMountableFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1055,11 +1386,11 @@ func (dbx *apiImpl) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (r
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListMountableFoldersContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1074,13 +1405,18 @@ func (dbx *apiImpl) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (r
 	return
 }
 
+func (dbx *apiImpl) ListMountableFoldersContinue(arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
+	return dbx.ListMountableFoldersContinueContext(context.Background(), arg)
+}
+
 // ListReceivedFilesAPIError is an error-wrapper for the list_received_files route
 type ListReceivedFilesAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingUserError `json:"error"`
 }
 
-func (dbx *apiImpl) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, err error) {
+// ListReceivedFilesContext : Returns a list of all files shared with current user.
+func (dbx *apiImpl) ListReceivedFilesContext(ctx context.Context, arg *ListFilesArg) (res *ListFilesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1093,11 +1429,11 @@ func (dbx *apiImpl) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListReceivedFilesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1112,13 +1448,19 @@ func (dbx *apiImpl) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, 
 	return
 }
 
+func (dbx *apiImpl) ListReceivedFiles(arg *ListFilesArg) (res *ListFilesResult, err error) {
+	return dbx.ListReceivedFilesContext(context.Background(), arg)
+}
+
 // ListReceivedFilesContinueAPIError is an error-wrapper for the list_received_files/continue route
 type ListReceivedFilesContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ListFilesContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *ListFilesResult, err error) {
+// ListReceivedFilesContinueContext : Get more results with a cursor from
+// `listReceivedFiles`.
+func (dbx *apiImpl) ListReceivedFilesContinueContext(ctx context.Context, arg *ListFilesContinueArg) (res *ListFilesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1131,11 +1473,11 @@ func (dbx *apiImpl) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *L
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListReceivedFilesContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1150,13 +1492,25 @@ func (dbx *apiImpl) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *L
 	return
 }
 
+func (dbx *apiImpl) ListReceivedFilesContinue(arg *ListFilesContinueArg) (res *ListFilesResult, err error) {
+	return dbx.ListReceivedFilesContinueContext(context.Background(), arg)
+}
+
 // ListSharedLinksAPIError is an error-wrapper for the list_shared_links route
 type ListSharedLinksAPIError struct {
 	dropbox.APIError
 	EndpointError *ListSharedLinksError `json:"error"`
 }
 
-func (dbx *apiImpl) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
+// ListSharedLinksContext : List shared links of this user. If no path is given,
+// returns a list of all shared links for the current user. For members of
+// business teams using team space and member folders, returns all shared
+// links in the team member's home folder unless the team space ID is
+// specified in the request header. If a non-empty path is given, returns a
+// list of all shared links that allow access to the given path - direct
+// links to the given path and links to parent folders of the given path.
+// Links to parent folders can be suppressed by setting direct_only to true.
+func (dbx *apiImpl) ListSharedLinksContext(ctx context.Context, arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1169,11 +1523,11 @@ func (dbx *apiImpl) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLin
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ListSharedLinksAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1188,13 +1542,24 @@ func (dbx *apiImpl) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLin
 	return
 }
 
+func (dbx *apiImpl) ListSharedLinks(arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
+	return dbx.ListSharedLinksContext(context.Background(), arg)
+}
+
 // ModifySharedLinkSettingsAPIError is an error-wrapper for the modify_shared_link_settings route
 type ModifySharedLinkSettingsAPIError struct {
 	dropbox.APIError
 	EndpointError *ModifySharedLinkSettingsError `json:"error"`
 }
 
-func (dbx *apiImpl) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
+// ModifySharedLinkSettingsContext : Modify the shared link's settings. If the
+// requested visibility conflict with the shared links policy of the team or
+// the shared folder (in case the linked file is part of a shared folder)
+// then the LinkPermissions.resolved_visibility of the returned
+// SharedLinkMetadata will reflect the actual visibility of the shared link
+// and the LinkPermissions.requested_visibility will reflect the requested
+// visibility.
+func (dbx *apiImpl) ModifySharedLinkSettingsContext(ctx context.Context, arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1207,11 +1572,11 @@ func (dbx *apiImpl) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ModifySharedLinkSettingsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1234,13 +1599,20 @@ func (dbx *apiImpl) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) 
 	return
 }
 
+func (dbx *apiImpl) ModifySharedLinkSettings(arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
+	return dbx.ModifySharedLinkSettingsContext(context.Background(), arg)
+}
+
 // MountFolderAPIError is an error-wrapper for the mount_folder route
 type MountFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *MountFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata, err error) {
+// MountFolderContext : The current user mounts the designated folder. Mount a
+// shared folder for a user after they have been added as a member. Once
+// mounted, the shared folder will appear in their Dropbox.
+func (dbx *apiImpl) MountFolderContext(ctx context.Context, arg *MountFolderArg) (res *SharedFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1253,11 +1625,11 @@ func (dbx *apiImpl) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata,
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MountFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1272,13 +1644,20 @@ func (dbx *apiImpl) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata,
 	return
 }
 
+func (dbx *apiImpl) MountFolder(arg *MountFolderArg) (res *SharedFolderMetadata, err error) {
+	return dbx.MountFolderContext(context.Background(), arg)
+}
+
 // RelinquishAccessAPIError is an error-wrapper for the relinquish_access route
 type RelinquishAccessAPIError struct {
 	dropbox.APIError
 	EndpointError *RelinquishAccessError `json:"error"`
 }
 
-func (dbx *apiImpl) RelinquishAccess(arg *RelinquishAccessArg) (res *RelinquishAccessResult, err error) {
+// RelinquishAccessContext : Removes all self-removable access from a file or
+// folder for the current user. Best-effort and idempotent: attempts to drop
+// link-visitor associations and explicit ACL membership.
+func (dbx *apiImpl) RelinquishAccessContext(ctx context.Context, arg *RelinquishAccessArg) (res *RelinquishAccessResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1291,11 +1670,11 @@ func (dbx *apiImpl) RelinquishAccess(arg *RelinquishAccessArg) (res *RelinquishA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RelinquishAccessAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1310,13 +1689,19 @@ func (dbx *apiImpl) RelinquishAccess(arg *RelinquishAccessArg) (res *RelinquishA
 	return
 }
 
+func (dbx *apiImpl) RelinquishAccess(arg *RelinquishAccessArg) (res *RelinquishAccessResult, err error) {
+	return dbx.RelinquishAccessContext(context.Background(), arg)
+}
+
 // RelinquishFileMembershipAPIError is an error-wrapper for the relinquish_file_membership route
 type RelinquishFileMembershipAPIError struct {
 	dropbox.APIError
 	EndpointError *RelinquishFileMembershipError `json:"error"`
 }
 
-func (dbx *apiImpl) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (err error) {
+// RelinquishFileMembershipContext : The current user relinquishes their membership
+// in the designated file.
+func (dbx *apiImpl) RelinquishFileMembershipContext(ctx context.Context, arg *RelinquishFileMembershipArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1329,11 +1714,11 @@ func (dbx *apiImpl) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RelinquishFileMembershipAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1344,13 +1729,22 @@ func (dbx *apiImpl) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (
 	return
 }
 
+func (dbx *apiImpl) RelinquishFileMembership(arg *RelinquishFileMembershipArg) (err error) {
+	return dbx.RelinquishFileMembershipContext(context.Background(), arg)
+}
+
 // RelinquishFolderMembershipAPIError is an error-wrapper for the relinquish_folder_membership route
 type RelinquishFolderMembershipAPIError struct {
 	dropbox.APIError
 	EndpointError *RelinquishFolderMembershipError `json:"error"`
 }
 
-func (dbx *apiImpl) RelinquishFolderMembership(arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
+// RelinquishFolderMembershipContext : The current user relinquishes their
+// membership in the designated shared folder and will no longer have access
+// to the folder.  A folder owner cannot relinquish membership in their own
+// folder. This will run synchronously if leave_a_copy is false, and
+// asynchronously if leave_a_copy is true.
+func (dbx *apiImpl) RelinquishFolderMembershipContext(ctx context.Context, arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1363,11 +1757,11 @@ func (dbx *apiImpl) RelinquishFolderMembership(arg *RelinquishFolderMembershipAr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RelinquishFolderMembershipAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1382,13 +1776,20 @@ func (dbx *apiImpl) RelinquishFolderMembership(arg *RelinquishFolderMembershipAr
 	return
 }
 
+func (dbx *apiImpl) RelinquishFolderMembership(arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
+	return dbx.RelinquishFolderMembershipContext(context.Background(), arg)
+}
+
 // RemoveFileMemberAPIError is an error-wrapper for the remove_file_member route
 type RemoveFileMemberAPIError struct {
 	dropbox.APIError
 	EndpointError *RemoveFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error) {
+// RemoveFileMemberContext : Identical to remove_file_member_2 but with less
+// information returned.
+// Deprecated:
+func (dbx *apiImpl) RemoveFileMemberContext(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error) {
 	log.Printf("WARNING: API `RemoveFileMember` is deprecated")
 
 	req := dropbox.Request{
@@ -1403,11 +1804,11 @@ func (dbx *apiImpl) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RemoveFileMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1422,13 +1823,18 @@ func (dbx *apiImpl) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberA
 	return
 }
 
+func (dbx *apiImpl) RemoveFileMember(arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error) {
+	return dbx.RemoveFileMemberContext(context.Background(), arg)
+}
+
 // RemoveFileMember2APIError is an error-wrapper for the remove_file_member_2 route
 type RemoveFileMember2APIError struct {
 	dropbox.APIError
 	EndpointError *RemoveFileMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error) {
+// RemoveFileMember2Context : Removes a specified member from the file.
+func (dbx *apiImpl) RemoveFileMember2Context(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1441,11 +1847,11 @@ func (dbx *apiImpl) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMember
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RemoveFileMember2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1460,13 +1866,19 @@ func (dbx *apiImpl) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMember
 	return
 }
 
+func (dbx *apiImpl) RemoveFileMember2(arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error) {
+	return dbx.RemoveFileMember2Context(context.Background(), arg)
+}
+
 // RemoveFolderMemberAPIError is an error-wrapper for the remove_folder_member route
 type RemoveFolderMemberAPIError struct {
 	dropbox.APIError
 	EndpointError *RemoveFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
+// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update policy
+// allows) of a shared folder to remove another member.
+func (dbx *apiImpl) RemoveFolderMemberContext(ctx context.Context, arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1479,11 +1891,11 @@ func (dbx *apiImpl) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.L
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RemoveFolderMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1498,13 +1910,22 @@ func (dbx *apiImpl) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.L
 	return
 }
 
+func (dbx *apiImpl) RemoveFolderMember(arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
+	return dbx.RemoveFolderMemberContext(context.Background(), arg)
+}
+
 // RevokeSharedLinkAPIError is an error-wrapper for the revoke_shared_link route
 type RevokeSharedLinkAPIError struct {
 	dropbox.APIError
 	EndpointError *RevokeSharedLinkError `json:"error"`
 }
 
-func (dbx *apiImpl) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
+// RevokeSharedLinkContext : Revoke a shared link. Note that even after revoking a
+// shared link to a file, the file may be accessible if there are shared
+// links leading to any of the file parent folders. To list all shared links
+// that enable access to a specific file, you can use the list_shared_links
+// with the file as the ListSharedLinksArg.path argument.
+func (dbx *apiImpl) RevokeSharedLinkContext(ctx context.Context, arg *RevokeSharedLinkArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1517,11 +1938,11 @@ func (dbx *apiImpl) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr RevokeSharedLinkAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1532,13 +1953,22 @@ func (dbx *apiImpl) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) RevokeSharedLink(arg *RevokeSharedLinkArg) (err error) {
+	return dbx.RevokeSharedLinkContext(context.Background(), arg)
+}
+
 // SetAccessInheritanceAPIError is an error-wrapper for the set_access_inheritance route
 type SetAccessInheritanceAPIError struct {
 	dropbox.APIError
 	EndpointError *SetAccessInheritanceError `json:"error"`
 }
 
-func (dbx *apiImpl) SetAccessInheritance(arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error) {
+// SetAccessInheritanceContext : Change the inheritance policy of an existing
+// Shared Folder. Only permitted for shared folders in a shared team root.
+// If a `ShareFolderLaunch.async_job_id` is returned, you'll need to call
+// `checkShareJobStatus` until the action completes to get the metadata for
+// the folder.
+func (dbx *apiImpl) SetAccessInheritanceContext(ctx context.Context, arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1551,11 +1981,11 @@ func (dbx *apiImpl) SetAccessInheritance(arg *SetAccessInheritanceArg) (res *Sha
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SetAccessInheritanceAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1570,13 +2000,23 @@ func (dbx *apiImpl) SetAccessInheritance(arg *SetAccessInheritanceArg) (res *Sha
 	return
 }
 
+func (dbx *apiImpl) SetAccessInheritance(arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error) {
+	return dbx.SetAccessInheritanceContext(context.Background(), arg)
+}
+
 // ShareFolderAPIError is an error-wrapper for the share_folder route
 type ShareFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *ShareFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
+// ShareFolderContext : Share a folder with collaborators. Most sharing will be
+// completed synchronously. Large folders will be completed asynchronously.
+// To make testing the async case repeatable, set
+// `ShareFolderArg.force_async`. If a `ShareFolderLaunch.async_job_id` is
+// returned, you'll need to call `checkShareJobStatus` until the action
+// completes to get the metadata for the folder.
+func (dbx *apiImpl) ShareFolderContext(ctx context.Context, arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1589,11 +2029,11 @@ func (dbx *apiImpl) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ShareFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1608,13 +2048,20 @@ func (dbx *apiImpl) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, er
 	return
 }
 
+func (dbx *apiImpl) ShareFolder(arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
+	return dbx.ShareFolderContext(context.Background(), arg)
+}
+
 // TransferFolderAPIError is an error-wrapper for the transfer_folder route
 type TransferFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *TransferFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) TransferFolder(arg *TransferFolderArg) (err error) {
+// TransferFolderContext : Transfer ownership of a shared folder to a member of the
+// shared folder. User must have `AccessLevel.owner` access to the shared
+// folder to perform a transfer.
+func (dbx *apiImpl) TransferFolderContext(ctx context.Context, arg *TransferFolderArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1627,11 +2074,11 @@ func (dbx *apiImpl) TransferFolder(arg *TransferFolderArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TransferFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1642,13 +2089,19 @@ func (dbx *apiImpl) TransferFolder(arg *TransferFolderArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) TransferFolder(arg *TransferFolderArg) (err error) {
+	return dbx.TransferFolderContext(context.Background(), arg)
+}
+
 // UnmountFolderAPIError is an error-wrapper for the unmount_folder route
 type UnmountFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *UnmountFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) UnmountFolder(arg *UnmountFolderArg) (err error) {
+// UnmountFolderContext : The current user unmounts the designated folder. They can
+// re-mount the folder at a later time using `mountFolder`.
+func (dbx *apiImpl) UnmountFolderContext(ctx context.Context, arg *UnmountFolderArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1661,11 +2114,11 @@ func (dbx *apiImpl) UnmountFolder(arg *UnmountFolderArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UnmountFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1676,13 +2129,19 @@ func (dbx *apiImpl) UnmountFolder(arg *UnmountFolderArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) UnmountFolder(arg *UnmountFolderArg) (err error) {
+	return dbx.UnmountFolderContext(context.Background(), arg)
+}
+
 // UnshareFileAPIError is an error-wrapper for the unshare_file route
 type UnshareFileAPIError struct {
 	dropbox.APIError
 	EndpointError *UnshareFileError `json:"error"`
 }
 
-func (dbx *apiImpl) UnshareFile(arg *UnshareFileArg) (err error) {
+// UnshareFileContext : Remove all members from this file. Does not remove
+// inherited members.
+func (dbx *apiImpl) UnshareFileContext(ctx context.Context, arg *UnshareFileArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1695,11 +2154,11 @@ func (dbx *apiImpl) UnshareFile(arg *UnshareFileArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UnshareFileAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1710,13 +2169,22 @@ func (dbx *apiImpl) UnshareFile(arg *UnshareFileArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) UnshareFile(arg *UnshareFileArg) (err error) {
+	return dbx.UnshareFileContext(context.Background(), arg)
+}
+
 // UnshareFolderAPIError is an error-wrapper for the unshare_folder route
 type UnshareFolderAPIError struct {
 	dropbox.APIError
 	EndpointError *UnshareFolderError `json:"error"`
 }
 
-func (dbx *apiImpl) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
+// UnshareFolderContext : Allows a shared folder owner to unshare the folder.
+// Unshare will not work in following cases: The shared folder contains
+// shared folders OR the shared folder is inside another shared folder.
+// You'll need to call `checkJobStatus` to determine if the action has
+// completed successfully.
+func (dbx *apiImpl) UnshareFolderContext(ctx context.Context, arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1729,11 +2197,11 @@ func (dbx *apiImpl) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmpty
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UnshareFolderAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1748,13 +2216,18 @@ func (dbx *apiImpl) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmpty
 	return
 }
 
+func (dbx *apiImpl) UnshareFolder(arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
+	return dbx.UnshareFolderContext(context.Background(), arg)
+}
+
 // UpdateFileMemberAPIError is an error-wrapper for the update_file_member route
 type UpdateFileMemberAPIError struct {
 	dropbox.APIError
 	EndpointError *FileMemberActionError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error) {
+// UpdateFileMemberContext : Changes a member's access on a shared file.
+func (dbx *apiImpl) UpdateFileMemberContext(ctx context.Context, arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1767,11 +2240,11 @@ func (dbx *apiImpl) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAcce
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UpdateFileMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1786,13 +2259,18 @@ func (dbx *apiImpl) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAcce
 	return
 }
 
+func (dbx *apiImpl) UpdateFileMember(arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error) {
+	return dbx.UpdateFileMemberContext(context.Background(), arg)
+}
+
 // UpdateFilePolicyAPIError is an error-wrapper for the update_file_policy route
 type UpdateFilePolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *UpdateFilePolicyError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFilePolicy(arg *UpdateFilePolicyArg) (res *SharedFileMetadata, err error) {
+// UpdateFilePolicyContext : Update the viewer info policy of a file.
+func (dbx *apiImpl) UpdateFilePolicyContext(ctx context.Context, arg *UpdateFilePolicyArg) (res *SharedFileMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1805,11 +2283,11 @@ func (dbx *apiImpl) UpdateFilePolicy(arg *UpdateFilePolicyArg) (res *SharedFileM
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UpdateFilePolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1824,13 +2302,19 @@ func (dbx *apiImpl) UpdateFilePolicy(arg *UpdateFilePolicyArg) (res *SharedFileM
 	return
 }
 
+func (dbx *apiImpl) UpdateFilePolicy(arg *UpdateFilePolicyArg) (res *SharedFileMetadata, err error) {
+	return dbx.UpdateFilePolicyContext(context.Background(), arg)
+}
+
 // UpdateFolderMemberAPIError is an error-wrapper for the update_folder_member route
 type UpdateFolderMemberAPIError struct {
 	dropbox.APIError
 	EndpointError *UpdateFolderMemberError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error) {
+// UpdateFolderMemberContext : Allows an owner or editor of a shared folder to
+// update another member's permissions.
+func (dbx *apiImpl) UpdateFolderMemberContext(ctx context.Context, arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1843,11 +2327,11 @@ func (dbx *apiImpl) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UpdateFolderMemberAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1862,13 +2346,20 @@ func (dbx *apiImpl) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberA
 	return
 }
 
+func (dbx *apiImpl) UpdateFolderMember(arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error) {
+	return dbx.UpdateFolderMemberContext(context.Background(), arg)
+}
+
 // UpdateFolderPolicyAPIError is an error-wrapper for the update_folder_policy route
 type UpdateFolderPolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *UpdateFolderPolicyError `json:"error"`
 }
 
-func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
+// UpdateFolderPolicyContext : Update the sharing policies for a shared folder.
+// User must have `AccessLevel.owner` access to the shared folder to update
+// its policies.
+func (dbx *apiImpl) UpdateFolderPolicyContext(ctx context.Context, arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "sharing",
@@ -1881,11 +2372,11 @@ func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedF
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr UpdateFolderPolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1900,8 +2391,17 @@ func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedF
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) UpdateFolderPolicy(arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
+	return dbx.UpdateFolderPolicyContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/team/client.go
+++ b/v6/dropbox/team/client.go
@@ -21,7 +21,9 @@
 package team
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 
@@ -429,6 +431,405 @@ type Client interface {
 	TokenGetAuthenticatedAdmin() (res *TokenGetAuthenticatedAdminResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// DevicesListMemberDevicesContext : List all device sessions of a team's member.
+	DevicesListMemberDevicesContext(ctx context.Context, arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error)
+	// DevicesListMembersDevicesContext : List all device sessions of a team.
+	// Permission : Team member file access.
+	DevicesListMembersDevicesContext(ctx context.Context, arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error)
+	// DevicesListTeamDevicesContext : List all device sessions of a team. Permission :
+	// Team member file access.
+	// Deprecated:
+	DevicesListTeamDevicesContext(ctx context.Context, arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error)
+	// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's member.
+	DevicesRevokeDeviceSessionContext(ctx context.Context, arg *RevokeDeviceSessionArg) (err error)
+	// DevicesRevokeDeviceSessionBatchContext : Revoke a list of device sessions of
+	// team members.
+	DevicesRevokeDeviceSessionBatchContext(ctx context.Context, arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error)
+	// FeaturesGetValuesContext : Get the values for one or more features. This route
+	// allows you to check your account's capability for what feature you can
+	// access or what value you have for certain features. Permission : Team
+	// information.
+	FeaturesGetValuesContext(ctx context.Context, arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error)
+	// GetInfoContext : Retrieves information about a team.
+	GetInfoContext(ctx context.Context) (res *TeamGetInfoResult, err error)
+	// GroupsCreateContext : Creates a new, empty group, with a requested name.
+	// Permission : Team member management.
+	GroupsCreateContext(ctx context.Context, arg *GroupCreateArg) (res *GroupFullInfo, err error)
+	// GroupsDeleteContext : Deletes a group. The group is deleted immediately. However
+	// the revoking of group-owned resources may take additional time. Use the
+	// `groupsJobStatusGet` to determine whether this process has completed.
+	// Permission : Team member management.
+	GroupsDeleteContext(ctx context.Context, arg *GroupSelector) (res *async.LaunchEmptyResult, err error)
+	// GroupsGetInfoContext : Retrieves information about one or more groups. Note that
+	// the optional field `GroupFullInfo.members` is not returned for
+	// system-managed groups. Permission : Team Information.
+	GroupsGetInfoContext(ctx context.Context, arg *GroupsSelector) (res []*GroupsGetInfoItem, err error)
+	// GroupsJobStatusGetContext : Once an async_job_id is returned from
+	// `groupsDelete`, `groupsMembersAdd` , or `groupsMembersRemove` use this
+	// method to poll the status of granting/revoking group members' access to
+	// group-owned resources. Permission : Team member management.
+	GroupsJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
+	// GroupsListContext : Lists groups on a team. Permission : Team Information.
+	GroupsListContext(ctx context.Context, arg *GroupsListArg) (res *GroupsListResult, err error)
+	// GroupsListContinueContext : Once a cursor has been retrieved from `groupsList`,
+	// use this to paginate through all groups. Permission : Team Information.
+	GroupsListContinueContext(ctx context.Context, arg *GroupsListContinueArg) (res *GroupsListResult, err error)
+	// GroupsMembersAddContext : Adds members to a group. The members are added
+	// immediately. However the granting of group-owned resources may take
+	// additional time. Use the `groupsJobStatusGet` to determine whether this
+	// process has completed. Permission : Team member management.
+	GroupsMembersAddContext(ctx context.Context, arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error)
+	// GroupsMembersListContext : Lists members of a group. Permission : Team
+	// Information.
+	GroupsMembersListContext(ctx context.Context, arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error)
+	// GroupsMembersListContinueContext : Once a cursor has been retrieved from
+	// `groupsMembersList`, use this to paginate through all members of the
+	// group. Permission : Team information.
+	GroupsMembersListContinueContext(ctx context.Context, arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error)
+	// GroupsMembersRemoveContext : Removes members from a group. The members are
+	// removed immediately. However the revoking of group-owned resources may
+	// take additional time. Use the `groupsJobStatusGet` to determine whether
+	// this process has completed. This method permits removing the only owner
+	// of a group, even in cases where this is not possible via the web client.
+	// Permission : Team member management.
+	GroupsMembersRemoveContext(ctx context.Context, arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error)
+	// GroupsMembersSetAccessTypeContext : Sets a member's access type in a group.
+	// Permission : Team member management.
+	GroupsMembersSetAccessTypeContext(ctx context.Context, arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error)
+	// GroupsUpdateContext : Updates a group's name and/or external ID. Permission :
+	// Team member management.
+	GroupsUpdateContext(ctx context.Context, arg *GroupUpdateArgs) (res *GroupFullInfo, err error)
+	// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note: Legal Holds
+	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// member file access.
+	LegalHoldsCreatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error)
+	// LegalHoldsGetPolicyContext : Gets a legal hold by Id. Note: Legal Holds is a
+	// paid add-on. Not all teams have the feature. Permission : Team member
+	// file access.
+	LegalHoldsGetPolicyContext(ctx context.Context, arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error)
+	// LegalHoldsListHeldRevisionsContext : List the file metadata that's under the
+	// hold. Note: Legal Holds is a paid add-on. Not all teams have the feature.
+	// Permission : Team member file access.
+	LegalHoldsListHeldRevisionsContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsArg) (res *LegalHoldsListHeldRevisionResult, err error)
+	// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file metadata
+	// that's under the hold. Note: Legal Holds is a paid add-on. Not all teams
+	// have the feature. Permission : Team member file access.
+	LegalHoldsListHeldRevisionsContinueContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error)
+	// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal Holds
+	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// member file access.
+	LegalHoldsListPoliciesContext(ctx context.Context, arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error)
+	// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal Holds
+	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// member file access.
+	LegalHoldsReleasePolicyContext(ctx context.Context, arg *LegalHoldsPolicyReleaseArg) (err error)
+	// LegalHoldsUpdatePolicyContext : Updates a legal hold. Note: Legal Holds is a
+	// paid add-on. Not all teams have the feature. Permission : Team member
+	// file access.
+	LegalHoldsUpdatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error)
+	// LinkedAppsListMemberLinkedAppsContext : List all linked applications of the team
+	// member. Note, this endpoint does not list any team-linked applications.
+	LinkedAppsListMemberLinkedAppsContext(ctx context.Context, arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error)
+	// LinkedAppsListMembersLinkedAppsContext : List all applications linked to the
+	// team members' accounts. Note, this endpoint does not list any team-linked
+	// applications.
+	LinkedAppsListMembersLinkedAppsContext(ctx context.Context, arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error)
+	// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the team
+	// members' accounts. Note, this endpoint doesn't list any team-linked
+	// applications.
+	// Deprecated:
+	LinkedAppsListTeamLinkedAppsContext(ctx context.Context, arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error)
+	// LinkedAppsRevokeLinkedAppContext : Revoke a linked application of the team
+	// member.
+	LinkedAppsRevokeLinkedAppContext(ctx context.Context, arg *RevokeLinkedApiAppArg) (err error)
+	// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked applications of
+	// the team members.
+	LinkedAppsRevokeLinkedAppBatchContext(ctx context.Context, arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error)
+	// MemberSpaceLimitsExcludedUsersAddContext : Add users to member space limits
+	// excluded users list.
+	MemberSpaceLimitsExcludedUsersAddContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error)
+	// MemberSpaceLimitsExcludedUsersListContext : List member space limits excluded
+	// users.
+	MemberSpaceLimitsExcludedUsersListContext(ctx context.Context, arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error)
+	// MemberSpaceLimitsExcludedUsersListContinueContext : Continue listing member
+	// space limits excluded users.
+	MemberSpaceLimitsExcludedUsersListContinueContext(ctx context.Context, arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error)
+	// MemberSpaceLimitsExcludedUsersRemoveContext : Remove users from member space
+	// limits excluded users list.
+	MemberSpaceLimitsExcludedUsersRemoveContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error)
+	// MemberSpaceLimitsGetCustomQuotaContext : Get users custom quota. A maximum of
+	// 1000 members can be specified in a single call. Note: to apply a custom
+	// space limit, a team admin needs to set a member space limit for the team
+	// first. (the team admin can check the settings here:
+	// https://www.dropbox.com/team/admin/settings/space).
+	MemberSpaceLimitsGetCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error)
+	// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A maximum
+	// of 1000 members can be specified in a single call. Note: to apply a
+	// custom space limit, a team admin needs to set a member space limit for
+	// the team first. (the team admin can check the settings here:
+	// https://www.dropbox.com/team/admin/settings/space).
+	MemberSpaceLimitsRemoveCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error)
+	// MemberSpaceLimitsSetCustomQuotaContext : Set users custom quota. Custom quota
+	// has to be at least 2GB. A maximum of 1000 members can be specified in a
+	// single call. Note: to apply a custom space limit, a team admin needs to
+	// set a member space limit for the team first. (the team admin can check
+	// the settings here: https://www.dropbox.com/team/admin/settings/space).
+	MemberSpaceLimitsSetCustomQuotaContext(ctx context.Context, arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error)
+	// MembersAddContext : Adds members to a team. Permission : Team member management
+	// A maximum of 20 members can be specified in a single call. If no Dropbox
+	// account exists with the email address specified, a new Dropbox account
+	// will be created with the given email address, and that account will be
+	// invited to the team. If a personal Dropbox account exists with the email
+	// address specified in the call, this call will create a placeholder
+	// Dropbox account for the user on the team and send an email inviting the
+	// user to migrate their existing personal account onto the team. Team
+	// member management apps are required to set an initial given_name and
+	// surname for a user to use in the team invitation and for 'Perform as team
+	// member' actions taken on the user before they become 'active'.
+	MembersAddContext(ctx context.Context, arg *MembersAddArg) (res *MembersAddLaunch, err error)
+	// MembersAddV2Context : Adds members to a team. Permission : Team member management
+	// A maximum of 20 members can be specified in a single call. If no Dropbox
+	// account exists with the email address specified, a new Dropbox account
+	// will be created with the given email address, and that account will be
+	// invited to the team. If a personal Dropbox account exists with the email
+	// address specified in the call, this call will create a placeholder
+	// Dropbox account for the user on the team and send an email inviting the
+	// user to migrate their existing personal account onto the team.
+	MembersAddV2Context(ctx context.Context, arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error)
+	// MembersAddJobStatusGetContext : Once an async_job_id is returned from
+	// `membersAdd` , use this to poll the status of the asynchronous request.
+	// Permission : Team member management.
+	MembersAddJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *MembersAddJobStatus, err error)
+	// MembersAddJobStatusGetV2Context : Once an async_job_id is returned from
+	// `membersAdd` , use this to poll the status of the asynchronous request.
+	// Permission : Team member management.
+	MembersAddJobStatusGetV2Context(ctx context.Context, arg *async.PollArg) (res *MembersAddJobStatusV2Result, err error)
+	// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a user
+	// who has been removed from the team. After permanent deletion, those files
+	// will not be available to be transferred to another team member.
+	// Permission : Team member management Exactly one of team_member_id, email,
+	// or external_id must be provided to identify the user account.
+	MembersDeleteFormerMemberFilesContext(ctx context.Context, arg *MembersFormerMemberArg) (err error)
+	// MembersDeleteProfilePhotoContext : Deletes a team member's profile photo.
+	// Permission : Team member management.
+	MembersDeleteProfilePhotoContext(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfo, err error)
+	// MembersDeleteProfilePhotoV2Context : Deletes a team member's profile photo.
+	// Permission : Team member management.
+	MembersDeleteProfilePhotoV2Context(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfoV2Result, err error)
+	// MembersGetAvailableTeamMemberRolesContext : Get available TeamMemberRoles for
+	// the connected team. To be used with `membersSetAdminPermissions`.
+	// Permission : Team member management.
+	MembersGetAvailableTeamMemberRolesContext(ctx context.Context) (res *MembersGetAvailableTeamMemberRolesResult, err error)
+	// MembersGetInfoContext : Returns information about multiple team members.
+	// Permission : Team information This endpoint will return
+	// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
+	// matched to a valid team member.
+	MembersGetInfoContext(ctx context.Context, arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error)
+	// MembersGetInfoV2Context : Returns information about multiple team members.
+	// Permission : Team information This endpoint will return
+	// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
+	// matched to a valid team member.
+	MembersGetInfoV2Context(ctx context.Context, arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error)
+	// MembersListContext : Lists members of a team. Permission : Team information.
+	MembersListContext(ctx context.Context, arg *MembersListArg) (res *MembersListResult, err error)
+	// MembersListV2Context : Lists members of a team. Permission : Team information.
+	MembersListV2Context(ctx context.Context, arg *MembersListArg) (res *MembersListV2Result, err error)
+	// MembersListContinueContext : Once a cursor has been retrieved from
+	// `membersList`, use this to paginate through all team members. Permission
+	// : Team information.
+	MembersListContinueContext(ctx context.Context, arg *MembersListContinueArg) (res *MembersListResult, err error)
+	// MembersListContinueV2Context : Once a cursor has been retrieved from
+	// `membersList`, use this to paginate through all team members. Permission
+	// : Team information.
+	MembersListContinueV2Context(ctx context.Context, arg *MembersListContinueArg) (res *MembersListV2Result, err error)
+	// MembersMoveFormerMemberFilesContext : Moves removed member's files to a
+	// different member. This endpoint initiates an asynchronous job. To obtain
+	// the final result of the job, the client should periodically poll
+	// `membersMoveFormerMemberFilesJobStatusCheck`. Permission : Team member
+	// management.
+	MembersMoveFormerMemberFilesContext(ctx context.Context, arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error)
+	// MembersMoveFormerMemberFilesJobStatusCheckContext : Once an async_job_id is
+	// returned from `membersMoveFormerMemberFiles` , use this to poll the
+	// status of the asynchronous request. Permission : Team member management.
+	MembersMoveFormerMemberFilesJobStatusCheckContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
+	// MembersRecoverContext : Recover a deleted member. Permission : Team member
+	// management Exactly one of team_member_id, email, or external_id must be
+	// provided to identify the user account.
+	MembersRecoverContext(ctx context.Context, arg *MembersRecoverArg) (err error)
+	// MembersRemoveContext : Removes a member from a team. Permission : Team member
+	// management Exactly one of team_member_id, email, or external_id must be
+	// provided to identify the user account. Accounts can be recovered via
+	// `membersRecover` for a 7 day period or until the account has been
+	// permanently deleted or transferred to another account (whichever comes
+	// first). Calling `membersAdd` while a user is still recoverable on your
+	// team will return with `MemberAddResult.user_already_on_team`. Accounts
+	// can have their files transferred via the admin console for a limited
+	// time, based on the version history length associated with the team (180
+	// days for most teams). Accounts can have their stacks transferred through
+	// the admin console. This only transfers stacks that they have created.
+	// This endpoint may initiate an asynchronous job. To obtain the final
+	// result of the job, the client should periodically poll
+	// `membersRemoveJobStatusGet`.
+	MembersRemoveContext(ctx context.Context, arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error)
+	// MembersRemoveJobStatusGetContext : Once an async_job_id is returned from
+	// `membersRemove` , use this to poll the status of the asynchronous
+	// request. Permission : Team member management.
+	MembersRemoveJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
+	// MembersSecondaryEmailsAddContext : Add secondary emails to users. Permission :
+	// Team member management. Emails that are on verified domains will be
+	// verified automatically. For each email address not on a verified domain a
+	// verification email will be sent.
+	MembersSecondaryEmailsAddContext(ctx context.Context, arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error)
+	// MembersSecondaryEmailsDeleteContext : Delete secondary emails from users
+	// Permission : Team member management. Users will be notified of deletions
+	// of verified secondary emails at both the secondary email and their
+	// primary email.
+	MembersSecondaryEmailsDeleteContext(ctx context.Context, arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error)
+	// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary email
+	// verification emails. Permission : Team member management.
+	MembersSecondaryEmailsResendVerificationEmailsContext(ctx context.Context, arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error)
+	// MembersSendWelcomeEmailContext : Sends welcome email to pending team member.
+	// Permission : Team member management Exactly one of team_member_id, email,
+	// or external_id must be provided to identify the user account. No-op if
+	// team member is not pending.
+	MembersSendWelcomeEmailContext(ctx context.Context, arg *UserSelectorArg) (err error)
+	// MembersSetAdminPermissionsContext : Updates a team member's permissions.
+	// Permission : Team member management.
+	MembersSetAdminPermissionsContext(ctx context.Context, arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error)
+	// MembersSetAdminPermissionsV2Context : Updates a team member's permissions.
+	// Permission : Team member management.
+	MembersSetAdminPermissionsV2Context(ctx context.Context, arg *MembersSetPermissions2Arg) (res *MembersSetPermissions2Result, err error)
+	// MembersSetProfileContext : Updates a team member's profile. Permission : Team
+	// member management.
+	MembersSetProfileContext(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfo, err error)
+	// MembersSetProfileV2Context : Updates a team member's profile. Permission : Team
+	// member management.
+	MembersSetProfileV2Context(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error)
+	// MembersSetProfilePhotoContext : Updates a team member's profile photo.
+	// Permission : Team member management.
+	MembersSetProfilePhotoContext(ctx context.Context, arg *MembersSetProfilePhotoArg) (res *TeamMemberInfo, err error)
+	// MembersSetProfilePhotoV2Context : Updates a team member's profile photo.
+	// Permission : Team member management.
+	MembersSetProfilePhotoV2Context(ctx context.Context, arg *MembersSetProfilePhotoArg) (res *TeamMemberInfoV2Result, err error)
+	// MembersSuspendContext : Suspend a member from a team. Permission : Team member
+	// management Exactly one of team_member_id, email, or external_id must be
+	// provided to identify the user account.
+	MembersSuspendContext(ctx context.Context, arg *MembersDeactivateArg) (err error)
+	// MembersUnsuspendContext : Unsuspend a member from a team. Permission : Team
+	// member management Exactly one of team_member_id, email, or external_id
+	// must be provided to identify the user account.
+	MembersUnsuspendContext(ctx context.Context, arg *MembersUnsuspendArg) (err error)
+	// NamespacesListContext : Returns a list of all team-accessible namespaces. This
+	// list includes team folders, shared folders containing team members, team
+	// members' home namespaces, and team members' app folders. Home namespaces
+	// and app folders are always owned by this team or members of the team, but
+	// shared folders may be owned by other users or other teams. Duplicates may
+	// occur in the list.
+	NamespacesListContext(ctx context.Context, arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error)
+	// NamespacesListContinueContext : Once a cursor has been retrieved from
+	// `namespacesList`, use this to paginate through all team-accessible
+	// namespaces. Duplicates may occur in the list.
+	NamespacesListContinueContext(ctx context.Context, arg *TeamNamespacesListContinueArg) (res *TeamNamespacesListResult, err error)
+	// PropertiesTemplateAddContext : Permission : Team member file access.
+	// Deprecated:
+	PropertiesTemplateAddContext(ctx context.Context, arg *file_properties.AddTemplateArg) (res *file_properties.AddTemplateResult, err error)
+	// PropertiesTemplateGetContext : Permission : Team member file access. The scope
+	// for the route is files.team_metadata.write.
+	// Deprecated:
+	PropertiesTemplateGetContext(ctx context.Context, arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error)
+	// ReportsGetActivityContext : Retrieves reporting data about a team's user
+	// activity. Deprecated: Will be removed on July 1st 2021.
+	// Deprecated:
+	ReportsGetActivityContext(ctx context.Context, arg *DateRange) (res *GetActivityReport, err error)
+	// ReportsGetDevicesContext : Retrieves reporting data about a team's linked
+	// devices. Deprecated: Will be removed on July 1st 2021.
+	// Deprecated:
+	ReportsGetDevicesContext(ctx context.Context, arg *DateRange) (res *GetDevicesReport, err error)
+	// ReportsGetMembershipContext : Retrieves reporting data about a team's
+	// membership. Deprecated: Will be removed on July 1st 2021.
+	// Deprecated:
+	ReportsGetMembershipContext(ctx context.Context, arg *DateRange) (res *GetMembershipReport, err error)
+	// ReportsGetStorageContext : Retrieves reporting data about a team's storage
+	// usage. Deprecated: Will be removed on July 1st 2021.
+	// Deprecated:
+	ReportsGetStorageContext(ctx context.Context, arg *DateRange) (res *GetStorageReport, err error)
+	// SharingAllowlistAddContext : Endpoint adds Approve List entries. Changes are
+	// effective immediately. Changes are committed in transaction. In case of
+	// single validation error - all entries are rejected. Valid domains
+	// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Added entries cannot
+	// overflow limit of 10000 entries per team. Maximum 100 entries per call is
+	// allowed.
+	SharingAllowlistAddContext(ctx context.Context, arg *SharingAllowlistAddArgs) (res *SharingAllowlistAddResponse, err error)
+	// SharingAllowlistListContext : Lists Approve List entries for given team, from
+	// newest to oldest, returning up to `limit` entries at a time. If there are
+	// more than `limit` entries associated with the current team, more can be
+	// fetched by passing the returned `cursor` to
+	// `sharingAllowlistListContinue`.
+	SharingAllowlistListContext(ctx context.Context, arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error)
+	// SharingAllowlistListContinueContext : Lists entries associated with given team,
+	// starting from a the cursor. See `sharingAllowlistList`.
+	SharingAllowlistListContinueContext(ctx context.Context, arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error)
+	// SharingAllowlistRemoveContext : Endpoint removes Approve List entries. Changes
+	// are effective immediately. Changes are committed in transaction. In case
+	// of single validation error - all entries are rejected. Valid domains
+	// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries being
+	// removed have to be present on the list. Maximum 1000 entries per call is
+	// allowed.
+	SharingAllowlistRemoveContext(ctx context.Context, arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error)
+	// TeamFolderActivateContext : Sets an archived team folder's status to active.
+	// Permission : Team member file access.
+	TeamFolderActivateContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error)
+	// TeamFolderArchiveContext : Sets an active team folder's status to archived and
+	// removes all folder and file members. This endpoint cannot be used for
+	// teams that have a shared team space. This route will either finish
+	// synchronously, or return a job ID and do the async archive job in
+	// background. Please use team_folder/archive/check to check the job status.
+	// Permission : Team member file access.
+	TeamFolderArchiveContext(ctx context.Context, arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error)
+	// TeamFolderArchiveCheckContext : Returns the status of an asynchronous job for
+	// archiving a team folder. The job may show '.tag' as complete, but the
+	// team folder could still be in the process of archiving (indicated by
+	// `TeamFolderMetadata.status` with 'archive_in_progress'). To confirm that
+	// the team folder is fully archived, check the field
+	// `TeamFolderMetadata.status` in the response for the value 'archived'.
+	// Permission : Team member file access.
+	TeamFolderArchiveCheckContext(ctx context.Context, arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error)
+	// TeamFolderCreateContext : Creates a new, active, team folder with no members.
+	// This endpoint can only be used for teams that do not already have a
+	// shared team space. Permission : Team member file access.
+	TeamFolderCreateContext(ctx context.Context, arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error)
+	// TeamFolderGetInfoContext : Retrieves metadata for team folders. Permission :
+	// Team member file access.
+	TeamFolderGetInfoContext(ctx context.Context, arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error)
+	// TeamFolderListContext : Lists all team folders. Permission : Team member file
+	// access.
+	TeamFolderListContext(ctx context.Context, arg *TeamFolderListArg) (res *TeamFolderListResult, err error)
+	// TeamFolderListContinueContext : Once a cursor has been retrieved from
+	// `teamFolderList`, use this to paginate through all team folders.
+	// Permission : Team member file access.
+	TeamFolderListContinueContext(ctx context.Context, arg *TeamFolderListContinueArg) (res *TeamFolderListResult, err error)
+	// TeamFolderPermanentlyDeleteContext : Permanently deletes an archived team
+	// folder. This endpoint cannot be used for teams that have a shared team
+	// space. Permission : Team member file access.
+	TeamFolderPermanentlyDeleteContext(ctx context.Context, arg *TeamFolderIdArg) (err error)
+	// TeamFolderRenameContext : Changes an active team folder's name. Permission :
+	// Team member file access.
+	TeamFolderRenameContext(ctx context.Context, arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error)
+	// TeamFolderRestoreContext : Sets an inactive team folder's status to active.
+	// Permission: Team member file access.
+	TeamFolderRestoreContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error)
+	// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team folder
+	// or its contents.  Use of this endpoint requires that the team has team
+	// selective sync enabled.
+	TeamFolderUpdateSyncSettingsContext(ctx context.Context, arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error)
+	// TokenGetAuthenticatedAdminContext : Returns the member profile of the admin who
+	// generated the team access token used to make the call.
+	TokenGetAuthenticatedAdminContext(ctx context.Context) (res *TokenGetAuthenticatedAdminResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // DevicesListMemberDevicesAPIError is an error-wrapper for the devices/list_member_devices route
@@ -437,7 +838,8 @@ type DevicesListMemberDevicesAPIError struct {
 	EndpointError *ListMemberDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
+// DevicesListMemberDevicesContext : List all device sessions of a team's member.
+func (dbx *apiImpl) DevicesListMemberDevicesContext(ctx context.Context, arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -450,11 +852,11 @@ func (dbx *apiImpl) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *Li
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DevicesListMemberDevicesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -469,13 +871,19 @@ func (dbx *apiImpl) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *Li
 	return
 }
 
+func (dbx *apiImpl) DevicesListMemberDevices(arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
+	return dbx.DevicesListMemberDevicesContext(context.Background(), arg)
+}
+
 // DevicesListMembersDevicesAPIError is an error-wrapper for the devices/list_members_devices route
 type DevicesListMembersDevicesAPIError struct {
 	dropbox.APIError
 	EndpointError *ListMembersDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error) {
+// DevicesListMembersDevicesContext : List all device sessions of a team.
+// Permission : Team member file access.
+func (dbx *apiImpl) DevicesListMembersDevicesContext(ctx context.Context, arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -488,11 +896,11 @@ func (dbx *apiImpl) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DevicesListMembersDevicesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -507,13 +915,20 @@ func (dbx *apiImpl) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *
 	return
 }
 
+func (dbx *apiImpl) DevicesListMembersDevices(arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error) {
+	return dbx.DevicesListMembersDevicesContext(context.Background(), arg)
+}
+
 // DevicesListTeamDevicesAPIError is an error-wrapper for the devices/list_team_devices route
 type DevicesListTeamDevicesAPIError struct {
 	dropbox.APIError
 	EndpointError *ListTeamDevicesError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
+// DevicesListTeamDevicesContext : List all device sessions of a team. Permission :
+// Team member file access.
+// Deprecated:
+func (dbx *apiImpl) DevicesListTeamDevicesContext(ctx context.Context, arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
 	log.Printf("WARNING: API `DevicesListTeamDevices` is deprecated")
 
 	req := dropbox.Request{
@@ -528,11 +943,11 @@ func (dbx *apiImpl) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DevicesListTeamDevicesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -547,13 +962,18 @@ func (dbx *apiImpl) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTe
 	return
 }
 
+func (dbx *apiImpl) DevicesListTeamDevices(arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
+	return dbx.DevicesListTeamDevicesContext(context.Background(), arg)
+}
+
 // DevicesRevokeDeviceSessionAPIError is an error-wrapper for the devices/revoke_device_session route
 type DevicesRevokeDeviceSessionAPIError struct {
 	dropbox.APIError
 	EndpointError *RevokeDeviceSessionError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err error) {
+// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's member.
+func (dbx *apiImpl) DevicesRevokeDeviceSessionContext(ctx context.Context, arg *RevokeDeviceSessionArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -566,11 +986,11 @@ func (dbx *apiImpl) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DevicesRevokeDeviceSessionAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -581,13 +1001,19 @@ func (dbx *apiImpl) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err
 	return
 }
 
+func (dbx *apiImpl) DevicesRevokeDeviceSession(arg *RevokeDeviceSessionArg) (err error) {
+	return dbx.DevicesRevokeDeviceSessionContext(context.Background(), arg)
+}
+
 // DevicesRevokeDeviceSessionBatchAPIError is an error-wrapper for the devices/revoke_device_session_batch route
 type DevicesRevokeDeviceSessionBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *RevokeDeviceSessionBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error) {
+// DevicesRevokeDeviceSessionBatchContext : Revoke a list of device sessions of
+// team members.
+func (dbx *apiImpl) DevicesRevokeDeviceSessionBatchContext(ctx context.Context, arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -600,11 +1026,11 @@ func (dbx *apiImpl) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatc
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr DevicesRevokeDeviceSessionBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -619,13 +1045,21 @@ func (dbx *apiImpl) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatc
 	return
 }
 
+func (dbx *apiImpl) DevicesRevokeDeviceSessionBatch(arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error) {
+	return dbx.DevicesRevokeDeviceSessionBatchContext(context.Background(), arg)
+}
+
 // FeaturesGetValuesAPIError is an error-wrapper for the features/get_values route
 type FeaturesGetValuesAPIError struct {
 	dropbox.APIError
 	EndpointError *FeaturesGetValuesBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) FeaturesGetValues(arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error) {
+// FeaturesGetValuesContext : Get the values for one or more features. This route
+// allows you to check your account's capability for what feature you can
+// access or what value you have for certain features. Permission : Team
+// information.
+func (dbx *apiImpl) FeaturesGetValuesContext(ctx context.Context, arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -638,11 +1072,11 @@ func (dbx *apiImpl) FeaturesGetValues(arg *FeaturesGetValuesBatchArg) (res *Feat
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr FeaturesGetValuesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -657,13 +1091,18 @@ func (dbx *apiImpl) FeaturesGetValues(arg *FeaturesGetValuesBatchArg) (res *Feat
 	return
 }
 
+func (dbx *apiImpl) FeaturesGetValues(arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error) {
+	return dbx.FeaturesGetValuesContext(context.Background(), arg)
+}
+
 // GetInfoAPIError is an error-wrapper for the get_info route
 type GetInfoAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetInfo() (res *TeamGetInfoResult, err error) {
+// GetInfoContext : Retrieves information about a team.
+func (dbx *apiImpl) GetInfoContext(ctx context.Context) (res *TeamGetInfoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -676,11 +1115,11 @@ func (dbx *apiImpl) GetInfo() (res *TeamGetInfoResult, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetInfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -695,13 +1134,19 @@ func (dbx *apiImpl) GetInfo() (res *TeamGetInfoResult, err error) {
 	return
 }
 
+func (dbx *apiImpl) GetInfo() (res *TeamGetInfoResult, err error) {
+	return dbx.GetInfoContext(context.Background())
+}
+
 // GroupsCreateAPIError is an error-wrapper for the groups/create route
 type GroupsCreateAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err error) {
+// GroupsCreateContext : Creates a new, empty group, with a requested name.
+// Permission : Team member management.
+func (dbx *apiImpl) GroupsCreateContext(ctx context.Context, arg *GroupCreateArg) (res *GroupFullInfo, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -714,11 +1159,11 @@ func (dbx *apiImpl) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsCreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -733,13 +1178,21 @@ func (dbx *apiImpl) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err e
 	return
 }
 
+func (dbx *apiImpl) GroupsCreate(arg *GroupCreateArg) (res *GroupFullInfo, err error) {
+	return dbx.GroupsCreateContext(context.Background(), arg)
+}
+
 // GroupsDeleteAPIError is an error-wrapper for the groups/delete route
 type GroupsDeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupDeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
+// GroupsDeleteContext : Deletes a group. The group is deleted immediately. However
+// the revoking of group-owned resources may take additional time. Use the
+// `groupsJobStatusGet` to determine whether this process has completed.
+// Permission : Team member management.
+func (dbx *apiImpl) GroupsDeleteContext(ctx context.Context, arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -752,11 +1205,11 @@ func (dbx *apiImpl) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResu
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsDeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -771,13 +1224,20 @@ func (dbx *apiImpl) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResu
 	return
 }
 
+func (dbx *apiImpl) GroupsDelete(arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
+	return dbx.GroupsDeleteContext(context.Background(), arg)
+}
+
 // GroupsGetInfoAPIError is an error-wrapper for the groups/get_info route
 type GroupsGetInfoAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupsGetInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
+// GroupsGetInfoContext : Retrieves information about one or more groups. Note that
+// the optional field `GroupFullInfo.members` is not returned for
+// system-managed groups. Permission : Team Information.
+func (dbx *apiImpl) GroupsGetInfoContext(ctx context.Context, arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -790,11 +1250,11 @@ func (dbx *apiImpl) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsGetInfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -809,13 +1269,21 @@ func (dbx *apiImpl) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem
 	return
 }
 
+func (dbx *apiImpl) GroupsGetInfo(arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
+	return dbx.GroupsGetInfoContext(context.Background(), arg)
+}
+
 // GroupsJobStatusGetAPIError is an error-wrapper for the groups/job_status/get route
 type GroupsJobStatusGetAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupsPollError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+// GroupsJobStatusGetContext : Once an async_job_id is returned from
+// `groupsDelete`, `groupsMembersAdd` , or `groupsMembersRemove` use this
+// method to poll the status of granting/revoking group members' access to
+// group-owned resources. Permission : Team member management.
+func (dbx *apiImpl) GroupsJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -828,11 +1296,11 @@ func (dbx *apiImpl) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmpty
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsJobStatusGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -847,13 +1315,18 @@ func (dbx *apiImpl) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmpty
 	return
 }
 
+func (dbx *apiImpl) GroupsJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+	return dbx.GroupsJobStatusGetContext(context.Background(), arg)
+}
+
 // GroupsListAPIError is an error-wrapper for the groups/list route
 type GroupsListAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err error) {
+// GroupsListContext : Lists groups on a team. Permission : Team Information.
+func (dbx *apiImpl) GroupsListContext(ctx context.Context, arg *GroupsListArg) (res *GroupsListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -866,11 +1339,11 @@ func (dbx *apiImpl) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -885,13 +1358,19 @@ func (dbx *apiImpl) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err e
 	return
 }
 
+func (dbx *apiImpl) GroupsList(arg *GroupsListArg) (res *GroupsListResult, err error) {
+	return dbx.GroupsListContext(context.Background(), arg)
+}
+
 // GroupsListContinueAPIError is an error-wrapper for the groups/list/continue route
 type GroupsListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupsListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
+// GroupsListContinueContext : Once a cursor has been retrieved from `groupsList`,
+// use this to paginate through all groups. Permission : Team Information.
+func (dbx *apiImpl) GroupsListContinueContext(ctx context.Context, arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -904,11 +1383,11 @@ func (dbx *apiImpl) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsL
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -923,13 +1402,21 @@ func (dbx *apiImpl) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsL
 	return
 }
 
+func (dbx *apiImpl) GroupsListContinue(arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
+	return dbx.GroupsListContinueContext(context.Background(), arg)
+}
+
 // GroupsMembersAddAPIError is an error-wrapper for the groups/members/add route
 type GroupsMembersAddAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupMembersAddError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error) {
+// GroupsMembersAddContext : Adds members to a group. The members are added
+// immediately. However the granting of group-owned resources may take
+// additional time. Use the `groupsJobStatusGet` to determine whether this
+// process has completed. Permission : Team member management.
+func (dbx *apiImpl) GroupsMembersAddContext(ctx context.Context, arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -942,11 +1429,11 @@ func (dbx *apiImpl) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembers
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsMembersAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -961,13 +1448,19 @@ func (dbx *apiImpl) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembers
 	return
 }
 
+func (dbx *apiImpl) GroupsMembersAdd(arg *GroupMembersAddArg) (res *GroupMembersChangeResult, err error) {
+	return dbx.GroupsMembersAddContext(context.Background(), arg)
+}
+
 // GroupsMembersListAPIError is an error-wrapper for the groups/members/list route
 type GroupsMembersListAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupSelectorError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error) {
+// GroupsMembersListContext : Lists members of a group. Permission : Team
+// Information.
+func (dbx *apiImpl) GroupsMembersListContext(ctx context.Context, arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -980,11 +1473,11 @@ func (dbx *apiImpl) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMem
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsMembersListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -999,13 +1492,20 @@ func (dbx *apiImpl) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMem
 	return
 }
 
+func (dbx *apiImpl) GroupsMembersList(arg *GroupsMembersListArg) (res *GroupsMembersListResult, err error) {
+	return dbx.GroupsMembersListContext(context.Background(), arg)
+}
+
 // GroupsMembersListContinueAPIError is an error-wrapper for the groups/members/list/continue route
 type GroupsMembersListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupsMembersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersListContinue(arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
+// GroupsMembersListContinueContext : Once a cursor has been retrieved from
+// `groupsMembersList`, use this to paginate through all members of the
+// group. Permission : Team information.
+func (dbx *apiImpl) GroupsMembersListContinueContext(ctx context.Context, arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1018,11 +1518,11 @@ func (dbx *apiImpl) GroupsMembersListContinue(arg *GroupsMembersListContinueArg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsMembersListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1037,13 +1537,23 @@ func (dbx *apiImpl) GroupsMembersListContinue(arg *GroupsMembersListContinueArg)
 	return
 }
 
+func (dbx *apiImpl) GroupsMembersListContinue(arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
+	return dbx.GroupsMembersListContinueContext(context.Background(), arg)
+}
+
 // GroupsMembersRemoveAPIError is an error-wrapper for the groups/members/remove route
 type GroupsMembersRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupMembersRemoveError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
+// GroupsMembersRemoveContext : Removes members from a group. The members are
+// removed immediately. However the revoking of group-owned resources may
+// take additional time. Use the `groupsJobStatusGet` to determine whether
+// this process has completed. This method permits removing the only owner
+// of a group, even in cases where this is not possible via the web client.
+// Permission : Team member management.
+func (dbx *apiImpl) GroupsMembersRemoveContext(ctx context.Context, arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1056,11 +1566,11 @@ func (dbx *apiImpl) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupM
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsMembersRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1075,13 +1585,19 @@ func (dbx *apiImpl) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupM
 	return
 }
 
+func (dbx *apiImpl) GroupsMembersRemove(arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
+	return dbx.GroupsMembersRemoveContext(context.Background(), arg)
+}
+
 // GroupsMembersSetAccessTypeAPIError is an error-wrapper for the groups/members/set_access_type route
 type GroupsMembersSetAccessTypeAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupMemberSetAccessTypeError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error) {
+// GroupsMembersSetAccessTypeContext : Sets a member's access type in a group.
+// Permission : Team member management.
+func (dbx *apiImpl) GroupsMembersSetAccessTypeContext(ctx context.Context, arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1094,11 +1610,11 @@ func (dbx *apiImpl) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsMembersSetAccessTypeAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1113,13 +1629,19 @@ func (dbx *apiImpl) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg
 	return
 }
 
+func (dbx *apiImpl) GroupsMembersSetAccessType(arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error) {
+	return dbx.GroupsMembersSetAccessTypeContext(context.Background(), arg)
+}
+
 // GroupsUpdateAPIError is an error-wrapper for the groups/update route
 type GroupsUpdateAPIError struct {
 	dropbox.APIError
 	EndpointError *GroupUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err error) {
+// GroupsUpdateContext : Updates a group's name and/or external ID. Permission :
+// Team member management.
+func (dbx *apiImpl) GroupsUpdateContext(ctx context.Context, arg *GroupUpdateArgs) (res *GroupFullInfo, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1132,11 +1654,11 @@ func (dbx *apiImpl) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GroupsUpdateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1151,13 +1673,20 @@ func (dbx *apiImpl) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err 
 	return
 }
 
+func (dbx *apiImpl) GroupsUpdate(arg *GroupUpdateArgs) (res *GroupFullInfo, err error) {
+	return dbx.GroupsUpdateContext(context.Background(), arg)
+}
+
 // LegalHoldsCreatePolicyAPIError is an error-wrapper for the legal_holds/create_policy route
 type LegalHoldsCreatePolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsPolicyCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsCreatePolicy(arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error) {
+// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note: Legal Holds
+// is a paid add-on. Not all teams have the feature. Permission : Team
+// member file access.
+func (dbx *apiImpl) LegalHoldsCreatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1170,11 +1699,11 @@ func (dbx *apiImpl) LegalHoldsCreatePolicy(arg *LegalHoldsPolicyCreateArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsCreatePolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1189,13 +1718,20 @@ func (dbx *apiImpl) LegalHoldsCreatePolicy(arg *LegalHoldsPolicyCreateArg) (res 
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsCreatePolicy(arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error) {
+	return dbx.LegalHoldsCreatePolicyContext(context.Background(), arg)
+}
+
 // LegalHoldsGetPolicyAPIError is an error-wrapper for the legal_holds/get_policy route
 type LegalHoldsGetPolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsGetPolicyError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsGetPolicy(arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error) {
+// LegalHoldsGetPolicyContext : Gets a legal hold by Id. Note: Legal Holds is a
+// paid add-on. Not all teams have the feature. Permission : Team member
+// file access.
+func (dbx *apiImpl) LegalHoldsGetPolicyContext(ctx context.Context, arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1208,11 +1744,11 @@ func (dbx *apiImpl) LegalHoldsGetPolicy(arg *LegalHoldsGetPolicyArg) (res *Legal
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsGetPolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1227,13 +1763,20 @@ func (dbx *apiImpl) LegalHoldsGetPolicy(arg *LegalHoldsGetPolicyArg) (res *Legal
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsGetPolicy(arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error) {
+	return dbx.LegalHoldsGetPolicyContext(context.Background(), arg)
+}
+
 // LegalHoldsListHeldRevisionsAPIError is an error-wrapper for the legal_holds/list_held_revisions route
 type LegalHoldsListHeldRevisionsAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsListHeldRevisionsError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsListHeldRevisions(arg *LegalHoldsListHeldRevisionsArg) (res *LegalHoldsListHeldRevisionResult, err error) {
+// LegalHoldsListHeldRevisionsContext : List the file metadata that's under the
+// hold. Note: Legal Holds is a paid add-on. Not all teams have the feature.
+// Permission : Team member file access.
+func (dbx *apiImpl) LegalHoldsListHeldRevisionsContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsArg) (res *LegalHoldsListHeldRevisionResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1246,11 +1789,11 @@ func (dbx *apiImpl) LegalHoldsListHeldRevisions(arg *LegalHoldsListHeldRevisions
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsListHeldRevisionsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1265,13 +1808,20 @@ func (dbx *apiImpl) LegalHoldsListHeldRevisions(arg *LegalHoldsListHeldRevisions
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsListHeldRevisions(arg *LegalHoldsListHeldRevisionsArg) (res *LegalHoldsListHeldRevisionResult, err error) {
+	return dbx.LegalHoldsListHeldRevisionsContext(context.Background(), arg)
+}
+
 // LegalHoldsListHeldRevisionsContinueAPIError is an error-wrapper for the legal_holds/list_held_revisions_continue route
 type LegalHoldsListHeldRevisionsContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsListHeldRevisionsError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinue(arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error) {
+// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file metadata
+// that's under the hold. Note: Legal Holds is a paid add-on. Not all teams
+// have the feature. Permission : Team member file access.
+func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinueContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1284,11 +1834,11 @@ func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinue(arg *LegalHoldsListHeldR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsListHeldRevisionsContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1303,13 +1853,20 @@ func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinue(arg *LegalHoldsListHeldR
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinue(arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error) {
+	return dbx.LegalHoldsListHeldRevisionsContinueContext(context.Background(), arg)
+}
+
 // LegalHoldsListPoliciesAPIError is an error-wrapper for the legal_holds/list_policies route
 type LegalHoldsListPoliciesAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsListPoliciesError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsListPolicies(arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error) {
+// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal Holds
+// is a paid add-on. Not all teams have the feature. Permission : Team
+// member file access.
+func (dbx *apiImpl) LegalHoldsListPoliciesContext(ctx context.Context, arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1322,11 +1879,11 @@ func (dbx *apiImpl) LegalHoldsListPolicies(arg *LegalHoldsListPoliciesArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsListPoliciesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1341,13 +1898,20 @@ func (dbx *apiImpl) LegalHoldsListPolicies(arg *LegalHoldsListPoliciesArg) (res 
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsListPolicies(arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error) {
+	return dbx.LegalHoldsListPoliciesContext(context.Background(), arg)
+}
+
 // LegalHoldsReleasePolicyAPIError is an error-wrapper for the legal_holds/release_policy route
 type LegalHoldsReleasePolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsPolicyReleaseError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsReleasePolicy(arg *LegalHoldsPolicyReleaseArg) (err error) {
+// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal Holds
+// is a paid add-on. Not all teams have the feature. Permission : Team
+// member file access.
+func (dbx *apiImpl) LegalHoldsReleasePolicyContext(ctx context.Context, arg *LegalHoldsPolicyReleaseArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1360,11 +1924,11 @@ func (dbx *apiImpl) LegalHoldsReleasePolicy(arg *LegalHoldsPolicyReleaseArg) (er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsReleasePolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1375,13 +1939,20 @@ func (dbx *apiImpl) LegalHoldsReleasePolicy(arg *LegalHoldsPolicyReleaseArg) (er
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsReleasePolicy(arg *LegalHoldsPolicyReleaseArg) (err error) {
+	return dbx.LegalHoldsReleasePolicyContext(context.Background(), arg)
+}
+
 // LegalHoldsUpdatePolicyAPIError is an error-wrapper for the legal_holds/update_policy route
 type LegalHoldsUpdatePolicyAPIError struct {
 	dropbox.APIError
 	EndpointError *LegalHoldsPolicyUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) LegalHoldsUpdatePolicy(arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error) {
+// LegalHoldsUpdatePolicyContext : Updates a legal hold. Note: Legal Holds is a
+// paid add-on. Not all teams have the feature. Permission : Team member
+// file access.
+func (dbx *apiImpl) LegalHoldsUpdatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1394,11 +1965,11 @@ func (dbx *apiImpl) LegalHoldsUpdatePolicy(arg *LegalHoldsPolicyUpdateArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LegalHoldsUpdatePolicyAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1413,13 +1984,19 @@ func (dbx *apiImpl) LegalHoldsUpdatePolicy(arg *LegalHoldsPolicyUpdateArg) (res 
 	return
 }
 
+func (dbx *apiImpl) LegalHoldsUpdatePolicy(arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error) {
+	return dbx.LegalHoldsUpdatePolicyContext(context.Background(), arg)
+}
+
 // LinkedAppsListMemberLinkedAppsAPIError is an error-wrapper for the linked_apps/list_member_linked_apps route
 type LinkedAppsListMemberLinkedAppsAPIError struct {
 	dropbox.APIError
 	EndpointError *ListMemberAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
+// LinkedAppsListMemberLinkedAppsContext : List all linked applications of the team
+// member. Note, this endpoint does not list any team-linked applications.
+func (dbx *apiImpl) LinkedAppsListMemberLinkedAppsContext(ctx context.Context, arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1432,11 +2009,11 @@ func (dbx *apiImpl) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LinkedAppsListMemberLinkedAppsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1451,13 +2028,20 @@ func (dbx *apiImpl) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res 
 	return
 }
 
+func (dbx *apiImpl) LinkedAppsListMemberLinkedApps(arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
+	return dbx.LinkedAppsListMemberLinkedAppsContext(context.Background(), arg)
+}
+
 // LinkedAppsListMembersLinkedAppsAPIError is an error-wrapper for the linked_apps/list_members_linked_apps route
 type LinkedAppsListMembersLinkedAppsAPIError struct {
 	dropbox.APIError
 	EndpointError *ListMembersAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error) {
+// LinkedAppsListMembersLinkedAppsContext : List all applications linked to the
+// team members' accounts. Note, this endpoint does not list any team-linked
+// applications.
+func (dbx *apiImpl) LinkedAppsListMembersLinkedAppsContext(ctx context.Context, arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1470,11 +2054,11 @@ func (dbx *apiImpl) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LinkedAppsListMembersLinkedAppsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1489,13 +2073,21 @@ func (dbx *apiImpl) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (re
 	return
 }
 
+func (dbx *apiImpl) LinkedAppsListMembersLinkedApps(arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error) {
+	return dbx.LinkedAppsListMembersLinkedAppsContext(context.Background(), arg)
+}
+
 // LinkedAppsListTeamLinkedAppsAPIError is an error-wrapper for the linked_apps/list_team_linked_apps route
 type LinkedAppsListTeamLinkedAppsAPIError struct {
 	dropbox.APIError
 	EndpointError *ListTeamAppsError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
+// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the team
+// members' accounts. Note, this endpoint doesn't list any team-linked
+// applications.
+// Deprecated:
+func (dbx *apiImpl) LinkedAppsListTeamLinkedAppsContext(ctx context.Context, arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
 	log.Printf("WARNING: API `LinkedAppsListTeamLinkedApps` is deprecated")
 
 	req := dropbox.Request{
@@ -1510,11 +2102,11 @@ func (dbx *apiImpl) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *Lis
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LinkedAppsListTeamLinkedAppsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1529,13 +2121,19 @@ func (dbx *apiImpl) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *Lis
 	return
 }
 
+func (dbx *apiImpl) LinkedAppsListTeamLinkedApps(arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
+	return dbx.LinkedAppsListTeamLinkedAppsContext(context.Background(), arg)
+}
+
 // LinkedAppsRevokeLinkedAppAPIError is an error-wrapper for the linked_apps/revoke_linked_app route
 type LinkedAppsRevokeLinkedAppAPIError struct {
 	dropbox.APIError
 	EndpointError *RevokeLinkedAppError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err error) {
+// LinkedAppsRevokeLinkedAppContext : Revoke a linked application of the team
+// member.
+func (dbx *apiImpl) LinkedAppsRevokeLinkedAppContext(ctx context.Context, arg *RevokeLinkedApiAppArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1548,11 +2146,11 @@ func (dbx *apiImpl) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LinkedAppsRevokeLinkedAppAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1563,13 +2161,19 @@ func (dbx *apiImpl) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err e
 	return
 }
 
+func (dbx *apiImpl) LinkedAppsRevokeLinkedApp(arg *RevokeLinkedApiAppArg) (err error) {
+	return dbx.LinkedAppsRevokeLinkedAppContext(context.Background(), arg)
+}
+
 // LinkedAppsRevokeLinkedAppBatchAPIError is an error-wrapper for the linked_apps/revoke_linked_app_batch route
 type LinkedAppsRevokeLinkedAppBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *RevokeLinkedAppBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
+// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked applications of
+// the team members.
+func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatchContext(ctx context.Context, arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1582,11 +2186,11 @@ func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr LinkedAppsRevokeLinkedAppBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1601,13 +2205,19 @@ func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchA
 	return
 }
 
+func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatch(arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
+	return dbx.LinkedAppsRevokeLinkedAppBatchContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsExcludedUsersAddAPIError is an error-wrapper for the member_space_limits/excluded_users/add route
 type MemberSpaceLimitsExcludedUsersAddAPIError struct {
 	dropbox.APIError
 	EndpointError *ExcludedUsersUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersAdd(arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
+// MemberSpaceLimitsExcludedUsersAddContext : Add users to member space limits
+// excluded users list.
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersAddContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1620,11 +2230,11 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersAdd(arg *ExcludedUsersUpdateAr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsExcludedUsersAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1639,13 +2249,19 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersAdd(arg *ExcludedUsersUpdateAr
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersAdd(arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
+	return dbx.MemberSpaceLimitsExcludedUsersAddContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsExcludedUsersListAPIError is an error-wrapper for the member_space_limits/excluded_users/list route
 type MemberSpaceLimitsExcludedUsersListAPIError struct {
 	dropbox.APIError
 	EndpointError *ExcludedUsersListError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersList(arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error) {
+// MemberSpaceLimitsExcludedUsersListContext : List member space limits excluded
+// users.
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContext(ctx context.Context, arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1658,11 +2274,11 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersList(arg *ExcludedUsersListArg
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsExcludedUsersListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1677,13 +2293,19 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersList(arg *ExcludedUsersListArg
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersList(arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error) {
+	return dbx.MemberSpaceLimitsExcludedUsersListContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsExcludedUsersListContinueAPIError is an error-wrapper for the member_space_limits/excluded_users/list/continue route
 type MemberSpaceLimitsExcludedUsersListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *ExcludedUsersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContinue(arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error) {
+// MemberSpaceLimitsExcludedUsersListContinueContext : Continue listing member
+// space limits excluded users.
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContinueContext(ctx context.Context, arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1696,11 +2318,11 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContinue(arg *ExcludedUser
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsExcludedUsersListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1715,13 +2337,19 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContinue(arg *ExcludedUser
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersListContinue(arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error) {
+	return dbx.MemberSpaceLimitsExcludedUsersListContinueContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsExcludedUsersRemoveAPIError is an error-wrapper for the member_space_limits/excluded_users/remove route
 type MemberSpaceLimitsExcludedUsersRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *ExcludedUsersUpdateError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersRemove(arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
+// MemberSpaceLimitsExcludedUsersRemoveContext : Remove users from member space
+// limits excluded users list.
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersRemoveContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1734,11 +2362,11 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersRemove(arg *ExcludedUsersUpdat
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsExcludedUsersRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1753,13 +2381,22 @@ func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersRemove(arg *ExcludedUsersUpdat
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsExcludedUsersRemove(arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error) {
+	return dbx.MemberSpaceLimitsExcludedUsersRemoveContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsGetCustomQuotaAPIError is an error-wrapper for the member_space_limits/get_custom_quota route
 type MemberSpaceLimitsGetCustomQuotaAPIError struct {
 	dropbox.APIError
 	EndpointError *CustomQuotaError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuota(arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error) {
+// MemberSpaceLimitsGetCustomQuotaContext : Get users custom quota. A maximum of
+// 1000 members can be specified in a single call. Note: to apply a custom
+// space limit, a team admin needs to set a member space limit for the team
+// first. (the team admin can check the settings here:
+// https://www.dropbox.com/team/admin/settings/space).
+func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1772,11 +2409,11 @@ func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuota(arg *CustomQuotaUsersArg) (r
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsGetCustomQuotaAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1791,13 +2428,22 @@ func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuota(arg *CustomQuotaUsersArg) (r
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuota(arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error) {
+	return dbx.MemberSpaceLimitsGetCustomQuotaContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsRemoveCustomQuotaAPIError is an error-wrapper for the member_space_limits/remove_custom_quota route
 type MemberSpaceLimitsRemoveCustomQuotaAPIError struct {
 	dropbox.APIError
 	EndpointError *CustomQuotaError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuota(arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error) {
+// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A maximum
+// of 1000 members can be specified in a single call. Note: to apply a
+// custom space limit, a team admin needs to set a member space limit for
+// the team first. (the team admin can check the settings here:
+// https://www.dropbox.com/team/admin/settings/space).
+func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1810,11 +2456,11 @@ func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuota(arg *CustomQuotaUsersArg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsRemoveCustomQuotaAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1829,13 +2475,22 @@ func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuota(arg *CustomQuotaUsersArg)
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuota(arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error) {
+	return dbx.MemberSpaceLimitsRemoveCustomQuotaContext(context.Background(), arg)
+}
+
 // MemberSpaceLimitsSetCustomQuotaAPIError is an error-wrapper for the member_space_limits/set_custom_quota route
 type MemberSpaceLimitsSetCustomQuotaAPIError struct {
 	dropbox.APIError
 	EndpointError *SetCustomQuotaError `json:"error"`
 }
 
-func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuota(arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error) {
+// MemberSpaceLimitsSetCustomQuotaContext : Set users custom quota. Custom quota
+// has to be at least 2GB. A maximum of 1000 members can be specified in a
+// single call. Note: to apply a custom space limit, a team admin needs to
+// set a member space limit for the team first. (the team admin can check
+// the settings here: https://www.dropbox.com/team/admin/settings/space).
+func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuotaContext(ctx context.Context, arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1848,11 +2503,11 @@ func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuota(arg *SetCustomQuotaArg) (res
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MemberSpaceLimitsSetCustomQuotaAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1867,13 +2522,28 @@ func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuota(arg *SetCustomQuotaArg) (res
 	return
 }
 
+func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuota(arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error) {
+	return dbx.MemberSpaceLimitsSetCustomQuotaContext(context.Background(), arg)
+}
+
 // MembersAddAPIError is an error-wrapper for the members/add route
 type MembersAddAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err error) {
+// MembersAddContext : Adds members to a team. Permission : Team member management
+// A maximum of 20 members can be specified in a single call. If no Dropbox
+// account exists with the email address specified, a new Dropbox account
+// will be created with the given email address, and that account will be
+// invited to the team. If a personal Dropbox account exists with the email
+// address specified in the call, this call will create a placeholder
+// Dropbox account for the user on the team and send an email inviting the
+// user to migrate their existing personal account onto the team. Team
+// member management apps are required to set an initial given_name and
+// surname for a user to use in the team invitation and for 'Perform as team
+// member' actions taken on the user before they become 'active'.
+func (dbx *apiImpl) MembersAddContext(ctx context.Context, arg *MembersAddArg) (res *MembersAddLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1886,11 +2556,11 @@ func (dbx *apiImpl) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err e
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1905,13 +2575,25 @@ func (dbx *apiImpl) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err e
 	return
 }
 
+func (dbx *apiImpl) MembersAdd(arg *MembersAddArg) (res *MembersAddLaunch, err error) {
+	return dbx.MembersAddContext(context.Background(), arg)
+}
+
 // MembersAddV2APIError is an error-wrapper for the members/add_v2 route
 type MembersAddV2APIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAddV2(arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error) {
+// MembersAddV2Context : Adds members to a team. Permission : Team member management
+// A maximum of 20 members can be specified in a single call. If no Dropbox
+// account exists with the email address specified, a new Dropbox account
+// will be created with the given email address, and that account will be
+// invited to the team. If a personal Dropbox account exists with the email
+// address specified in the call, this call will create a placeholder
+// Dropbox account for the user on the team and send an email inviting the
+// user to migrate their existing personal account onto the team.
+func (dbx *apiImpl) MembersAddV2Context(ctx context.Context, arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1924,11 +2606,11 @@ func (dbx *apiImpl) MembersAddV2(arg *MembersAddV2Arg) (res *MembersAddLaunchV2R
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersAddV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1943,13 +2625,20 @@ func (dbx *apiImpl) MembersAddV2(arg *MembersAddV2Arg) (res *MembersAddLaunchV2R
 	return
 }
 
+func (dbx *apiImpl) MembersAddV2(arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error) {
+	return dbx.MembersAddV2Context(context.Background(), arg)
+}
+
 // MembersAddJobStatusGetAPIError is an error-wrapper for the members/add/job_status/get route
 type MembersAddJobStatusGetAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJobStatus, err error) {
+// MembersAddJobStatusGetContext : Once an async_job_id is returned from
+// `membersAdd` , use this to poll the status of the asynchronous request.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersAddJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *MembersAddJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -1962,11 +2651,11 @@ func (dbx *apiImpl) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJ
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersAddJobStatusGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -1981,13 +2670,20 @@ func (dbx *apiImpl) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJ
 	return
 }
 
+func (dbx *apiImpl) MembersAddJobStatusGet(arg *async.PollArg) (res *MembersAddJobStatus, err error) {
+	return dbx.MembersAddJobStatusGetContext(context.Background(), arg)
+}
+
 // MembersAddJobStatusGetV2APIError is an error-wrapper for the members/add/job_status/get_v2 route
 type MembersAddJobStatusGetV2APIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersAddJobStatusGetV2(arg *async.PollArg) (res *MembersAddJobStatusV2Result, err error) {
+// MembersAddJobStatusGetV2Context : Once an async_job_id is returned from
+// `membersAdd` , use this to poll the status of the asynchronous request.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersAddJobStatusGetV2Context(ctx context.Context, arg *async.PollArg) (res *MembersAddJobStatusV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2000,11 +2696,11 @@ func (dbx *apiImpl) MembersAddJobStatusGetV2(arg *async.PollArg) (res *MembersAd
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersAddJobStatusGetV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2019,13 +2715,22 @@ func (dbx *apiImpl) MembersAddJobStatusGetV2(arg *async.PollArg) (res *MembersAd
 	return
 }
 
+func (dbx *apiImpl) MembersAddJobStatusGetV2(arg *async.PollArg) (res *MembersAddJobStatusV2Result, err error) {
+	return dbx.MembersAddJobStatusGetV2Context(context.Background(), arg)
+}
+
 // MembersDeleteFormerMemberFilesAPIError is an error-wrapper for the members/delete_former_member_files route
 type MembersDeleteFormerMemberFilesAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersDeleteFormerMemberFilesError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersDeleteFormerMemberFiles(arg *MembersFormerMemberArg) (err error) {
+// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a user
+// who has been removed from the team. After permanent deletion, those files
+// will not be available to be transferred to another team member.
+// Permission : Team member management Exactly one of team_member_id, email,
+// or external_id must be provided to identify the user account.
+func (dbx *apiImpl) MembersDeleteFormerMemberFilesContext(ctx context.Context, arg *MembersFormerMemberArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2038,11 +2743,11 @@ func (dbx *apiImpl) MembersDeleteFormerMemberFiles(arg *MembersFormerMemberArg) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersDeleteFormerMemberFilesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2053,13 +2758,19 @@ func (dbx *apiImpl) MembersDeleteFormerMemberFiles(arg *MembersFormerMemberArg) 
 	return
 }
 
+func (dbx *apiImpl) MembersDeleteFormerMemberFiles(arg *MembersFormerMemberArg) (err error) {
+	return dbx.MembersDeleteFormerMemberFilesContext(context.Background(), arg)
+}
+
 // MembersDeleteProfilePhotoAPIError is an error-wrapper for the members/delete_profile_photo route
 type MembersDeleteProfilePhotoAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersDeleteProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersDeleteProfilePhoto(arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfo, err error) {
+// MembersDeleteProfilePhotoContext : Deletes a team member's profile photo.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersDeleteProfilePhotoContext(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfo, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2072,11 +2783,11 @@ func (dbx *apiImpl) MembersDeleteProfilePhoto(arg *MembersDeleteProfilePhotoArg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersDeleteProfilePhotoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2091,13 +2802,19 @@ func (dbx *apiImpl) MembersDeleteProfilePhoto(arg *MembersDeleteProfilePhotoArg)
 	return
 }
 
+func (dbx *apiImpl) MembersDeleteProfilePhoto(arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfo, err error) {
+	return dbx.MembersDeleteProfilePhotoContext(context.Background(), arg)
+}
+
 // MembersDeleteProfilePhotoV2APIError is an error-wrapper for the members/delete_profile_photo_v2 route
 type MembersDeleteProfilePhotoV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersDeleteProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersDeleteProfilePhotoV2(arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
+// MembersDeleteProfilePhotoV2Context : Deletes a team member's profile photo.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersDeleteProfilePhotoV2Context(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2110,11 +2827,11 @@ func (dbx *apiImpl) MembersDeleteProfilePhotoV2(arg *MembersDeleteProfilePhotoAr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersDeleteProfilePhotoV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2129,13 +2846,20 @@ func (dbx *apiImpl) MembersDeleteProfilePhotoV2(arg *MembersDeleteProfilePhotoAr
 	return
 }
 
+func (dbx *apiImpl) MembersDeleteProfilePhotoV2(arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
+	return dbx.MembersDeleteProfilePhotoV2Context(context.Background(), arg)
+}
+
 // MembersGetAvailableTeamMemberRolesAPIError is an error-wrapper for the members/get_available_team_member_roles route
 type MembersGetAvailableTeamMemberRolesAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersGetAvailableTeamMemberRoles() (res *MembersGetAvailableTeamMemberRolesResult, err error) {
+// MembersGetAvailableTeamMemberRolesContext : Get available TeamMemberRoles for
+// the connected team. To be used with `membersSetAdminPermissions`.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersGetAvailableTeamMemberRolesContext(ctx context.Context) (res *MembersGetAvailableTeamMemberRolesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2148,11 +2872,11 @@ func (dbx *apiImpl) MembersGetAvailableTeamMemberRoles() (res *MembersGetAvailab
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersGetAvailableTeamMemberRolesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2167,13 +2891,21 @@ func (dbx *apiImpl) MembersGetAvailableTeamMemberRoles() (res *MembersGetAvailab
 	return
 }
 
+func (dbx *apiImpl) MembersGetAvailableTeamMemberRoles() (res *MembersGetAvailableTeamMemberRolesResult, err error) {
+	return dbx.MembersGetAvailableTeamMemberRolesContext(context.Background())
+}
+
 // MembersGetInfoAPIError is an error-wrapper for the members/get_info route
 type MembersGetInfoAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersGetInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
+// MembersGetInfoContext : Returns information about multiple team members.
+// Permission : Team information This endpoint will return
+// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
+// matched to a valid team member.
+func (dbx *apiImpl) MembersGetInfoContext(ctx context.Context, arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2186,11 +2918,11 @@ func (dbx *apiImpl) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetIn
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersGetInfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2205,13 +2937,21 @@ func (dbx *apiImpl) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetIn
 	return
 }
 
+func (dbx *apiImpl) MembersGetInfo(arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
+	return dbx.MembersGetInfoContext(context.Background(), arg)
+}
+
 // MembersGetInfoV2APIError is an error-wrapper for the members/get_info_v2 route
 type MembersGetInfoV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersGetInfoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersGetInfoV2(arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error) {
+// MembersGetInfoV2Context : Returns information about multiple team members.
+// Permission : Team information This endpoint will return
+// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
+// matched to a valid team member.
+func (dbx *apiImpl) MembersGetInfoV2Context(ctx context.Context, arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2224,11 +2964,11 @@ func (dbx *apiImpl) MembersGetInfoV2(arg *MembersGetInfoV2Arg) (res *MembersGetI
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersGetInfoV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2243,13 +2983,18 @@ func (dbx *apiImpl) MembersGetInfoV2(arg *MembersGetInfoV2Arg) (res *MembersGetI
 	return
 }
 
+func (dbx *apiImpl) MembersGetInfoV2(arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error) {
+	return dbx.MembersGetInfoV2Context(context.Background(), arg)
+}
+
 // MembersListAPIError is an error-wrapper for the members/list route
 type MembersListAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersListError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersList(arg *MembersListArg) (res *MembersListResult, err error) {
+// MembersListContext : Lists members of a team. Permission : Team information.
+func (dbx *apiImpl) MembersListContext(ctx context.Context, arg *MembersListArg) (res *MembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2262,11 +3007,11 @@ func (dbx *apiImpl) MembersList(arg *MembersListArg) (res *MembersListResult, er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2281,13 +3026,18 @@ func (dbx *apiImpl) MembersList(arg *MembersListArg) (res *MembersListResult, er
 	return
 }
 
+func (dbx *apiImpl) MembersList(arg *MembersListArg) (res *MembersListResult, err error) {
+	return dbx.MembersListContext(context.Background(), arg)
+}
+
 // MembersListV2APIError is an error-wrapper for the members/list_v2 route
 type MembersListV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersListError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersListV2(arg *MembersListArg) (res *MembersListV2Result, err error) {
+// MembersListV2Context : Lists members of a team. Permission : Team information.
+func (dbx *apiImpl) MembersListV2Context(ctx context.Context, arg *MembersListArg) (res *MembersListV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2300,11 +3050,11 @@ func (dbx *apiImpl) MembersListV2(arg *MembersListArg) (res *MembersListV2Result
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersListV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2319,13 +3069,20 @@ func (dbx *apiImpl) MembersListV2(arg *MembersListArg) (res *MembersListV2Result
 	return
 }
 
+func (dbx *apiImpl) MembersListV2(arg *MembersListArg) (res *MembersListV2Result, err error) {
+	return dbx.MembersListV2Context(context.Background(), arg)
+}
+
 // MembersListContinueAPIError is an error-wrapper for the members/list/continue route
 type MembersListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersListContinue(arg *MembersListContinueArg) (res *MembersListResult, err error) {
+// MembersListContinueContext : Once a cursor has been retrieved from
+// `membersList`, use this to paginate through all team members. Permission
+// : Team information.
+func (dbx *apiImpl) MembersListContinueContext(ctx context.Context, arg *MembersListContinueArg) (res *MembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2338,11 +3095,11 @@ func (dbx *apiImpl) MembersListContinue(arg *MembersListContinueArg) (res *Membe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2357,13 +3114,20 @@ func (dbx *apiImpl) MembersListContinue(arg *MembersListContinueArg) (res *Membe
 	return
 }
 
+func (dbx *apiImpl) MembersListContinue(arg *MembersListContinueArg) (res *MembersListResult, err error) {
+	return dbx.MembersListContinueContext(context.Background(), arg)
+}
+
 // MembersListContinueV2APIError is an error-wrapper for the members/list/continue_v2 route
 type MembersListContinueV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersListContinueV2(arg *MembersListContinueArg) (res *MembersListV2Result, err error) {
+// MembersListContinueV2Context : Once a cursor has been retrieved from
+// `membersList`, use this to paginate through all team members. Permission
+// : Team information.
+func (dbx *apiImpl) MembersListContinueV2Context(ctx context.Context, arg *MembersListContinueArg) (res *MembersListV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2376,11 +3140,11 @@ func (dbx *apiImpl) MembersListContinueV2(arg *MembersListContinueArg) (res *Mem
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersListContinueV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2395,13 +3159,22 @@ func (dbx *apiImpl) MembersListContinueV2(arg *MembersListContinueArg) (res *Mem
 	return
 }
 
+func (dbx *apiImpl) MembersListContinueV2(arg *MembersListContinueArg) (res *MembersListV2Result, err error) {
+	return dbx.MembersListContinueV2Context(context.Background(), arg)
+}
+
 // MembersMoveFormerMemberFilesAPIError is an error-wrapper for the members/move_former_member_files route
 type MembersMoveFormerMemberFilesAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersTransferFormerMembersFilesError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersMoveFormerMemberFiles(arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error) {
+// MembersMoveFormerMemberFilesContext : Moves removed member's files to a
+// different member. This endpoint initiates an asynchronous job. To obtain
+// the final result of the job, the client should periodically poll
+// `membersMoveFormerMemberFilesJobStatusCheck`. Permission : Team member
+// management.
+func (dbx *apiImpl) MembersMoveFormerMemberFilesContext(ctx context.Context, arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2414,11 +3187,11 @@ func (dbx *apiImpl) MembersMoveFormerMemberFiles(arg *MembersDataTransferArg) (r
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersMoveFormerMemberFilesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2433,13 +3206,20 @@ func (dbx *apiImpl) MembersMoveFormerMemberFiles(arg *MembersDataTransferArg) (r
 	return
 }
 
+func (dbx *apiImpl) MembersMoveFormerMemberFiles(arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error) {
+	return dbx.MembersMoveFormerMemberFilesContext(context.Background(), arg)
+}
+
 // MembersMoveFormerMemberFilesJobStatusCheckAPIError is an error-wrapper for the members/move_former_member_files/job_status/check route
 type MembersMoveFormerMemberFilesJobStatusCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheck(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+// MembersMoveFormerMemberFilesJobStatusCheckContext : Once an async_job_id is
+// returned from `membersMoveFormerMemberFiles` , use this to poll the
+// status of the asynchronous request. Permission : Team member management.
+func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheckContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2452,11 +3232,11 @@ func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheck(arg *async.PollAr
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersMoveFormerMemberFilesJobStatusCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2471,13 +3251,20 @@ func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheck(arg *async.PollAr
 	return
 }
 
+func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheck(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+	return dbx.MembersMoveFormerMemberFilesJobStatusCheckContext(context.Background(), arg)
+}
+
 // MembersRecoverAPIError is an error-wrapper for the members/recover route
 type MembersRecoverAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersRecoverError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRecover(arg *MembersRecoverArg) (err error) {
+// MembersRecoverContext : Recover a deleted member. Permission : Team member
+// management Exactly one of team_member_id, email, or external_id must be
+// provided to identify the user account.
+func (dbx *apiImpl) MembersRecoverContext(ctx context.Context, arg *MembersRecoverArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2490,11 +3277,11 @@ func (dbx *apiImpl) MembersRecover(arg *MembersRecoverArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersRecoverAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2505,13 +3292,31 @@ func (dbx *apiImpl) MembersRecover(arg *MembersRecoverArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) MembersRecover(arg *MembersRecoverArg) (err error) {
+	return dbx.MembersRecoverContext(context.Background(), arg)
+}
+
 // MembersRemoveAPIError is an error-wrapper for the members/remove route
 type MembersRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersRemoveError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
+// MembersRemoveContext : Removes a member from a team. Permission : Team member
+// management Exactly one of team_member_id, email, or external_id must be
+// provided to identify the user account. Accounts can be recovered via
+// `membersRecover` for a 7 day period or until the account has been
+// permanently deleted or transferred to another account (whichever comes
+// first). Calling `membersAdd` while a user is still recoverable on your
+// team will return with `MemberAddResult.user_already_on_team`. Accounts
+// can have their files transferred via the admin console for a limited
+// time, based on the version history length associated with the team (180
+// days for most teams). Accounts can have their stacks transferred through
+// the admin console. This only transfers stacks that they have created.
+// This endpoint may initiate an asynchronous job. To obtain the final
+// result of the job, the client should periodically poll
+// `membersRemoveJobStatusGet`.
+func (dbx *apiImpl) MembersRemoveContext(ctx context.Context, arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2524,11 +3329,11 @@ func (dbx *apiImpl) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmpty
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2543,13 +3348,20 @@ func (dbx *apiImpl) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmpty
 	return
 }
 
+func (dbx *apiImpl) MembersRemove(arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
+	return dbx.MembersRemoveContext(context.Background(), arg)
+}
+
 // MembersRemoveJobStatusGetAPIError is an error-wrapper for the members/remove/job_status/get route
 type MembersRemoveJobStatusGetAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+// MembersRemoveJobStatusGetContext : Once an async_job_id is returned from
+// `membersRemove` , use this to poll the status of the asynchronous
+// request. Permission : Team member management.
+func (dbx *apiImpl) MembersRemoveJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2562,11 +3374,11 @@ func (dbx *apiImpl) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.Po
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersRemoveJobStatusGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2581,13 +3393,21 @@ func (dbx *apiImpl) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.Po
 	return
 }
 
+func (dbx *apiImpl) MembersRemoveJobStatusGet(arg *async.PollArg) (res *async.PollEmptyResult, err error) {
+	return dbx.MembersRemoveJobStatusGetContext(context.Background(), arg)
+}
+
 // MembersSecondaryEmailsAddAPIError is an error-wrapper for the members/secondary_emails/add route
 type MembersSecondaryEmailsAddAPIError struct {
 	dropbox.APIError
 	EndpointError *AddSecondaryEmailsError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSecondaryEmailsAdd(arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error) {
+// MembersSecondaryEmailsAddContext : Add secondary emails to users. Permission :
+// Team member management. Emails that are on verified domains will be
+// verified automatically. For each email address not on a verified domain a
+// verification email will be sent.
+func (dbx *apiImpl) MembersSecondaryEmailsAddContext(ctx context.Context, arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2600,11 +3420,11 @@ func (dbx *apiImpl) MembersSecondaryEmailsAdd(arg *AddSecondaryEmailsArg) (res *
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSecondaryEmailsAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2619,13 +3439,21 @@ func (dbx *apiImpl) MembersSecondaryEmailsAdd(arg *AddSecondaryEmailsArg) (res *
 	return
 }
 
+func (dbx *apiImpl) MembersSecondaryEmailsAdd(arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error) {
+	return dbx.MembersSecondaryEmailsAddContext(context.Background(), arg)
+}
+
 // MembersSecondaryEmailsDeleteAPIError is an error-wrapper for the members/secondary_emails/delete route
 type MembersSecondaryEmailsDeleteAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSecondaryEmailsDelete(arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error) {
+// MembersSecondaryEmailsDeleteContext : Delete secondary emails from users
+// Permission : Team member management. Users will be notified of deletions
+// of verified secondary emails at both the secondary email and their
+// primary email.
+func (dbx *apiImpl) MembersSecondaryEmailsDeleteContext(ctx context.Context, arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2638,11 +3466,11 @@ func (dbx *apiImpl) MembersSecondaryEmailsDelete(arg *DeleteSecondaryEmailsArg) 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSecondaryEmailsDeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2657,13 +3485,19 @@ func (dbx *apiImpl) MembersSecondaryEmailsDelete(arg *DeleteSecondaryEmailsArg) 
 	return
 }
 
+func (dbx *apiImpl) MembersSecondaryEmailsDelete(arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error) {
+	return dbx.MembersSecondaryEmailsDeleteContext(context.Background(), arg)
+}
+
 // MembersSecondaryEmailsResendVerificationEmailsAPIError is an error-wrapper for the members/secondary_emails/resend_verification_emails route
 type MembersSecondaryEmailsResendVerificationEmailsAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmails(arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error) {
+// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary email
+// verification emails. Permission : Team member management.
+func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmailsContext(ctx context.Context, arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2676,11 +3510,11 @@ func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmails(arg *ResendVe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSecondaryEmailsResendVerificationEmailsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2695,13 +3529,21 @@ func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmails(arg *ResendVe
 	return
 }
 
+func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmails(arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error) {
+	return dbx.MembersSecondaryEmailsResendVerificationEmailsContext(context.Background(), arg)
+}
+
 // MembersSendWelcomeEmailAPIError is an error-wrapper for the members/send_welcome_email route
 type MembersSendWelcomeEmailAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersSendWelcomeError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
+// MembersSendWelcomeEmailContext : Sends welcome email to pending team member.
+// Permission : Team member management Exactly one of team_member_id, email,
+// or external_id must be provided to identify the user account. No-op if
+// team member is not pending.
+func (dbx *apiImpl) MembersSendWelcomeEmailContext(ctx context.Context, arg *UserSelectorArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2714,11 +3556,11 @@ func (dbx *apiImpl) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSendWelcomeEmailAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2729,13 +3571,19 @@ func (dbx *apiImpl) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) MembersSendWelcomeEmail(arg *UserSelectorArg) (err error) {
+	return dbx.MembersSendWelcomeEmailContext(context.Background(), arg)
+}
+
 // MembersSetAdminPermissionsAPIError is an error-wrapper for the members/set_admin_permissions route
 type MembersSetAdminPermissionsAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetPermissionsError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error) {
+// MembersSetAdminPermissionsContext : Updates a team member's permissions.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersSetAdminPermissionsContext(ctx context.Context, arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2748,11 +3596,11 @@ func (dbx *apiImpl) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (r
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetAdminPermissionsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2767,13 +3615,19 @@ func (dbx *apiImpl) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (r
 	return
 }
 
+func (dbx *apiImpl) MembersSetAdminPermissions(arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error) {
+	return dbx.MembersSetAdminPermissionsContext(context.Background(), arg)
+}
+
 // MembersSetAdminPermissionsV2APIError is an error-wrapper for the members/set_admin_permissions_v2 route
 type MembersSetAdminPermissionsV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetPermissions2Error `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetAdminPermissionsV2(arg *MembersSetPermissions2Arg) (res *MembersSetPermissions2Result, err error) {
+// MembersSetAdminPermissionsV2Context : Updates a team member's permissions.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersSetAdminPermissionsV2Context(ctx context.Context, arg *MembersSetPermissions2Arg) (res *MembersSetPermissions2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2786,11 +3640,11 @@ func (dbx *apiImpl) MembersSetAdminPermissionsV2(arg *MembersSetPermissions2Arg)
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetAdminPermissionsV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2805,13 +3659,19 @@ func (dbx *apiImpl) MembersSetAdminPermissionsV2(arg *MembersSetPermissions2Arg)
 	return
 }
 
+func (dbx *apiImpl) MembersSetAdminPermissionsV2(arg *MembersSetPermissions2Arg) (res *MembersSetPermissions2Result, err error) {
+	return dbx.MembersSetAdminPermissionsV2Context(context.Background(), arg)
+}
+
 // MembersSetProfileAPIError is an error-wrapper for the members/set_profile route
 type MembersSetProfileAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetProfileError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMemberInfo, err error) {
+// MembersSetProfileContext : Updates a team member's profile. Permission : Team
+// member management.
+func (dbx *apiImpl) MembersSetProfileContext(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfo, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2824,11 +3684,11 @@ func (dbx *apiImpl) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMembe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetProfileAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2843,13 +3703,19 @@ func (dbx *apiImpl) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMembe
 	return
 }
 
+func (dbx *apiImpl) MembersSetProfile(arg *MembersSetProfileArg) (res *TeamMemberInfo, err error) {
+	return dbx.MembersSetProfileContext(context.Background(), arg)
+}
+
 // MembersSetProfileV2APIError is an error-wrapper for the members/set_profile_v2 route
 type MembersSetProfileV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetProfileError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetProfileV2(arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error) {
+// MembersSetProfileV2Context : Updates a team member's profile. Permission : Team
+// member management.
+func (dbx *apiImpl) MembersSetProfileV2Context(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2862,11 +3728,11 @@ func (dbx *apiImpl) MembersSetProfileV2(arg *MembersSetProfileArg) (res *TeamMem
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetProfileV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2881,13 +3747,19 @@ func (dbx *apiImpl) MembersSetProfileV2(arg *MembersSetProfileArg) (res *TeamMem
 	return
 }
 
+func (dbx *apiImpl) MembersSetProfileV2(arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error) {
+	return dbx.MembersSetProfileV2Context(context.Background(), arg)
+}
+
 // MembersSetProfilePhotoAPIError is an error-wrapper for the members/set_profile_photo route
 type MembersSetProfilePhotoAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetProfilePhoto(arg *MembersSetProfilePhotoArg) (res *TeamMemberInfo, err error) {
+// MembersSetProfilePhotoContext : Updates a team member's profile photo.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersSetProfilePhotoContext(ctx context.Context, arg *MembersSetProfilePhotoArg) (res *TeamMemberInfo, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2900,11 +3772,11 @@ func (dbx *apiImpl) MembersSetProfilePhoto(arg *MembersSetProfilePhotoArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetProfilePhotoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2919,13 +3791,19 @@ func (dbx *apiImpl) MembersSetProfilePhoto(arg *MembersSetProfilePhotoArg) (res 
 	return
 }
 
+func (dbx *apiImpl) MembersSetProfilePhoto(arg *MembersSetProfilePhotoArg) (res *TeamMemberInfo, err error) {
+	return dbx.MembersSetProfilePhotoContext(context.Background(), arg)
+}
+
 // MembersSetProfilePhotoV2APIError is an error-wrapper for the members/set_profile_photo_v2 route
 type MembersSetProfilePhotoV2APIError struct {
 	dropbox.APIError
 	EndpointError *MembersSetProfilePhotoError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSetProfilePhotoV2(arg *MembersSetProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
+// MembersSetProfilePhotoV2Context : Updates a team member's profile photo.
+// Permission : Team member management.
+func (dbx *apiImpl) MembersSetProfilePhotoV2Context(ctx context.Context, arg *MembersSetProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2938,11 +3816,11 @@ func (dbx *apiImpl) MembersSetProfilePhotoV2(arg *MembersSetProfilePhotoArg) (re
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSetProfilePhotoV2APIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2957,13 +3835,20 @@ func (dbx *apiImpl) MembersSetProfilePhotoV2(arg *MembersSetProfilePhotoArg) (re
 	return
 }
 
+func (dbx *apiImpl) MembersSetProfilePhotoV2(arg *MembersSetProfilePhotoArg) (res *TeamMemberInfoV2Result, err error) {
+	return dbx.MembersSetProfilePhotoV2Context(context.Background(), arg)
+}
+
 // MembersSuspendAPIError is an error-wrapper for the members/suspend route
 type MembersSuspendAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersSuspendError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersSuspend(arg *MembersDeactivateArg) (err error) {
+// MembersSuspendContext : Suspend a member from a team. Permission : Team member
+// management Exactly one of team_member_id, email, or external_id must be
+// provided to identify the user account.
+func (dbx *apiImpl) MembersSuspendContext(ctx context.Context, arg *MembersDeactivateArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -2976,11 +3861,11 @@ func (dbx *apiImpl) MembersSuspend(arg *MembersDeactivateArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersSuspendAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -2991,13 +3876,20 @@ func (dbx *apiImpl) MembersSuspend(arg *MembersDeactivateArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) MembersSuspend(arg *MembersDeactivateArg) (err error) {
+	return dbx.MembersSuspendContext(context.Background(), arg)
+}
+
 // MembersUnsuspendAPIError is an error-wrapper for the members/unsuspend route
 type MembersUnsuspendAPIError struct {
 	dropbox.APIError
 	EndpointError *MembersUnsuspendError `json:"error"`
 }
 
-func (dbx *apiImpl) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
+// MembersUnsuspendContext : Unsuspend a member from a team. Permission : Team
+// member management Exactly one of team_member_id, email, or external_id
+// must be provided to identify the user account.
+func (dbx *apiImpl) MembersUnsuspendContext(ctx context.Context, arg *MembersUnsuspendArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3010,11 +3902,11 @@ func (dbx *apiImpl) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr MembersUnsuspendAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3025,13 +3917,23 @@ func (dbx *apiImpl) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
 	return
 }
 
+func (dbx *apiImpl) MembersUnsuspend(arg *MembersUnsuspendArg) (err error) {
+	return dbx.MembersUnsuspendContext(context.Background(), arg)
+}
+
 // NamespacesListAPIError is an error-wrapper for the namespaces/list route
 type NamespacesListAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamNamespacesListError `json:"error"`
 }
 
-func (dbx *apiImpl) NamespacesList(arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error) {
+// NamespacesListContext : Returns a list of all team-accessible namespaces. This
+// list includes team folders, shared folders containing team members, team
+// members' home namespaces, and team members' app folders. Home namespaces
+// and app folders are always owned by this team or members of the team, but
+// shared folders may be owned by other users or other teams. Duplicates may
+// occur in the list.
+func (dbx *apiImpl) NamespacesListContext(ctx context.Context, arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3044,11 +3946,11 @@ func (dbx *apiImpl) NamespacesList(arg *TeamNamespacesListArg) (res *TeamNamespa
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr NamespacesListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3063,13 +3965,20 @@ func (dbx *apiImpl) NamespacesList(arg *TeamNamespacesListArg) (res *TeamNamespa
 	return
 }
 
+func (dbx *apiImpl) NamespacesList(arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error) {
+	return dbx.NamespacesListContext(context.Background(), arg)
+}
+
 // NamespacesListContinueAPIError is an error-wrapper for the namespaces/list/continue route
 type NamespacesListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamNamespacesListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) NamespacesListContinue(arg *TeamNamespacesListContinueArg) (res *TeamNamespacesListResult, err error) {
+// NamespacesListContinueContext : Once a cursor has been retrieved from
+// `namespacesList`, use this to paginate through all team-accessible
+// namespaces. Duplicates may occur in the list.
+func (dbx *apiImpl) NamespacesListContinueContext(ctx context.Context, arg *TeamNamespacesListContinueArg) (res *TeamNamespacesListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3082,11 +3991,11 @@ func (dbx *apiImpl) NamespacesListContinue(arg *TeamNamespacesListContinueArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr NamespacesListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3101,13 +4010,19 @@ func (dbx *apiImpl) NamespacesListContinue(arg *TeamNamespacesListContinueArg) (
 	return
 }
 
+func (dbx *apiImpl) NamespacesListContinue(arg *TeamNamespacesListContinueArg) (res *TeamNamespacesListResult, err error) {
+	return dbx.NamespacesListContinueContext(context.Background(), arg)
+}
+
 // PropertiesTemplateAddAPIError is an error-wrapper for the properties/template/add route
 type PropertiesTemplateAddAPIError struct {
 	dropbox.APIError
 	EndpointError *file_properties.ModifyTemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateAdd(arg *file_properties.AddTemplateArg) (res *file_properties.AddTemplateResult, err error) {
+// PropertiesTemplateAddContext : Permission : Team member file access.
+// Deprecated:
+func (dbx *apiImpl) PropertiesTemplateAddContext(ctx context.Context, arg *file_properties.AddTemplateArg) (res *file_properties.AddTemplateResult, err error) {
 	log.Printf("WARNING: API `PropertiesTemplateAdd` is deprecated")
 
 	req := dropbox.Request{
@@ -3122,11 +4037,11 @@ func (dbx *apiImpl) PropertiesTemplateAdd(arg *file_properties.AddTemplateArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesTemplateAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3141,13 +4056,20 @@ func (dbx *apiImpl) PropertiesTemplateAdd(arg *file_properties.AddTemplateArg) (
 	return
 }
 
+func (dbx *apiImpl) PropertiesTemplateAdd(arg *file_properties.AddTemplateArg) (res *file_properties.AddTemplateResult, err error) {
+	return dbx.PropertiesTemplateAddContext(context.Background(), arg)
+}
+
 // PropertiesTemplateGetAPIError is an error-wrapper for the properties/template/get route
 type PropertiesTemplateGetAPIError struct {
 	dropbox.APIError
 	EndpointError *file_properties.TemplateError `json:"error"`
 }
 
-func (dbx *apiImpl) PropertiesTemplateGet(arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error) {
+// PropertiesTemplateGetContext : Permission : Team member file access. The scope
+// for the route is files.team_metadata.write.
+// Deprecated:
+func (dbx *apiImpl) PropertiesTemplateGetContext(ctx context.Context, arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error) {
 	log.Printf("WARNING: API `PropertiesTemplateGet` is deprecated")
 
 	req := dropbox.Request{
@@ -3162,11 +4084,11 @@ func (dbx *apiImpl) PropertiesTemplateGet(arg *file_properties.GetTemplateArg) (
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr PropertiesTemplateGetAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3181,13 +4103,20 @@ func (dbx *apiImpl) PropertiesTemplateGet(arg *file_properties.GetTemplateArg) (
 	return
 }
 
+func (dbx *apiImpl) PropertiesTemplateGet(arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error) {
+	return dbx.PropertiesTemplateGetContext(context.Background(), arg)
+}
+
 // ReportsGetActivityAPIError is an error-wrapper for the reports/get_activity route
 type ReportsGetActivityAPIError struct {
 	dropbox.APIError
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, err error) {
+// ReportsGetActivityContext : Retrieves reporting data about a team's user
+// activity. Deprecated: Will be removed on July 1st 2021.
+// Deprecated:
+func (dbx *apiImpl) ReportsGetActivityContext(ctx context.Context, arg *DateRange) (res *GetActivityReport, err error) {
 	log.Printf("WARNING: API `ReportsGetActivity` is deprecated")
 
 	req := dropbox.Request{
@@ -3202,11 +4131,11 @@ func (dbx *apiImpl) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ReportsGetActivityAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3221,13 +4150,20 @@ func (dbx *apiImpl) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, 
 	return
 }
 
+func (dbx *apiImpl) ReportsGetActivity(arg *DateRange) (res *GetActivityReport, err error) {
+	return dbx.ReportsGetActivityContext(context.Background(), arg)
+}
+
 // ReportsGetDevicesAPIError is an error-wrapper for the reports/get_devices route
 type ReportsGetDevicesAPIError struct {
 	dropbox.APIError
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, err error) {
+// ReportsGetDevicesContext : Retrieves reporting data about a team's linked
+// devices. Deprecated: Will be removed on July 1st 2021.
+// Deprecated:
+func (dbx *apiImpl) ReportsGetDevicesContext(ctx context.Context, arg *DateRange) (res *GetDevicesReport, err error) {
 	log.Printf("WARNING: API `ReportsGetDevices` is deprecated")
 
 	req := dropbox.Request{
@@ -3242,11 +4178,11 @@ func (dbx *apiImpl) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ReportsGetDevicesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3261,13 +4197,20 @@ func (dbx *apiImpl) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, er
 	return
 }
 
+func (dbx *apiImpl) ReportsGetDevices(arg *DateRange) (res *GetDevicesReport, err error) {
+	return dbx.ReportsGetDevicesContext(context.Background(), arg)
+}
+
 // ReportsGetMembershipAPIError is an error-wrapper for the reports/get_membership route
 type ReportsGetMembershipAPIError struct {
 	dropbox.APIError
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetMembership(arg *DateRange) (res *GetMembershipReport, err error) {
+// ReportsGetMembershipContext : Retrieves reporting data about a team's
+// membership. Deprecated: Will be removed on July 1st 2021.
+// Deprecated:
+func (dbx *apiImpl) ReportsGetMembershipContext(ctx context.Context, arg *DateRange) (res *GetMembershipReport, err error) {
 	log.Printf("WARNING: API `ReportsGetMembership` is deprecated")
 
 	req := dropbox.Request{
@@ -3282,11 +4225,11 @@ func (dbx *apiImpl) ReportsGetMembership(arg *DateRange) (res *GetMembershipRepo
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ReportsGetMembershipAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3301,13 +4244,20 @@ func (dbx *apiImpl) ReportsGetMembership(arg *DateRange) (res *GetMembershipRepo
 	return
 }
 
+func (dbx *apiImpl) ReportsGetMembership(arg *DateRange) (res *GetMembershipReport, err error) {
+	return dbx.ReportsGetMembershipContext(context.Background(), arg)
+}
+
 // ReportsGetStorageAPIError is an error-wrapper for the reports/get_storage route
 type ReportsGetStorageAPIError struct {
 	dropbox.APIError
 	EndpointError *DateRangeError `json:"error"`
 }
 
-func (dbx *apiImpl) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, err error) {
+// ReportsGetStorageContext : Retrieves reporting data about a team's storage
+// usage. Deprecated: Will be removed on July 1st 2021.
+// Deprecated:
+func (dbx *apiImpl) ReportsGetStorageContext(ctx context.Context, arg *DateRange) (res *GetStorageReport, err error) {
 	log.Printf("WARNING: API `ReportsGetStorage` is deprecated")
 
 	req := dropbox.Request{
@@ -3322,11 +4272,11 @@ func (dbx *apiImpl) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, er
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr ReportsGetStorageAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3341,13 +4291,23 @@ func (dbx *apiImpl) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, er
 	return
 }
 
+func (dbx *apiImpl) ReportsGetStorage(arg *DateRange) (res *GetStorageReport, err error) {
+	return dbx.ReportsGetStorageContext(context.Background(), arg)
+}
+
 // SharingAllowlistAddAPIError is an error-wrapper for the sharing_allowlist/add route
 type SharingAllowlistAddAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingAllowlistAddError `json:"error"`
 }
 
-func (dbx *apiImpl) SharingAllowlistAdd(arg *SharingAllowlistAddArgs) (res *SharingAllowlistAddResponse, err error) {
+// SharingAllowlistAddContext : Endpoint adds Approve List entries. Changes are
+// effective immediately. Changes are committed in transaction. In case of
+// single validation error - all entries are rejected. Valid domains
+// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Added entries cannot
+// overflow limit of 10000 entries per team. Maximum 100 entries per call is
+// allowed.
+func (dbx *apiImpl) SharingAllowlistAddContext(ctx context.Context, arg *SharingAllowlistAddArgs) (res *SharingAllowlistAddResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3360,11 +4320,11 @@ func (dbx *apiImpl) SharingAllowlistAdd(arg *SharingAllowlistAddArgs) (res *Shar
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SharingAllowlistAddAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3379,13 +4339,22 @@ func (dbx *apiImpl) SharingAllowlistAdd(arg *SharingAllowlistAddArgs) (res *Shar
 	return
 }
 
+func (dbx *apiImpl) SharingAllowlistAdd(arg *SharingAllowlistAddArgs) (res *SharingAllowlistAddResponse, err error) {
+	return dbx.SharingAllowlistAddContext(context.Background(), arg)
+}
+
 // SharingAllowlistListAPIError is an error-wrapper for the sharing_allowlist/list route
 type SharingAllowlistListAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingAllowlistListError `json:"error"`
 }
 
-func (dbx *apiImpl) SharingAllowlistList(arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error) {
+// SharingAllowlistListContext : Lists Approve List entries for given team, from
+// newest to oldest, returning up to `limit` entries at a time. If there are
+// more than `limit` entries associated with the current team, more can be
+// fetched by passing the returned `cursor` to
+// `sharingAllowlistListContinue`.
+func (dbx *apiImpl) SharingAllowlistListContext(ctx context.Context, arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3398,11 +4367,11 @@ func (dbx *apiImpl) SharingAllowlistList(arg *SharingAllowlistListArg) (res *Sha
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SharingAllowlistListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3417,13 +4386,19 @@ func (dbx *apiImpl) SharingAllowlistList(arg *SharingAllowlistListArg) (res *Sha
 	return
 }
 
+func (dbx *apiImpl) SharingAllowlistList(arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error) {
+	return dbx.SharingAllowlistListContext(context.Background(), arg)
+}
+
 // SharingAllowlistListContinueAPIError is an error-wrapper for the sharing_allowlist/list/continue route
 type SharingAllowlistListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingAllowlistListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) SharingAllowlistListContinue(arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error) {
+// SharingAllowlistListContinueContext : Lists entries associated with given team,
+// starting from a the cursor. See `sharingAllowlistList`.
+func (dbx *apiImpl) SharingAllowlistListContinueContext(ctx context.Context, arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3436,11 +4411,11 @@ func (dbx *apiImpl) SharingAllowlistListContinue(arg *SharingAllowlistListContin
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SharingAllowlistListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3455,13 +4430,23 @@ func (dbx *apiImpl) SharingAllowlistListContinue(arg *SharingAllowlistListContin
 	return
 }
 
+func (dbx *apiImpl) SharingAllowlistListContinue(arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error) {
+	return dbx.SharingAllowlistListContinueContext(context.Background(), arg)
+}
+
 // SharingAllowlistRemoveAPIError is an error-wrapper for the sharing_allowlist/remove route
 type SharingAllowlistRemoveAPIError struct {
 	dropbox.APIError
 	EndpointError *SharingAllowlistRemoveError `json:"error"`
 }
 
-func (dbx *apiImpl) SharingAllowlistRemove(arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error) {
+// SharingAllowlistRemoveContext : Endpoint removes Approve List entries. Changes
+// are effective immediately. Changes are committed in transaction. In case
+// of single validation error - all entries are rejected. Valid domains
+// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries being
+// removed have to be present on the list. Maximum 1000 entries per call is
+// allowed.
+func (dbx *apiImpl) SharingAllowlistRemoveContext(ctx context.Context, arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3474,11 +4459,11 @@ func (dbx *apiImpl) SharingAllowlistRemove(arg *SharingAllowlistRemoveArgs) (res
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr SharingAllowlistRemoveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3493,13 +4478,19 @@ func (dbx *apiImpl) SharingAllowlistRemove(arg *SharingAllowlistRemoveArgs) (res
 	return
 }
 
+func (dbx *apiImpl) SharingAllowlistRemove(arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error) {
+	return dbx.SharingAllowlistRemoveContext(context.Background(), arg)
+}
+
 // TeamFolderActivateAPIError is an error-wrapper for the team_folder/activate route
 type TeamFolderActivateAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderActivateError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
+// TeamFolderActivateContext : Sets an archived team folder's status to active.
+// Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderActivateContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3512,11 +4503,11 @@ func (dbx *apiImpl) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMet
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderActivateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3531,13 +4522,23 @@ func (dbx *apiImpl) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMet
 	return
 }
 
+func (dbx *apiImpl) TeamFolderActivate(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
+	return dbx.TeamFolderActivateContext(context.Background(), arg)
+}
+
 // TeamFolderArchiveAPIError is an error-wrapper for the team_folder/archive route
 type TeamFolderArchiveAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderArchiveError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
+// TeamFolderArchiveContext : Sets an active team folder's status to archived and
+// removes all folder and file members. This endpoint cannot be used for
+// teams that have a shared team space. This route will either finish
+// synchronously, or return a job ID and do the async archive job in
+// background. Please use team_folder/archive/check to check the job status.
+// Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderArchiveContext(ctx context.Context, arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3550,11 +4551,11 @@ func (dbx *apiImpl) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolde
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderArchiveAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3569,13 +4570,24 @@ func (dbx *apiImpl) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolde
 	return
 }
 
+func (dbx *apiImpl) TeamFolderArchive(arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
+	return dbx.TeamFolderArchiveContext(context.Background(), arg)
+}
+
 // TeamFolderArchiveCheckAPIError is an error-wrapper for the team_folder/archive/check route
 type TeamFolderArchiveCheckAPIError struct {
 	dropbox.APIError
 	EndpointError *async.PollError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
+// TeamFolderArchiveCheckContext : Returns the status of an asynchronous job for
+// archiving a team folder. The job may show '.tag' as complete, but the
+// team folder could still be in the process of archiving (indicated by
+// `TeamFolderMetadata.status` with 'archive_in_progress'). To confirm that
+// the team folder is fully archived, check the field
+// `TeamFolderMetadata.status` in the response for the value 'archived'.
+// Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderArchiveCheckContext(ctx context.Context, arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3588,11 +4600,11 @@ func (dbx *apiImpl) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderA
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderArchiveCheckAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3607,13 +4619,20 @@ func (dbx *apiImpl) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderA
 	return
 }
 
+func (dbx *apiImpl) TeamFolderArchiveCheck(arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
+	return dbx.TeamFolderArchiveCheckContext(context.Background(), arg)
+}
+
 // TeamFolderCreateAPIError is an error-wrapper for the team_folder/create route
 type TeamFolderCreateAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderCreateError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
+// TeamFolderCreateContext : Creates a new, active, team folder with no members.
+// This endpoint can only be used for teams that do not already have a
+// shared team space. Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderCreateContext(ctx context.Context, arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3626,11 +4645,11 @@ func (dbx *apiImpl) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderM
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderCreateAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3645,13 +4664,19 @@ func (dbx *apiImpl) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderM
 	return
 }
 
+func (dbx *apiImpl) TeamFolderCreate(arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
+	return dbx.TeamFolderCreateContext(context.Background(), arg)
+}
+
 // TeamFolderGetInfoAPIError is an error-wrapper for the team_folder/get_info route
 type TeamFolderGetInfoAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error) {
+// TeamFolderGetInfoContext : Retrieves metadata for team folders. Permission :
+// Team member file access.
+func (dbx *apiImpl) TeamFolderGetInfoContext(ctx context.Context, arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3664,11 +4689,11 @@ func (dbx *apiImpl) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFold
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderGetInfoAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3683,13 +4708,19 @@ func (dbx *apiImpl) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFold
 	return
 }
 
+func (dbx *apiImpl) TeamFolderGetInfo(arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error) {
+	return dbx.TeamFolderGetInfoContext(context.Background(), arg)
+}
+
 // TeamFolderListAPIError is an error-wrapper for the team_folder/list route
 type TeamFolderListAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderListError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListResult, err error) {
+// TeamFolderListContext : Lists all team folders. Permission : Team member file
+// access.
+func (dbx *apiImpl) TeamFolderListContext(ctx context.Context, arg *TeamFolderListArg) (res *TeamFolderListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3702,11 +4733,11 @@ func (dbx *apiImpl) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListR
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderListAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3721,13 +4752,20 @@ func (dbx *apiImpl) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListR
 	return
 }
 
+func (dbx *apiImpl) TeamFolderList(arg *TeamFolderListArg) (res *TeamFolderListResult, err error) {
+	return dbx.TeamFolderListContext(context.Background(), arg)
+}
+
 // TeamFolderListContinueAPIError is an error-wrapper for the team_folder/list/continue route
 type TeamFolderListContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderListContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderListContinue(arg *TeamFolderListContinueArg) (res *TeamFolderListResult, err error) {
+// TeamFolderListContinueContext : Once a cursor has been retrieved from
+// `teamFolderList`, use this to paginate through all team folders.
+// Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderListContinueContext(ctx context.Context, arg *TeamFolderListContinueArg) (res *TeamFolderListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3740,11 +4778,11 @@ func (dbx *apiImpl) TeamFolderListContinue(arg *TeamFolderListContinueArg) (res 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderListContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3759,13 +4797,20 @@ func (dbx *apiImpl) TeamFolderListContinue(arg *TeamFolderListContinueArg) (res 
 	return
 }
 
+func (dbx *apiImpl) TeamFolderListContinue(arg *TeamFolderListContinueArg) (res *TeamFolderListResult, err error) {
+	return dbx.TeamFolderListContinueContext(context.Background(), arg)
+}
+
 // TeamFolderPermanentlyDeleteAPIError is an error-wrapper for the team_folder/permanently_delete route
 type TeamFolderPermanentlyDeleteAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderPermanentlyDeleteError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error) {
+// TeamFolderPermanentlyDeleteContext : Permanently deletes an archived team
+// folder. This endpoint cannot be used for teams that have a shared team
+// space. Permission : Team member file access.
+func (dbx *apiImpl) TeamFolderPermanentlyDeleteContext(ctx context.Context, arg *TeamFolderIdArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3778,11 +4823,11 @@ func (dbx *apiImpl) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderPermanentlyDeleteAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3793,13 +4838,19 @@ func (dbx *apiImpl) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error
 	return
 }
 
+func (dbx *apiImpl) TeamFolderPermanentlyDelete(arg *TeamFolderIdArg) (err error) {
+	return dbx.TeamFolderPermanentlyDeleteContext(context.Background(), arg)
+}
+
 // TeamFolderRenameAPIError is an error-wrapper for the team_folder/rename route
 type TeamFolderRenameAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderRenameError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error) {
+// TeamFolderRenameContext : Changes an active team folder's name. Permission :
+// Team member file access.
+func (dbx *apiImpl) TeamFolderRenameContext(ctx context.Context, arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3812,11 +4863,11 @@ func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderM
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderRenameAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3831,13 +4882,19 @@ func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderM
 	return
 }
 
+func (dbx *apiImpl) TeamFolderRename(arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error) {
+	return dbx.TeamFolderRenameContext(context.Background(), arg)
+}
+
 // TeamFolderRestoreAPIError is an error-wrapper for the team_folder/restore route
 type TeamFolderRestoreAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderRestoreError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderRestore(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
+// TeamFolderRestoreContext : Sets an inactive team folder's status to active.
+// Permission: Team member file access.
+func (dbx *apiImpl) TeamFolderRestoreContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3850,11 +4907,11 @@ func (dbx *apiImpl) TeamFolderRestore(arg *TeamFolderIdArg) (res *TeamFolderMeta
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderRestoreAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3869,13 +4926,20 @@ func (dbx *apiImpl) TeamFolderRestore(arg *TeamFolderIdArg) (res *TeamFolderMeta
 	return
 }
 
+func (dbx *apiImpl) TeamFolderRestore(arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error) {
+	return dbx.TeamFolderRestoreContext(context.Background(), arg)
+}
+
 // TeamFolderUpdateSyncSettingsAPIError is an error-wrapper for the team_folder/update_sync_settings route
 type TeamFolderUpdateSyncSettingsAPIError struct {
 	dropbox.APIError
 	EndpointError *TeamFolderUpdateSyncSettingsError `json:"error"`
 }
 
-func (dbx *apiImpl) TeamFolderUpdateSyncSettings(arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error) {
+// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team folder
+// or its contents.  Use of this endpoint requires that the team has team
+// selective sync enabled.
+func (dbx *apiImpl) TeamFolderUpdateSyncSettingsContext(ctx context.Context, arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3888,11 +4952,11 @@ func (dbx *apiImpl) TeamFolderUpdateSyncSettings(arg *TeamFolderUpdateSyncSettin
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TeamFolderUpdateSyncSettingsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3907,13 +4971,19 @@ func (dbx *apiImpl) TeamFolderUpdateSyncSettings(arg *TeamFolderUpdateSyncSettin
 	return
 }
 
+func (dbx *apiImpl) TeamFolderUpdateSyncSettings(arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error) {
+	return dbx.TeamFolderUpdateSyncSettingsContext(context.Background(), arg)
+}
+
 // TokenGetAuthenticatedAdminAPIError is an error-wrapper for the token/get_authenticated_admin route
 type TokenGetAuthenticatedAdminAPIError struct {
 	dropbox.APIError
 	EndpointError *TokenGetAuthenticatedAdminError `json:"error"`
 }
 
-func (dbx *apiImpl) TokenGetAuthenticatedAdmin() (res *TokenGetAuthenticatedAdminResult, err error) {
+// TokenGetAuthenticatedAdminContext : Returns the member profile of the admin who
+// generated the team access token used to make the call.
+func (dbx *apiImpl) TokenGetAuthenticatedAdminContext(ctx context.Context) (res *TokenGetAuthenticatedAdminResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team",
@@ -3926,11 +4996,11 @@ func (dbx *apiImpl) TokenGetAuthenticatedAdmin() (res *TokenGetAuthenticatedAdmi
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr TokenGetAuthenticatedAdminAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -3945,8 +5015,17 @@ func (dbx *apiImpl) TokenGetAuthenticatedAdmin() (res *TokenGetAuthenticatedAdmi
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) TokenGetAuthenticatedAdmin() (res *TokenGetAuthenticatedAdminResult, err error) {
+	return dbx.TokenGetAuthenticatedAdminContext(context.Background())
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/team_log/client.go
+++ b/v6/dropbox/team_log/client.go
@@ -21,7 +21,9 @@
 package team_log
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -46,6 +48,25 @@ type Client interface {
 	GetEventsContinue(arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// GetEventsContext : Retrieves team events. If the result's
+	// `GetTeamEventsResult.has_more` field is true, call `getEventsContinue`
+	// with the returned cursor to retrieve more entries. If end_time is not
+	// specified in your request, you may use the returned cursor to poll
+	// `getEventsContinue` for new events. Many attributes note 'may be missing
+	// due to historical data gap'. Note that the file_operations category and &
+	// analogous paper events are not available on all Dropbox Business `plans`
+	// </business/plans-comparison>. Use `features/get_values`
+	// </developers/documentation/http/teams#team-features-get_values> to check
+	// for this feature. Permission : Team Auditing.
+	GetEventsContext(ctx context.Context, arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error)
+	// GetEventsContinueContext : Once a cursor has been retrieved from `getEvents`,
+	// use this to paginate through all events. Permission : Team Auditing.
+	GetEventsContinueContext(ctx context.Context, arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error)
+}
+
 type apiImpl dropbox.Context
 
 // GetEventsAPIError is an error-wrapper for the get_events route
@@ -54,7 +75,17 @@ type GetEventsAPIError struct {
 	EndpointError *GetTeamEventsError `json:"error"`
 }
 
-func (dbx *apiImpl) GetEvents(arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error) {
+// GetEventsContext : Retrieves team events. If the result's
+// `GetTeamEventsResult.has_more` field is true, call `getEventsContinue`
+// with the returned cursor to retrieve more entries. If end_time is not
+// specified in your request, you may use the returned cursor to poll
+// `getEventsContinue` for new events. Many attributes note 'may be missing
+// due to historical data gap'. Note that the file_operations category and &
+// analogous paper events are not available on all Dropbox Business `plans`
+// </business/plans-comparison>. Use `features/get_values`
+// </developers/documentation/http/teams#team-features-get_values> to check
+// for this feature. Permission : Team Auditing.
+func (dbx *apiImpl) GetEventsContext(ctx context.Context, arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team_log",
@@ -67,11 +98,11 @@ func (dbx *apiImpl) GetEvents(arg *GetTeamEventsArg) (res *GetTeamEventsResult, 
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetEventsAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -86,13 +117,19 @@ func (dbx *apiImpl) GetEvents(arg *GetTeamEventsArg) (res *GetTeamEventsResult, 
 	return
 }
 
+func (dbx *apiImpl) GetEvents(arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error) {
+	return dbx.GetEventsContext(context.Background(), arg)
+}
+
 // GetEventsContinueAPIError is an error-wrapper for the get_events/continue route
 type GetEventsContinueAPIError struct {
 	dropbox.APIError
 	EndpointError *GetTeamEventsContinueError `json:"error"`
 }
 
-func (dbx *apiImpl) GetEventsContinue(arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error) {
+// GetEventsContinueContext : Once a cursor has been retrieved from `getEvents`,
+// use this to paginate through all events. Permission : Team Auditing.
+func (dbx *apiImpl) GetEventsContinueContext(ctx context.Context, arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "team_log",
@@ -105,11 +142,11 @@ func (dbx *apiImpl) GetEventsContinue(arg *GetTeamEventsContinueArg) (res *GetTe
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetEventsContinueAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -124,8 +161,17 @@ func (dbx *apiImpl) GetEventsContinue(arg *GetTeamEventsContinueArg) (res *GetTe
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) GetEventsContinue(arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error) {
+	return dbx.GetEventsContinueContext(context.Background(), arg)
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }

--- a/v6/dropbox/users/client.go
+++ b/v6/dropbox/users/client.go
@@ -21,7 +21,9 @@
 package users
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
@@ -45,6 +47,24 @@ type Client interface {
 	GetSpaceUsage() (res *SpaceUsage, err error)
 }
 
+// ContextClient interface describes all routes in this namespace with context support
+type ContextClient interface {
+	Client
+	// FeaturesGetValuesContext : Get a list of feature values that may be configured
+	// for the current account.
+	FeaturesGetValuesContext(ctx context.Context, arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error)
+	// GetAccountContext : Get information about a user's account.
+	GetAccountContext(ctx context.Context, arg *GetAccountArg) (res *BasicAccount, err error)
+	// GetAccountBatchContext : Get information about multiple user accounts. At most
+	// 300 accounts may be queried per request.
+	GetAccountBatchContext(ctx context.Context, arg *GetAccountBatchArg) (res []*BasicAccount, err error)
+	// GetCurrentAccountContext : Get information about the current user's account.
+	GetCurrentAccountContext(ctx context.Context) (res *FullAccount, err error)
+	// GetSpaceUsageContext : Get the space usage information for the current user's
+	// account.
+	GetSpaceUsageContext(ctx context.Context) (res *SpaceUsage, err error)
+}
+
 type apiImpl dropbox.Context
 
 // FeaturesGetValuesAPIError is an error-wrapper for the features/get_values route
@@ -53,7 +73,9 @@ type FeaturesGetValuesAPIError struct {
 	EndpointError *UserFeaturesGetValuesBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) FeaturesGetValues(arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error) {
+// FeaturesGetValuesContext : Get a list of feature values that may be configured
+// for the current account.
+func (dbx *apiImpl) FeaturesGetValuesContext(ctx context.Context, arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "users",
@@ -66,11 +88,11 @@ func (dbx *apiImpl) FeaturesGetValues(arg *UserFeaturesGetValuesBatchArg) (res *
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr FeaturesGetValuesAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -85,13 +107,18 @@ func (dbx *apiImpl) FeaturesGetValues(arg *UserFeaturesGetValuesBatchArg) (res *
 	return
 }
 
+func (dbx *apiImpl) FeaturesGetValues(arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error) {
+	return dbx.FeaturesGetValuesContext(context.Background(), arg)
+}
+
 // GetAccountAPIError is an error-wrapper for the get_account route
 type GetAccountAPIError struct {
 	dropbox.APIError
 	EndpointError *GetAccountError `json:"error"`
 }
 
-func (dbx *apiImpl) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error) {
+// GetAccountContext : Get information about a user's account.
+func (dbx *apiImpl) GetAccountContext(ctx context.Context, arg *GetAccountArg) (res *BasicAccount, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "users",
@@ -104,11 +131,11 @@ func (dbx *apiImpl) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetAccountAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -123,13 +150,19 @@ func (dbx *apiImpl) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error
 	return
 }
 
+func (dbx *apiImpl) GetAccount(arg *GetAccountArg) (res *BasicAccount, err error) {
+	return dbx.GetAccountContext(context.Background(), arg)
+}
+
 // GetAccountBatchAPIError is an error-wrapper for the get_account_batch route
 type GetAccountBatchAPIError struct {
 	dropbox.APIError
 	EndpointError *GetAccountBatchError `json:"error"`
 }
 
-func (dbx *apiImpl) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
+// GetAccountBatchContext : Get information about multiple user accounts. At most
+// 300 accounts may be queried per request.
+func (dbx *apiImpl) GetAccountBatchContext(ctx context.Context, arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "users",
@@ -142,11 +175,11 @@ func (dbx *apiImpl) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccoun
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetAccountBatchAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -161,13 +194,18 @@ func (dbx *apiImpl) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccoun
 	return
 }
 
+func (dbx *apiImpl) GetAccountBatch(arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
+	return dbx.GetAccountBatchContext(context.Background(), arg)
+}
+
 // GetCurrentAccountAPIError is an error-wrapper for the get_current_account route
 type GetCurrentAccountAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetCurrentAccount() (res *FullAccount, err error) {
+// GetCurrentAccountContext : Get information about the current user's account.
+func (dbx *apiImpl) GetCurrentAccountContext(ctx context.Context) (res *FullAccount, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "users",
@@ -180,11 +218,11 @@ func (dbx *apiImpl) GetCurrentAccount() (res *FullAccount, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetCurrentAccountAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -199,13 +237,19 @@ func (dbx *apiImpl) GetCurrentAccount() (res *FullAccount, err error) {
 	return
 }
 
+func (dbx *apiImpl) GetCurrentAccount() (res *FullAccount, err error) {
+	return dbx.GetCurrentAccountContext(context.Background())
+}
+
 // GetSpaceUsageAPIError is an error-wrapper for the get_space_usage route
 type GetSpaceUsageAPIError struct {
 	dropbox.APIError
 	EndpointError struct{} `json:"error"`
 }
 
-func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
+// GetSpaceUsageContext : Get the space usage information for the current user's
+// account.
+func (dbx *apiImpl) GetSpaceUsageContext(ctx context.Context) (res *SpaceUsage, err error) {
 	req := dropbox.Request{
 		Host:         "api",
 		Namespace:    "users",
@@ -218,11 +262,11 @@ func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
 
 	var resp []byte
 	var respBody io.ReadCloser
-	resp, respBody, err = (*dropbox.Context)(dbx).Execute(req, nil)
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
 	if err != nil {
 		var appErr GetSpaceUsageAPIError
 		err = auth.ParseError(err, &appErr)
-		if err == &appErr {
+		if errors.Is(err, &appErr) {
 			err = appErr
 		}
 		return
@@ -237,8 +281,17 @@ func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
 	return
 }
 
-// New returns a Client implementation for this namespace
-func New(c dropbox.Config) Client {
+func (dbx *apiImpl) GetSpaceUsage() (res *SpaceUsage, err error) {
+	return dbx.GetSpaceUsageContext(context.Background())
+}
+
+// NewContext returns a ContextClient implementation for this namespace
+func NewContext(c dropbox.Config) ContextClient {
 	ctx := apiImpl(dropbox.NewContext(c))
 	return &ctx
+}
+
+// New returns a Client implementation for this namespace
+func New(c dropbox.Config) Client {
+	return NewContext(c)
 }


### PR DESCRIPTION
## Summary

- Add `ContextClient` interface to every namespace with `*Context(ctx, ...)` variants of all API methods
- Add `NewContext()` constructor returning `ContextClient`; keep `New()` returning `Client` for backwards compatibility
- Split `Execute` into `Execute(req, body)` (background ctx) and `ExecuteContext(ctx, req, body)` (caller-provided ctx) using `http.NewRequestWithContext`
- Non-context methods delegate to their Context variants with `context.Background()`
- Replace direct error pointer comparisons with `errors.Is`

## Migration

No breaking changes. Existing code works as-is.

```go
// Before
client := users.New(config)
account, err := client.GetCurrentAccount()

// After — use NewContext to get access to Context variants
client := users.NewContext(config)
account, err := client.GetCurrentAccountContext(ctx)
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] All existing tests pass unchanged
- [x] `TestContextCancellation` — verifies context propagation cancels HTTP request
- [x] `TestExecuteBackwardCompatibility` — verifies `Execute(req, body)` still works
- [x] Compile-time assertions: `var _ users.Client = legacyUsersClient{}` and `var _ func(Config) Client = New`

Closes #108