### PR TITLE
Bump oauth2 to latest Go 1.23-compatible version

### DIFF
--- a/v6/go.mod
+++ b/v6/go.mod
@@ -2,4 +2,4 @@ module github.com/dropbox/dropbox-sdk-go-unofficial/v6
 
 go 1.23.0
 
-require golang.org/x/oauth2 v0.28.0
+require golang.org/x/oauth2 v0.30.0

--- a/v6/go.sum
+++ b/v6/go.sum
@@ -2,3 +2,5 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=


### PR DESCRIPTION
## Summary

- Bump golang.org/x/oauth2 from v0.28.0 to v0.30.0
- Keep the module Go version at 1.23.0

## Rationale

Dependabot PR #130 bumps oauth2 to v0.36.0, but that changes this module to go 1.25.0. v0.30.0 is the latest oauth2 release I found that still keeps go 1.23.0.

## Test plan

- go test ./... -count=1
- go vet ./...
- go build ./...

Replaces #130.