### PR TITLE
Prepare v6.2.0 release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 on:
   pull_request:
+  push:
+    branches: [ master ]
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 on:
   pull_request:
+  push:
+    branches: [ master ]
 jobs:
   test:
     strategy:

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -40,7 +40,7 @@ const (
 	hostAPI       = "api"
 	hostContent   = "content"
 	hostNotify    = "notify"
-	sdkVersion    = "6.0.0"
+	sdkVersion    = "6.2.0"
 	specVersion   = "b5f7ddd"
 )
 

--- a/v6/dropbox/version_test.go
+++ b/v6/dropbox/version_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dropbox_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+)
+
+func TestVersion(t *testing.T) {
+	sdkVersion, specVersion := dropbox.Version()
+
+	if sdkVersion != "6.2.0" {
+		t.Fatalf("sdk version = %q, want %q", sdkVersion, "6.2.0")
+	}
+
+	if !regexp.MustCompile(`^[0-9a-f]{7,40}$`).MatchString(specVersion) {
+		t.Fatalf("spec version = %q, want git commit hash", specVersion)
+	}
+}


### PR DESCRIPTION
## Summary

- Update SDK runtime version to 6.2.0 for the next feature release
- Add a version test covering dropbox.Version() SDK/spec values
- Run Test and Lint workflows on pushes to master as well as pull requests

## Test plan

- go test -race ./... -count=1
- go vet ./...
- go build ./...
- git diff --check