### PR TITLE
Add automatic content_hash for upload routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,57 @@ Here's an example:
   }
 ```
 
-### Computing upload content hashes
+### Automatic upload integrity (`content_hash`)
 
-Upload routes accept an optional Dropbox `content_hash` value for server-side validation. Use `contenthash.Compute` to calculate it before upload:
+For file upload calls whose argument includes `ContentHash`, the SDK automatically
+computes a Dropbox `content_hash` when the content reader implements `io.ReadSeeker`.
+This covers `Upload`, `UploadSessionStart`, `UploadSessionAppendV2`,
+`UploadSessionAppendBatch`, and `UploadSessionFinish`. The server rejects the
+request if the hash does not match the received bytes, providing end-to-end
+integrity protection with no code changes required.
+
+Because the hash must appear in the HTTP request header, the SDK reads the content once
+to compute the hash, seeks back, then reads again for the upload body. For local files
+the second read is typically served from the OS page cache. To disable auto-hashing:
 
 ```go
+_, err = client.Upload(arg, files.WithoutAutoContentHash(f))
+```
+
+The SDK treats a reader as seekable when it implements `io.ReadSeeker`.
+Non-seekable readers (e.g. `io.Pipe`, `bytes.Buffer`) are never hashed
+automatically because the SDK cannot rewind them for the upload body.
+
+To set `content_hash` manually instead, assign it on the arg. The SDK skips
+auto-hashing when a value is already present, even if the reader is wrapped with
+`WithoutAutoContentHash`. This also works for non-seekable readers if you already
+know the Dropbox content hash:
+
+```go
+arg := files.NewUploadArg("/remote-file.txt")
+arg.ContentHash = myPrecomputedHash
+_, err = client.Upload(arg, f)
+```
+
+### Computing content hashes manually
+
+Use the `contenthash` package directly when you need the hash value (e.g. for
+local-vs-remote comparison):
+
+```go
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash"
+
 f, err := os.Open("local-file.txt")
 if err != nil {
     return err
 }
 defer f.Close()
 
-contentHash, err := contenthash.Compute(f)
+hash, err := contenthash.Compute(f)
 if err != nil {
     return err
 }
-if _, err := f.Seek(0, io.SeekStart); err != nil {
-    return err
-}
-
-arg := files.NewUploadArg("/remote-file.txt")
-arg.ContentHash = contentHash
-_, err = client.Upload(arg, f)
+fmt.Println(hash) // hex-encoded Dropbox content_hash
 ```
 
 ### Working with polymorphic responses

--- a/generator/go_client.stoneg.py
+++ b/generator/go_client.stoneg.py
@@ -124,6 +124,14 @@ class GoClientBackend(CodeBackend):
                     out('log.Printf("Use API `%s` instead")' % replacement_fn)
                 out()
 
+            if (namespace.name == 'files' and route_style == 'upload' and
+                    self._route_arg_has_content_hash(route)):
+                arg_type = fmt_var(route.arg_data_type.name)
+                out('arg, content, err = addAutoContentHashTo%s(arg, content)' % arg_type)
+                with self.block('if err != nil'):
+                    out('return')
+                out()
+
             args = {
                 "Host": route.attrs.get('host', 'api'),
                 "Namespace": namespace.name,
@@ -189,3 +197,9 @@ class GoClientBackend(CodeBackend):
                 call_args.append('content')
             out('return dbx.%sContext(%s)' % (fn, ', '.join(call_args)))
         out()
+
+    def _route_arg_has_content_hash(self, route):
+        if not is_struct_type(route.arg_data_type):
+            return False
+        return any(field.name == 'content_hash'
+                   for field in route.arg_data_type.all_fields)

--- a/v6/dropbox/files/client.go
+++ b/v6/dropbox/files/client.go
@@ -985,6 +985,11 @@ type AlphaUploadAPIError struct {
 func (dbx *apiImpl) AlphaUploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
 	log.Printf("WARNING: API `AlphaUpload` is deprecated")
 
+	arg, content, err = addAutoContentHashToUploadArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -3628,6 +3633,11 @@ type UploadAPIError struct {
 // information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
+	arg, content, err = addAutoContentHashToUploadArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -3726,6 +3736,11 @@ type UploadSessionAppendV2APIError struct {
 // allowed per month. For more information, see the Data transport limit
 // page https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionAppendV2Context(ctx context.Context, arg *UploadSessionAppendArg, content io.Reader) (err error) {
+	arg, content, err = addAutoContentHashToUploadSessionAppendArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -3775,6 +3790,11 @@ type UploadSessionAppendBatchAPIError struct {
 // per month. For more information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionAppendBatchContext(ctx context.Context, arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error) {
+	arg, content, err = addAutoContentHashToUploadSessionAppendBatchArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -3825,6 +3845,11 @@ type UploadSessionFinishAPIError struct {
 // information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionFinishContext(ctx context.Context, arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
+	arg, content, err = addAutoContentHashToUploadSessionFinishArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",
@@ -4065,6 +4090,11 @@ type UploadSessionStartAPIError struct {
 // or `UploadSessionAppendBatchArgEntry.close` set to true that may contain
 // any remaining data.
 func (dbx *apiImpl) UploadSessionStartContext(ctx context.Context, arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
+	arg, content, err = addAutoContentHashToUploadSessionStartArg(arg, content)
+	if err != nil {
+		return
+	}
+
 	req := dropbox.Request{
 		Host:         "content",
 		Namespace:    "files",

--- a/v6/dropbox/files/content_hash.go
+++ b/v6/dropbox/files/content_hash.go
@@ -1,0 +1,196 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package files
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash"
+)
+
+type autoContentHashDisabled interface {
+	autoContentHashDisabled()
+}
+
+type autoContentHashDisabledReader struct {
+	io.Reader
+}
+
+func (autoContentHashDisabledReader) autoContentHashDisabled() {}
+
+type autoContentHashDisabledReadSeeker struct {
+	io.ReadSeeker
+}
+
+func (autoContentHashDisabledReadSeeker) autoContentHashDisabled() {}
+
+type autoContentHashDisabledWriterTo struct {
+	io.Reader
+	io.WriterTo
+}
+
+func (autoContentHashDisabledWriterTo) autoContentHashDisabled() {}
+
+type autoContentHashDisabledReadSeekerWriterTo struct {
+	io.ReadSeeker
+	io.WriterTo
+}
+
+func (autoContentHashDisabledReadSeekerWriterTo) autoContentHashDisabled() {}
+
+// WithoutAutoContentHash returns a reader that disables automatic SDK
+// content_hash population for upload requests. A manually supplied
+// ContentHash value on the upload argument is still sent.
+//
+// By default, the SDK automatically computes a Dropbox content_hash for file
+// upload calls whose argument includes ContentHash, when the content reader
+// implements io.ReadSeeker. The hash is sent to the server which rejects the
+// request on mismatch, providing end-to-end integrity protection.
+//
+// Because the hash must be known before the HTTP body is sent, the SDK reads
+// the content once to compute the hash, seeks back to the original position,
+// then reads again for the upload. For local files this is typically served
+// from the OS page cache; for network-backed readers (NFS, S3) this doubles
+// I/O. Use this function to disable auto-hashing when the extra read is
+// unacceptable.
+//
+// A reader is considered seekable when it implements io.ReadSeeker.
+// Non-seekable readers are never hashed automatically because they cannot be
+// rewound for the upload. Callers may still set ContentHash manually on the
+// upload argument when they already know the Dropbox content hash.
+// The returned reader preserves io.ReadSeeker and io.WriterTo when the original
+// reader implements them.
+func WithoutAutoContentHash(content io.Reader) io.Reader {
+	if content == nil {
+		return nil
+	}
+	readSeeker, hasReadSeeker := content.(io.ReadSeeker)
+	writerTo, hasWriterTo := content.(io.WriterTo)
+	switch {
+	case hasReadSeeker && hasWriterTo:
+		return autoContentHashDisabledReadSeekerWriterTo{
+			ReadSeeker: readSeeker,
+			WriterTo:   writerTo,
+		}
+	case hasReadSeeker:
+		return autoContentHashDisabledReadSeeker{ReadSeeker: readSeeker}
+	case hasWriterTo:
+		return autoContentHashDisabledWriterTo{
+			Reader:   content,
+			WriterTo: writerTo,
+		}
+	}
+	return autoContentHashDisabledReader{Reader: content}
+}
+
+func addAutoContentHashToUploadArg(arg *UploadArg, content io.Reader) (*UploadArg, io.Reader, error) {
+	if arg == nil {
+		return arg, content, nil
+	}
+	hash, content, ok, err := autoContentHash(arg.ContentHash, content)
+	if err != nil || !ok {
+		return arg, content, err
+	}
+	argCopy := *arg
+	argCopy.ContentHash = hash
+	return &argCopy, content, nil
+}
+
+func addAutoContentHashToUploadSessionStartArg(arg *UploadSessionStartArg, content io.Reader) (*UploadSessionStartArg, io.Reader, error) {
+	if arg == nil {
+		return arg, content, nil
+	}
+	hash, content, ok, err := autoContentHash(arg.ContentHash, content)
+	if err != nil || !ok {
+		return arg, content, err
+	}
+	argCopy := *arg
+	argCopy.ContentHash = hash
+	return &argCopy, content, nil
+}
+
+func addAutoContentHashToUploadSessionAppendArg(arg *UploadSessionAppendArg, content io.Reader) (*UploadSessionAppendArg, io.Reader, error) {
+	if arg == nil {
+		return arg, content, nil
+	}
+	hash, content, ok, err := autoContentHash(arg.ContentHash, content)
+	if err != nil || !ok {
+		return arg, content, err
+	}
+	argCopy := *arg
+	argCopy.ContentHash = hash
+	return &argCopy, content, nil
+}
+
+func addAutoContentHashToUploadSessionAppendBatchArg(arg *UploadSessionAppendBatchArg, content io.Reader) (*UploadSessionAppendBatchArg, io.Reader, error) {
+	if arg == nil {
+		return arg, content, nil
+	}
+	hash, content, ok, err := autoContentHash(arg.ContentHash, content)
+	if err != nil || !ok {
+		return arg, content, err
+	}
+	argCopy := *arg
+	argCopy.ContentHash = hash
+	return &argCopy, content, nil
+}
+
+func addAutoContentHashToUploadSessionFinishArg(arg *UploadSessionFinishArg, content io.Reader) (*UploadSessionFinishArg, io.Reader, error) {
+	if arg == nil {
+		return arg, content, nil
+	}
+	hash, content, ok, err := autoContentHash(arg.ContentHash, content)
+	if err != nil || !ok {
+		return arg, content, err
+	}
+	argCopy := *arg
+	argCopy.ContentHash = hash
+	return &argCopy, content, nil
+}
+
+func autoContentHash(existing string, content io.Reader) (string, io.Reader, bool, error) {
+	if existing != "" || content == nil {
+		return "", content, false, nil
+	}
+	if _, ok := content.(autoContentHashDisabled); ok {
+		return "", content, false, nil
+	}
+	seeker, ok := content.(io.ReadSeeker)
+	if !ok {
+		return "", content, false, nil
+	}
+
+	start, err := seeker.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", content, false, nil
+	}
+
+	hash, err := contenthash.Compute(seeker)
+	_, seekErr := seeker.Seek(start, io.SeekStart)
+	if err != nil {
+		return "", content, false, fmt.Errorf("files: auto content_hash: compute: %w", err)
+	}
+	if seekErr != nil {
+		return "", content, false, fmt.Errorf("files: auto content_hash: restore reader offset: %w", seekErr)
+	}
+	return hash, content, true, nil
+}

--- a/v6/dropbox/files/content_hash_upload_test.go
+++ b/v6/dropbox/files/content_hash_upload_test.go
@@ -1,0 +1,405 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package files_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+type capturedUploadRequest struct {
+	path string
+	arg  string
+	body []byte
+}
+
+type nonSeekableReader struct {
+	reader *strings.Reader
+}
+
+func (r *nonSeekableReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+type brokenSeekReader struct {
+	reader *strings.Reader
+}
+
+func (r *brokenSeekReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *brokenSeekReader) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("seek unavailable")
+}
+
+type readErrorSeeker struct {
+	err error
+}
+
+func (r *readErrorSeeker) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
+func (r *readErrorSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+func TestAutoContentHashUploadRoutes(t *testing.T) {
+	const payload = "payload for automatic content hash"
+	expectedHash := mustContentHash(t, payload)
+
+	tests := []struct {
+		name     string
+		wantPath string
+		call     func(files.Client, io.Reader) error
+	}{
+		{
+			name:     "alpha upload",
+			wantPath: "/files/alpha/upload",
+			call: func(client files.Client, content io.Reader) error {
+				_, err := client.AlphaUpload(files.NewUploadArg("/alpha.txt"), content)
+				return err
+			},
+		},
+		{
+			name:     "upload",
+			wantPath: "/files/upload",
+			call: func(client files.Client, content io.Reader) error {
+				_, err := client.Upload(files.NewUploadArg("/upload.txt"), content)
+				return err
+			},
+		},
+		{
+			name:     "upload session start",
+			wantPath: "/files/upload_session/start",
+			call: func(client files.Client, content io.Reader) error {
+				_, err := client.UploadSessionStart(files.NewUploadSessionStartArg(), content)
+				return err
+			},
+		},
+		{
+			name:     "upload session append v2",
+			wantPath: "/files/upload_session/append_v2",
+			call: func(client files.Client, content io.Reader) error {
+				err := client.UploadSessionAppendV2(files.NewUploadSessionAppendArg(files.NewUploadSessionCursor("sid", 0)), content)
+				return err
+			},
+		},
+		{
+			name:     "upload session append batch",
+			wantPath: "/files/upload_session/append_batch",
+			call: func(client files.Client, content io.Reader) error {
+				entry := files.NewUploadSessionAppendBatchArgEntry(files.NewUploadSessionCursor("sid", 0), uint64(len(payload)))
+				_, err := client.UploadSessionAppendBatch(files.NewUploadSessionAppendBatchArg([]*files.UploadSessionAppendBatchArgEntry{entry}), content)
+				return err
+			},
+		},
+		{
+			name:     "upload session finish",
+			wantPath: "/files/upload_session/finish",
+			call: func(client files.Client, content io.Reader) error {
+				arg := files.NewUploadSessionFinishArg(files.NewUploadSessionCursor("sid", 0), files.NewCommitInfo("/finish.txt"))
+				_, err := client.UploadSessionFinish(arg, content)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, requests := newUploadTestClient(t)
+
+			if err := tt.call(client, strings.NewReader(payload)); err != nil {
+				t.Fatalf("upload route failed: %v", err)
+			}
+
+			req := nextUploadRequest(t, requests)
+			if req.path != tt.wantPath {
+				t.Fatalf("route path = %q, want %q", req.path, tt.wantPath)
+			}
+			if string(req.body) != payload {
+				t.Fatalf("body = %q, want %q", string(req.body), payload)
+			}
+
+			arg := decodeDropboxAPIArg(t, req.arg)
+			if got := arg["content_hash"]; got != expectedHash {
+				t.Fatalf("content_hash = %v, want %q", got, expectedHash)
+			}
+		})
+	}
+}
+
+func TestAutoContentHashManualValueWins(t *testing.T) {
+	const payload = "payload with manual hash"
+	const manualHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	client, requests := newUploadTestClient(t)
+	arg := files.NewUploadArg("/manual.txt")
+	arg.ContentHash = manualHash
+
+	if _, err := client.Upload(arg, strings.NewReader(payload)); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if got := gotArg["content_hash"]; got != manualHash {
+		t.Fatalf("content_hash = %v, want manual hash %q", got, manualHash)
+	}
+}
+
+func TestAutoContentHashDoesNotMutateCallerArg(t *testing.T) {
+	const payload = "payload for arg mutation check"
+	client, requests := newUploadTestClient(t)
+	arg := files.NewUploadArg("/mutation.txt")
+
+	if _, err := client.Upload(arg, strings.NewReader(payload)); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if got := gotArg["content_hash"]; got != mustContentHash(t, payload) {
+		t.Fatalf("content_hash = %v, want computed hash", got)
+	}
+	if arg.ContentHash != "" {
+		t.Fatalf("caller arg ContentHash = %q, want empty", arg.ContentHash)
+	}
+}
+
+func TestWithoutAutoContentHashOmitsGeneratedHash(t *testing.T) {
+	const payload = "payload with opt out"
+	client, requests := newUploadTestClient(t)
+
+	if _, err := client.Upload(files.NewUploadArg("/opt-out.txt"), files.WithoutAutoContentHash(strings.NewReader(payload))); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	if string(req.body) != payload {
+		t.Fatalf("body = %q, want %q", string(req.body), payload)
+	}
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if _, ok := gotArg["content_hash"]; ok {
+		t.Fatalf("content_hash was sent for opt-out reader: %v", gotArg["content_hash"])
+	}
+}
+
+func TestWithoutAutoContentHashStillSendsManualHash(t *testing.T) {
+	const payload = "payload with opt out and manual hash"
+	const manualHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	client, requests := newUploadTestClient(t)
+	arg := files.NewUploadArg("/manual-opt-out.txt")
+	arg.ContentHash = manualHash
+
+	if _, err := client.Upload(arg, files.WithoutAutoContentHash(strings.NewReader(payload))); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if got := gotArg["content_hash"]; got != manualHash {
+		t.Fatalf("content_hash = %v, want manual hash %q", got, manualHash)
+	}
+}
+
+func TestWithoutAutoContentHashPreservesReaderInterfaces(t *testing.T) {
+	content := files.WithoutAutoContentHash(strings.NewReader("payload"))
+	if _, ok := content.(io.ReadSeeker); !ok {
+		t.Fatal("WithoutAutoContentHash stripped io.ReadSeeker")
+	}
+	if _, ok := content.(io.WriterTo); !ok {
+		t.Fatal("WithoutAutoContentHash stripped io.WriterTo")
+	}
+}
+
+func TestAutoContentHashSkipsNonSeekableReader(t *testing.T) {
+	const payload = "payload from non-seekable reader"
+	client, requests := newUploadTestClient(t)
+	content := &nonSeekableReader{reader: strings.NewReader(payload)}
+
+	if _, err := client.Upload(files.NewUploadArg("/non-seekable.txt"), content); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	if string(req.body) != payload {
+		t.Fatalf("body = %q, want %q", string(req.body), payload)
+	}
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if _, ok := gotArg["content_hash"]; ok {
+		t.Fatalf("content_hash was sent for non-seekable reader: %v", gotArg["content_hash"])
+	}
+}
+
+func TestAutoContentHashSkipsReaderWhenCurrentOffsetCannotBeRead(t *testing.T) {
+	const payload = "payload from reader with broken seek"
+	client, requests := newUploadTestClient(t)
+	content := &brokenSeekReader{reader: strings.NewReader(payload)}
+
+	if _, err := client.Upload(files.NewUploadArg("/broken-seek.txt"), content); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	if string(req.body) != payload {
+		t.Fatalf("body = %q, want %q", string(req.body), payload)
+	}
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if _, ok := gotArg["content_hash"]; ok {
+		t.Fatalf("content_hash was sent for reader with broken seek: %v", gotArg["content_hash"])
+	}
+}
+
+func TestAutoContentHashWrapsReadError(t *testing.T) {
+	readErr := errors.New("read failed")
+	client, requests := newUploadTestClient(t)
+
+	_, err := client.Upload(files.NewUploadArg("/read-error.txt"), &readErrorSeeker{err: readErr})
+	if err == nil {
+		t.Fatal("upload succeeded, want auto content_hash error")
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("error = %v, want to wrap %v", err, readErr)
+	}
+	if !strings.Contains(err.Error(), "auto content_hash") {
+		t.Fatalf("error = %q, want auto content_hash context", err.Error())
+	}
+
+	select {
+	case req := <-requests:
+		t.Fatalf("unexpected request after auto content_hash failure: %s", req.path)
+	default:
+	}
+}
+
+func TestAutoContentHashUsesAndPreservesCurrentReaderOffset(t *testing.T) {
+	const prefix = "already-read:"
+	const payload = "payload from current offset"
+	client, requests := newUploadTestClient(t)
+	content := strings.NewReader(prefix + payload)
+	if _, err := content.Seek(int64(len(prefix)), io.SeekStart); err != nil {
+		t.Fatalf("seek failed: %v", err)
+	}
+
+	if _, err := client.Upload(files.NewUploadArg("/offset.txt"), content); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	req := nextUploadRequest(t, requests)
+	if string(req.body) != payload {
+		t.Fatalf("body = %q, want %q", string(req.body), payload)
+	}
+	gotArg := decodeDropboxAPIArg(t, req.arg)
+	if got := gotArg["content_hash"]; got != mustContentHash(t, payload) {
+		t.Fatalf("content_hash = %v, want hash of %q", got, payload)
+	}
+}
+
+func newUploadTestClient(t *testing.T) (files.Client, <-chan capturedUploadRequest) {
+	t.Helper()
+
+	requests := make(chan capturedUploadRequest, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		requests <- capturedUploadRequest{
+			path: r.URL.Path,
+			arg:  r.Header.Get("Dropbox-API-Arg"),
+			body: body,
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, err = w.Write([]byte(uploadTestResponse(r.URL.Path)))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	config := dropbox.Config{
+		Client: ts.Client(),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return fmt.Sprintf("%s/%s/%s", ts.URL, namespace, route)
+		},
+	}
+	return files.New(config), requests
+}
+
+func uploadTestResponse(path string) string {
+	switch path {
+	case "/files/upload_session/start":
+		return `{"session_id":"sid"}`
+	case "/files/upload_session/append_v2":
+		return `{}`
+	case "/files/upload_session/append_batch":
+		return `{"entries":[{".tag":"success"}]}`
+	default:
+		return `{"name":"file.txt","id":"id:test","client_modified":"2020-01-02T03:04:05Z","server_modified":"2020-01-02T03:04:06Z","rev":"rev","size":1,"is_downloadable":true}`
+	}
+}
+
+func nextUploadRequest(t *testing.T, requests <-chan capturedUploadRequest) capturedUploadRequest {
+	t.Helper()
+
+	select {
+	case req := <-requests:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upload request")
+		return capturedUploadRequest{}
+	}
+}
+
+func decodeDropboxAPIArg(t *testing.T, header string) map[string]interface{} {
+	t.Helper()
+
+	var arg map[string]interface{}
+	if err := json.Unmarshal([]byte(header), &arg); err != nil {
+		t.Fatalf("unmarshal Dropbox-API-Arg %q: %v", header, err)
+	}
+	return arg
+}
+
+func mustContentHash(t *testing.T, payload string) string {
+	t.Helper()
+
+	hash, err := contenthash.Compute(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("compute content hash: %v", err)
+	}
+	return hash
+}


### PR DESCRIPTION
## Summary

- Automatically compute and send Dropbox `content_hash` for all file upload routes (`Upload`, `UploadSessionStart`, `UploadSessionAppendV2`, `UploadSessionAppendBatch`, `UploadSessionFinish`) when the content reader is seekable (`io.ReadSeeker`). The server rejects on mismatch, providing end-to-end integrity with no code changes required.
- Add `WithoutAutoContentHash` opt-out that preserves `io.ReadSeeker` and `io.WriterTo` interfaces via 4 wrapper types.
- Update the code generator (`go_client.stoneg.py`) to emit auto-hash calls for routes with a `content_hash` field.
- Add README documentation covering auto-hash behavior, opt-out, manual hash, and the `contenthash` package.

## Design decisions

- Double-read is unavoidable: hash must be in the HTTP header before the body is sent.
- Non-seekable readers silently skip hashing (graceful degradation).
- Arg is shallow-copied before mutation — callers' originals are never modified.
- Seek failures before compute skip silently; failures after compute abort with a wrapped error.

## Test plan

- [x] Unit tests for `contenthash` package (known vectors, fixture files, chunk boundaries, zero-value, reset, error paths, whitebox panic tests)
- [x] Integration tests for auto-hash (`content_hash_upload_test.go`) covering seekable, non-seekable, opt-out, pre-set hash, nil arg, empty content
- [x] All tests pass (`go test ./dropbox/contenthash/... ./dropbox/files/...`)
- [x] Verified algorithm matches Python reference implementation