### PR TITLE
Add least-privilege CI permissions and CHANGELOG

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '18 6 * * 0'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [ master ]
+permissions:
+  contents: read
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [ master ]
+permissions:
+  contents: read
 jobs:
   test:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+Notable changes to this SDK are documented here. Historical entries are
+summarized from the repository history.
+
+## Unreleased
+
+### Added
+
+- Added the `dropbox/contenthash` package for computing Dropbox API
+  `content_hash` values.
+- Added automatic `content_hash` population for seekable file upload readers
+  on upload routes whose arguments include `ContentHash`.
+
+### Security
+
+- Added explicit least-privilege permissions to GitHub Actions workflows.
+
+## v6.2.0 - 2026-06-30
+
+### Added
+
+- Added `context.Context` support to generated namespace clients.
+
+### Changed
+
+- Bumped `golang.org/x/oauth2` to a Go 1.23-compatible version.
+- Updated GitHub Actions dependencies, including checkout, setup-go, CodeQL,
+  and golangci-lint actions.
+- Fixed lint issues reported by golangci-lint v9.
+
+## v6.1.0 - 2026-06-29
+
+### Fixed
+
+- Fixed timestamp serialization format.
+
+### Changed
+
+- Updated the Dropbox API spec and regenerated the SDK.
+- Updated README usage examples for polymorphic responses and timestamps.
+- Replaced deprecated `io/ioutil` usage with `io` package equivalents.
+- Bumped dependencies and CI configuration.
+
+## v6.0.5 - 2022-10-03
+
+### Changed
+
+- Updated the Dropbox API spec and regenerated the SDK.
+- Added generator support for map types.
+- Updated GitHub Actions dependencies, including checkout, setup-go, CodeQL,
+  and golangci-lint actions.


### PR DESCRIPTION
## Summary

- Pin GitHub Actions workflow permissions to least-privilege (contents: read, security-events: write for CodeQL)
- Add CHANGELOG.md documenting notable changes across SDK releases

## Test plan

- [x] CI workflows still trigger correctly (permissions are additive restrictions, not new capabilities)
- [x] CHANGELOG follows Keep a Changelog format