### PR TITLE
Build Go module during CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.23.x'
+        cache-dependency-path: v6/go.sum
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -55,22 +56,10 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
+    - name: Build Go module
       if: matrix.language == 'go'
-      uses: github/codeql-action/autobuild@v4
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      run: go build ./...
+      working-directory: ./v6
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- replace CodeQL Go autobuild with an explicit build from ./v6
- point setup-go cache dependency path at v6/go.sum
- remove stale autobuild guidance comments

## Why
CodeQL reported that golang.org/x/oauth2 could not be found for language:go. The repository module lives under ./v6, while the CodeQL job ran from the repository root.