### PR TITLE
Improve CI workflows and add golangci-lint config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
+          cache-dependency-path: v6/go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
     - name: Install Go
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v7
+        cache-dependency-path: v6/go.sum
+    - name: Vet
+      run: go vet ./...
+      working-directory: ./v6
     - name: Test
-      run: go test -race -v ./...
+      run: go test -vet=off -race -v ./...
       working-directory: ./v6

--- a/v6/.golangci.yml
+++ b/v6/.golangci.yml
@@ -1,0 +1,26 @@
+version: "2"
+linters:
+  settings:
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -63,6 +63,8 @@ func (e APIError) Error() string {
 	return e.ErrorSummary
 }
 
+// SDKInternalError is returned when the Dropbox API responds with a status code
+// that does not carry a typed error body (e.g. 500 Internal Server Error).
 type SDKInternalError struct {
 	StatusCode int
 	Content    string


### PR DESCRIPTION
## Summary
- Add `cache-dependency-path: v6/go.sum` to test and lint workflows for faster module caching
- Fix step order in test.yml: checkout before setup-go so cache key can read go.sum
- Add explicit `go vet` step with `-vet=off` on `go test` to avoid duplicate vet runs
- Add `.golangci.yml` (v2 format) with govet enable-all and standard exclusion presets
- Add godoc comment to `SDKInternalError`