### PR TITLE
Add OAuth2 PKCE support and refreshable token sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Notable changes to this SDK are documented here. Historical entries are
 summarized from the repository history.
 
+## Unreleased
+
+### Added
+
+- Added the `dropbox/oauth` package with PKCE authorization URL, code
+  exchange, and refresh-token helpers.
+- Added `dropbox.Config.TokenSource` for refreshable OAuth token sources.
+
 ## v6.3.0 - 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,9 +55,49 @@ func main() {
 
 ### Using OAuth2 flow
 
-For this, you will need your `APP_KEY` and `APP_SECRET` from the developers console. Your app will then have to take users though the oauth flow, as part of which users will explicitly grant permissions to your app. At the end of this process, users will get a token that the app can then use for subsequent authentication. See [this](https://pkg.go.dev/golang.org/x/oauth2#example-Config) for an example of oauth2 flow in Go.
+For PKCE, you will need your `APP_KEY` from the developers console. Your app
+will then have to take users through the OAuth flow, as part of which users
+will explicitly grant permissions to your app. At the end of this process, your
+app exchanges the authorization code for a token.
 
-Once you have the token, usage is same as above.
+```go
+import "context"
+import "fmt"
+
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+import dropboxoauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth"
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+
+func main() {
+  ctx := context.Background()
+  flow, err := dropboxoauth.NewPKCEFlow(appKey)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("Go to %s\n", flow.AuthCodeURL())
+  // Read the authorization code from the user.
+  token, err := flow.Exchange(ctx, code)
+  if err != nil {
+    panic(err)
+  }
+
+  config := dropbox.Config{
+    TokenSource: dropboxoauth.TokenSource(ctx, appKey, token),
+  }
+  dbx := users.New(config)
+  // start making API calls
+}
+```
+
+The PKCE helper requests offline access by default. Use
+`dropboxoauth.TokenSource` in `dropbox.Config` for automatic refresh, or call
+`dropboxoauth.Refresh` directly when you manage token storage yourself.
+
+Existing apps that use an app secret can continue to use `golang.org/x/oauth2`
+directly with `dropbox.OAuthEndpoint(domain)`. The SDK still accepts a static
+access token through `dropbox.Config.Token`; for refreshable tokens, pass a
+token source through `dropbox.Config.TokenSource`.
 
 ### Making API calls
 

--- a/v6/dropbox/oauth/oauth.go
+++ b/v6/dropbox/oauth/oauth.go
@@ -1,0 +1,251 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package oauth provides helpers for Dropbox OAuth 2 flows.
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"golang.org/x/oauth2"
+)
+
+const (
+	tokenAccessTypeParam      = "token_access_type"
+	includeGrantedScopesParam = "include_granted_scopes"
+)
+
+// TokenAccessType controls whether Dropbox returns refreshable credentials.
+type TokenAccessType string
+
+const (
+	// TokenAccessTypeOffline requests a refresh token.
+	TokenAccessTypeOffline TokenAccessType = "offline"
+	// TokenAccessTypeOnline requests only a short-lived access token.
+	TokenAccessTypeOnline TokenAccessType = "online"
+)
+
+// IncludeGrantedScopes controls whether Dropbox reuses previously granted scopes.
+type IncludeGrantedScopes string
+
+const (
+	// IncludeGrantedScopesUser requests previously granted user scopes.
+	IncludeGrantedScopesUser IncludeGrantedScopes = "user"
+	// IncludeGrantedScopesTeam requests previously granted team scopes.
+	IncludeGrantedScopesTeam IncludeGrantedScopes = "team"
+)
+
+// Option configures Dropbox OAuth helpers.
+type Option func(*options)
+
+type options struct {
+	domain               string
+	redirectURL          string
+	state                string
+	verifier             string
+	scopes               []string
+	tokenAccessType      TokenAccessType
+	includeGrantedScopes IncludeGrantedScopes
+	httpClient           *http.Client
+}
+
+// PKCEFlow manages authorization URL generation and code exchange for PKCE.
+type PKCEFlow struct {
+	opts options
+	conf *oauth2.Config
+}
+
+// NewPKCEFlow creates a Dropbox OAuth 2 PKCE flow.
+func NewPKCEFlow(appKey string, opts ...Option) (*PKCEFlow, error) {
+	appKey = strings.TrimSpace(appKey)
+	if appKey == "" {
+		return nil, errors.New("dropbox oauth: app key is required")
+	}
+
+	o := options{
+		tokenAccessType: TokenAccessTypeOffline,
+	}
+	applyOptions(&o, opts)
+	if o.state == "" {
+		o.state = oauth2.GenerateVerifier()
+	}
+	if o.verifier == "" {
+		o.verifier = oauth2.GenerateVerifier()
+	}
+
+	return &PKCEFlow{
+		opts: o,
+		conf: oauthConfig(appKey, o.domain, o.redirectURL, o.scopes),
+	}, nil
+}
+
+// WithDomain configures the Dropbox API domain.
+func WithDomain(domain string) Option {
+	return func(opts *options) {
+		opts.domain = domain
+	}
+}
+
+// WithRedirectURL configures the OAuth redirect URL.
+func WithRedirectURL(url string) Option {
+	return func(opts *options) {
+		opts.redirectURL = url
+	}
+}
+
+// WithState configures the OAuth state value.
+func WithState(state string) Option {
+	return func(opts *options) {
+		opts.state = state
+	}
+}
+
+// WithVerifier configures the PKCE code verifier.
+func WithVerifier(verifier string) Option {
+	return func(opts *options) {
+		opts.verifier = verifier
+	}
+}
+
+// WithScopes configures OAuth scopes.
+func WithScopes(scopes ...string) Option {
+	return func(opts *options) {
+		opts.scopes = append([]string(nil), scopes...)
+	}
+}
+
+// WithTokenAccessType configures the Dropbox token access type.
+func WithTokenAccessType(value TokenAccessType) Option {
+	return func(opts *options) {
+		opts.tokenAccessType = value
+	}
+}
+
+// WithIncludeGrantedScopes configures Dropbox include_granted_scopes.
+func WithIncludeGrantedScopes(value IncludeGrantedScopes) Option {
+	return func(opts *options) {
+		opts.includeGrantedScopes = value
+	}
+}
+
+// WithHTTPClient configures the HTTP client used for token exchange or refresh.
+func WithHTTPClient(client *http.Client) Option {
+	return func(opts *options) {
+		opts.httpClient = client
+	}
+}
+
+// AuthCodeURL returns the authorization URL for this PKCE flow.
+func (f *PKCEFlow) AuthCodeURL() string {
+	options := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(f.opts.verifier)}
+	if f.opts.tokenAccessType != "" {
+		options = append(options, oauth2.SetAuthURLParam(tokenAccessTypeParam, string(f.opts.tokenAccessType)))
+	}
+	if f.opts.includeGrantedScopes != "" {
+		options = append(options, oauth2.SetAuthURLParam(includeGrantedScopesParam, string(f.opts.includeGrantedScopes)))
+	}
+	return f.conf.AuthCodeURL(f.opts.state, options...)
+}
+
+// Exchange exchanges an authorization code for an OAuth token.
+func (f *PKCEFlow) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+	return f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, oauth2.VerifierOption(f.opts.verifier))
+}
+
+// State returns the OAuth state for this flow.
+func (f *PKCEFlow) State() string {
+	return f.opts.state
+}
+
+// Verifier returns the PKCE verifier for this flow.
+func (f *PKCEFlow) Verifier() string {
+	return f.opts.verifier
+}
+
+// Refresh refreshes a Dropbox OAuth token.
+func Refresh(ctx context.Context, appKey string, token *oauth2.Token, opts ...Option) (*oauth2.Token, error) {
+	appKey = strings.TrimSpace(appKey)
+	if appKey == "" {
+		return nil, errors.New("dropbox oauth: app key is required")
+	}
+	if token == nil {
+		return nil, errors.New("dropbox oauth: token is required")
+	}
+	if token.RefreshToken == "" {
+		return nil, errors.New("dropbox oauth: refresh token is required")
+	}
+
+	o := options{}
+	applyOptions(&o, opts)
+
+	expired := *token
+	expired.Expiry = time.Now().Add(-time.Second)
+
+	refreshed, err := oauthConfig(appKey, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), &expired).Token()
+	if err != nil {
+		return nil, err
+	}
+	if refreshed == nil {
+		return nil, errors.New("dropbox oauth: token refresh returned nil token")
+	}
+	return refreshed, nil
+}
+
+// TokenSource returns an OAuth token source backed by Dropbox refresh tokens.
+func TokenSource(ctx context.Context, appKey string, token *oauth2.Token, opts ...Option) oauth2.TokenSource {
+	appKey = strings.TrimSpace(appKey)
+	o := options{}
+	applyOptions(&o, opts)
+	return oauthConfig(appKey, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), token)
+}
+
+func applyOptions(o *options, opts []Option) {
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
+	}
+}
+
+func oauthConfig(appKey string, domain string, redirectURL string, scopes []string) *oauth2.Config {
+	endpoint := dropbox.OAuthEndpoint(domain)
+	endpoint.AuthStyle = oauth2.AuthStyleInParams
+	return &oauth2.Config{
+		ClientID:    appKey,
+		Endpoint:    endpoint,
+		RedirectURL: redirectURL,
+		Scopes:      append([]string(nil), scopes...),
+	}
+}
+
+func withHTTPClient(ctx context.Context, client *http.Client) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if client == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, client)
+}

--- a/v6/dropbox/oauth/oauth_test.go
+++ b/v6/dropbox/oauth/oauth_test.go
@@ -1,0 +1,277 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package oauth_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	dropboxoauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth"
+	"golang.org/x/oauth2"
+)
+
+const testVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+func TestPKCEFlowAuthCodeURL(t *testing.T) {
+	flow, err := dropboxoauth.NewPKCEFlow(
+		"app-key",
+		dropboxoauth.WithState("test-state"),
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithRedirectURL("http://localhost/callback"),
+		dropboxoauth.WithScopes("files.metadata.read", "files.content.write"),
+		dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopesUser),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.AuthCodeURL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	if authURL.Scheme != "https" || authURL.Host != "www.dropbox.com" || authURL.Path != "/1/oauth2/authorize" {
+		t.Fatalf("auth URL = %s", authURL)
+	}
+	assertQueryValue(t, query, "client_id", "app-key")
+	assertQueryValue(t, query, "response_type", "code")
+	assertQueryValue(t, query, "state", "test-state")
+	assertQueryValue(t, query, "redirect_uri", "http://localhost/callback")
+	assertQueryValue(t, query, "scope", "files.metadata.read files.content.write")
+	assertQueryValue(t, query, "include_granted_scopes", "user")
+	assertQueryValue(t, query, "token_access_type", "offline")
+	assertQueryValue(t, query, "code_challenge", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	assertQueryValue(t, query, "code_challenge_method", "S256")
+}
+
+func TestPKCEFlowGeneratesStateAndVerifier(t *testing.T) {
+	flow, err := dropboxoauth.NewPKCEFlow("app-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if flow.State() == "" {
+		t.Fatal("expected generated state")
+	}
+	if flow.Verifier() == "" {
+		t.Fatal("expected generated verifier")
+	}
+	if !strings.Contains(flow.AuthCodeURL(), "token_access_type=offline") {
+		t.Fatalf("expected offline token access type in auth URL, got %q", flow.AuthCodeURL())
+	}
+}
+
+func TestPKCEFlowExchangeSendsVerifierAndAppKey(t *testing.T) {
+	var requestURL string
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		requestURL = req.URL.String()
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expires_in":3600}`), nil
+	})
+
+	flow, err := dropboxoauth.NewPKCEFlow(
+		"app-key",
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := flow.Exchange(context.Background(), "auth-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.AccessToken != "access-token" || token.RefreshToken != "refresh-token" || token.TokenType != "Bearer" {
+		t.Fatalf("unexpected token: %#v", token)
+	}
+	if requestURL != "https://api.dropboxapi.com/1/oauth2/token" {
+		t.Fatalf("request URL = %q", requestURL)
+	}
+	assertQueryValue(t, form, "grant_type", "authorization_code")
+	assertQueryValue(t, form, "code", "auth-code")
+	assertQueryValue(t, form, "code_verifier", testVerifier)
+	assertQueryValue(t, form, "client_id", "app-key")
+	if got := form.Get("client_secret"); got != "" {
+		t.Fatalf("client_secret = %q, want empty", got)
+	}
+}
+
+func TestRefreshSendsRefreshTokenAndPreservesRefreshToken(t *testing.T) {
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"new-access","expires_in":3600}`), nil
+	})
+
+	token, err := dropboxoauth.Refresh(context.Background(), "app-key", &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, dropboxoauth.WithHTTPClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.AccessToken != "new-access" {
+		t.Fatalf("access token = %q, want new-access", token.AccessToken)
+	}
+	if token.RefreshToken != "old-refresh" {
+		t.Fatalf("refresh token = %q, want old-refresh", token.RefreshToken)
+	}
+	if token.Type() != "Bearer" {
+		t.Fatalf("token type = %q, want Bearer", token.Type())
+	}
+	assertQueryValue(t, form, "grant_type", "refresh_token")
+	assertQueryValue(t, form, "refresh_token", "old-refresh")
+	assertQueryValue(t, form, "client_id", "app-key")
+	if got := form.Get("client_secret"); got != "" {
+		t.Fatalf("client_secret = %q, want empty", got)
+	}
+}
+
+func TestTokenSourceRefreshesExpiredToken(t *testing.T) {
+	calls := 0
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return jsonResponse(http.StatusOK, `{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`), nil
+	})
+	source := dropboxoauth.TokenSource(context.Background(), "app-key", &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, dropboxoauth.WithHTTPClient(client))
+
+	token, err := source.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.AccessToken != "new-access" || token.RefreshToken != "new-refresh" {
+		t.Fatalf("unexpected token: %#v", token)
+	}
+	cached, err := source.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached.AccessToken != "new-access" {
+		t.Fatalf("cached access token = %q, want new-access", cached.AccessToken)
+	}
+	if calls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", calls)
+	}
+}
+
+func TestCustomDomainChangesOAuthEndpoints(t *testing.T) {
+	flow, err := dropboxoauth.NewPKCEFlow(
+		"app-key",
+		dropboxoauth.WithDomain(".example.com"),
+		dropboxoauth.WithState("state"),
+		dropboxoauth.WithVerifier(testVerifier),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.AuthCodeURL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authURL.Host != "meta.example.com" {
+		t.Fatalf("auth host = %q, want meta.example.com", authURL.Host)
+	}
+
+	var tokenHost string
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		tokenHost = req.URL.Host
+		return jsonResponse(http.StatusOK, `{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer"}`), nil
+	})
+	_, err = dropboxoauth.Refresh(context.Background(), "app-key", &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, dropboxoauth.WithDomain(".example.com"), dropboxoauth.WithHTTPClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokenHost != "api.example.com" {
+		t.Fatalf("token host = %q, want api.example.com", tokenHost)
+	}
+}
+
+func TestNewPKCEFlowRejectsMissingAppKey(t *testing.T) {
+	if _, err := dropboxoauth.NewPKCEFlow(" "); err == nil {
+		t.Fatal("expected missing app key error")
+	}
+}
+
+func TestRefreshRejectsMissingRefreshToken(t *testing.T) {
+	_, err := dropboxoauth.Refresh(context.Background(), "app-key", &oauth2.Token{AccessToken: "access-token"})
+	if err == nil {
+		t.Fatal("expected missing refresh token error")
+	}
+}
+
+func assertQueryValue(t *testing.T, values url.Values, key string, want string) {
+	t.Helper()
+	if got := values.Get(key); got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func readForm(req *http.Request) (url.Values, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	return url.ParseQuery(string(body))
+}
+
+func httpClient(fn func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{Transport: roundTripFunc(fn)}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -88,14 +88,18 @@ type Config struct {
 	AsAdminID string
 	// Path relative to which action should be taken
 	PathRoot string
-	// No need to set -- for testing only
+	// Dropbox API domain. The default is ".dropboxapi.com".
 	Domain string
-	// No need to set -- for testing only
+	// HTTP client used for authenticated Dropbox API calls. If set, Client takes
+	// precedence over TokenSource and Token.
 	Client *http.Client
 	// No need to set -- for testing only
 	HeaderGenerator func(hostType string, namespace string, route string) map[string]string
 	// No need to set -- for testing only
 	URLGenerator func(hostType string, namespace string, route string) string
+	// OAuth2 token source used for authenticated Dropbox API calls. If Client is
+	// nil and TokenSource is set, TokenSource takes precedence over Token.
+	TokenSource oauth2.TokenSource
 }
 
 // LogLevel defines a type that can set the desired level of logging the SDK will generate.
@@ -282,9 +286,13 @@ func NewContext(c Config) Context {
 
 	client := c.Client
 	if client == nil {
-		var conf = &oauth2.Config{Endpoint: OAuthEndpoint(domain)}
-		tok := &oauth2.Token{AccessToken: c.Token}
-		client = conf.Client(context.Background(), tok)
+		if c.TokenSource != nil {
+			client = oauth2.NewClient(context.Background(), c.TokenSource)
+		} else {
+			var conf = &oauth2.Config{Endpoint: OAuthEndpoint(domain)}
+			tok := &oauth2.Token{AccessToken: c.Token}
+			client = conf.Client(context.Background(), tok)
+		}
 	}
 
 	noAuthClient := c.Client

--- a/v6/dropbox/sdk_test.go
+++ b/v6/dropbox/sdk_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+	"golang.org/x/oauth2"
 )
 
 func generateURL(base string, namespace string, route string) string {
@@ -279,6 +280,97 @@ func TestExecuteBackwardCompatibility(t *testing.T) {
 	}
 }
 
+func TestNewContextUsesTokenSourceBeforeToken(t *testing.T) {
+	var authHeader string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			authHeader = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{
+		Token:       "static-token",
+		TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "source-token"}),
+		LogLevel:    dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		},
+	}
+	executeTestRequest(t, config)
+	if authHeader != "Bearer source-token" {
+		t.Fatalf("Authorization = %q, want %q", authHeader, "Bearer source-token")
+	}
+}
+
+func TestNewContextUsesTokenWhenTokenSourceUnset(t *testing.T) {
+	var authHeader string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			authHeader = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{
+		Token:    "static-token",
+		LogLevel: dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		},
+	}
+	executeTestRequest(t, config)
+	if authHeader != "Bearer static-token" {
+		t.Fatalf("Authorization = %q, want %q", authHeader, "Bearer static-token")
+	}
+}
+
+func TestNewContextClientTakesPrecedenceOverTokenSource(t *testing.T) {
+	var authHeader string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			authHeader = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{
+		Client:      ts.Client(),
+		Token:       "static-token",
+		TokenSource: failingTokenSource{t: t},
+		LogLevel:    dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		},
+	}
+	executeTestRequest(t, config)
+	if authHeader != "" {
+		t.Fatalf("Authorization = %q, want empty", authHeader)
+	}
+}
+
+func TestNewContextNoAuthDoesNotUseTokenSource(t *testing.T) {
+	var authHeader string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			authHeader = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{
+		TokenSource: failingTokenSource{t: t},
+		LogLevel:    dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		},
+	}
+	executeTestRequestWithAuth(t, config, "noauth")
+	if authHeader != "" {
+		t.Fatalf("Authorization = %q, want empty", authHeader)
+	}
+}
+
 func TestContextCancellation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -301,5 +393,42 @@ func TestContextCancellation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "context canceled") {
 		t.Errorf("expected context canceled error, got: %v", err)
+	}
+}
+
+type failingTokenSource struct {
+	t *testing.T
+}
+
+func (s failingTokenSource) Token() (*oauth2.Token, error) {
+	s.t.Helper()
+	s.t.Fatal("TokenSource should not be used when Config.Client is set")
+	return nil, fmt.Errorf("unexpected TokenSource use")
+}
+
+func executeTestRequest(t *testing.T, config dropbox.Config) {
+	t.Helper()
+	executeTestRequestWithAuth(t, config, "user")
+}
+
+func executeTestRequestWithAuth(t *testing.T, config dropbox.Config, auth string) {
+	t.Helper()
+
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      auth,
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resp) != "{}" {
+		t.Errorf("unexpected response: %s", string(resp))
+	}
+	if respBody != nil {
+		t.Errorf("unexpected response body: %v", respBody)
 	}
 }


### PR DESCRIPTION
## Summary

Adds first-class OAuth2 PKCE support to the Go SDK, requiring only an app key (no app secret), plus SDK wiring for refreshable tokens.

- New `dropbox/oauth` package:
  - `NewPKCEFlow` with `AuthCodeURL` / `Exchange` for the authorization-code flow
  - `Refresh` and `TokenSource` helpers for refreshable (offline) tokens
  - Functional options: domain, redirect URL, state, verifier, scopes, token access type, `include_granted_scopes`, HTTP client
- New `dropbox.Config.TokenSource` field. When `Config.Client` is unset, `TokenSource` takes precedence over the static `Token`, so access tokens refresh transparently during API calls. No-auth endpoints never receive the token source.
- README + CHANGELOG updates.

## Backward compatibility

Fully backward compatible. `TokenSource` is appended at the end of `Config` (positional literals unaffected), and the static-`Token` path is preserved byte-for-byte when `TokenSource` is nil.