### PR TITLE
Add web redirect PKCE OAuth flow with CSRF validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ summarized from the repository history.
 
 - Added the `dropbox/oauth` package with PKCE authorization URL, code
   exchange, and refresh-token helpers.
+- Added web redirect PKCE OAuth helpers with caller-owned CSRF validation.
 - Added `dropbox.Config.TokenSource` for refreshable OAuth token sources.
 
 ## v6.3.0 - 2026-07-04

--- a/README.md
+++ b/README.md
@@ -94,6 +94,49 @@ The PKCE helper requests offline access by default. Use
 `dropboxoauth.TokenSource` in `dropbox.Config` for automatic refresh, or call
 `dropboxoauth.Refresh` directly when you manage token storage yourself.
 
+For redirect-based web apps, use `NewWebPKCEFlow`. Each login attempt needs a
+single PKCE verifier for both `Start` and `Finish`; generate it with
+`oauth2.GenerateVerifier` from `golang.org/x/oauth2`, store it with the
+returned CSRF token in the user's session, then pass both values back when
+finishing the flow:
+
+```go
+verifier := oauth2.GenerateVerifier()
+flow, err := dropboxoauth.NewWebPKCEFlow(
+  appKey,
+  redirectURL,
+  dropboxoauth.WithVerifier(verifier),
+)
+if err != nil {
+  return err
+}
+
+authURL, csrfToken, err := flow.Start("optional-url-state")
+if err != nil {
+  return err
+}
+// Redirect the user to authURL and store csrfToken and verifier in your web session.
+
+// In the callback handler, load csrfToken and verifier from your web session.
+flow, err = dropboxoauth.NewWebPKCEFlow(
+  appKey,
+  redirectURL,
+  dropboxoauth.WithVerifier(verifier),
+)
+if err != nil {
+  return err
+}
+
+result, err := flow.Finish(r.Context(), r.URL.Query(), csrfToken)
+if err != nil {
+  return err
+}
+
+config := dropbox.Config{
+  TokenSource: dropboxoauth.TokenSource(r.Context(), appKey, result.Token),
+}
+```
+
 Existing apps that use an app secret can continue to use `golang.org/x/oauth2`
 directly with `dropbox.OAuthEndpoint(domain)`. The SDK still accepts a static
 access token through `dropbox.Config.Token`; for refreshable tokens, pass a

--- a/v6/dropbox/oauth/oauth.go
+++ b/v6/dropbox/oauth/oauth.go
@@ -23,8 +23,14 @@ package oauth
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +41,9 @@ import (
 const (
 	tokenAccessTypeParam      = "token_access_type"
 	includeGrantedScopesParam = "include_granted_scopes"
+	localeParam               = "locale"
+	stateSeparator            = "|"
+	csrfTokenBytes            = 16
 )
 
 // TokenAccessType controls whether Dropbox returns refreshable credentials.
@@ -68,6 +77,7 @@ type options struct {
 	scopes               []string
 	tokenAccessType      TokenAccessType
 	includeGrantedScopes IncludeGrantedScopes
+	locale               string
 	httpClient           *http.Client
 }
 
@@ -77,25 +87,118 @@ type PKCEFlow struct {
 	conf *oauth2.Config
 }
 
+// WebPKCEFlow manages redirect-based authorization URL generation and code
+// exchange for PKCE web apps.
+type WebPKCEFlow struct {
+	opts options
+	conf *oauth2.Config
+}
+
+// FlowResult contains OAuth authorization information returned by a flow.
+type FlowResult struct {
+	Token     *oauth2.Token
+	AccountID string
+	TeamID    string
+	UserID    string
+	URLState  string
+	Scopes    []string
+}
+
+// BadRequestError is returned when the redirect query is malformed.
+type BadRequestError struct {
+	Message string
+}
+
+func (e *BadRequestError) Error() string {
+	if e.Message == "" {
+		return "dropbox oauth: bad request"
+	}
+	return "dropbox oauth: bad request: " + e.Message
+}
+
+// BadStateError is returned when the caller has no stored CSRF state.
+type BadStateError struct {
+	Message string
+}
+
+func (e *BadStateError) Error() string {
+	if e.Message == "" {
+		return "dropbox oauth: bad state"
+	}
+	return "dropbox oauth: bad state: " + e.Message
+}
+
+// CSRFError is returned when the redirect state does not match the stored CSRF token.
+type CSRFError struct{}
+
+func (e *CSRFError) Error() string {
+	return "dropbox oauth: csrf token mismatch"
+}
+
+// NotApprovedError is returned when the user denies authorization.
+type NotApprovedError struct {
+	Description string
+}
+
+func (e *NotApprovedError) Error() string {
+	if e.Description == "" {
+		return "dropbox oauth: authorization was not approved"
+	}
+	return "dropbox oauth: authorization was not approved: " + e.Description
+}
+
+// ProviderError is returned when Dropbox redirects with an unexpected error.
+type ProviderError struct {
+	ErrorCode   string
+	Description string
+}
+
+func (e *ProviderError) Error() string {
+	if e.Description == "" {
+		return "dropbox oauth: provider error: " + e.ErrorCode
+	}
+	return "dropbox oauth: provider error: " + e.ErrorCode + ": " + e.Description
+}
+
 // NewPKCEFlow creates a Dropbox OAuth 2 PKCE flow.
 func NewPKCEFlow(appKey string, opts ...Option) (*PKCEFlow, error) {
-	appKey = strings.TrimSpace(appKey)
-	if appKey == "" {
-		return nil, errors.New("dropbox oauth: app key is required")
+	appKey, err := cleanAppKey(appKey)
+	if err != nil {
+		return nil, err
 	}
 
-	o := options{
-		tokenAccessType: TokenAccessTypeOffline,
-	}
-	applyOptions(&o, opts)
+	o := newFlowOptions(opts)
 	if o.state == "" {
 		o.state = oauth2.GenerateVerifier()
 	}
-	if o.verifier == "" {
-		o.verifier = oauth2.GenerateVerifier()
-	}
 
 	return &PKCEFlow{
+		opts: o,
+		conf: oauthConfig(appKey, o.domain, o.redirectURL, o.scopes),
+	}, nil
+}
+
+// NewWebPKCEFlow creates a Dropbox OAuth 2 PKCE flow for web redirects.
+func NewWebPKCEFlow(appKey string, redirectURL string, opts ...Option) (*WebPKCEFlow, error) {
+	appKey, err := cleanAppKey(appKey)
+	if err != nil {
+		return nil, err
+	}
+
+	redirectURL = strings.TrimSpace(redirectURL)
+	o := newFlowOptions(opts)
+	if o.state != "" {
+		return nil, errors.New("dropbox oauth: WithState is not supported by WebPKCEFlow; pass URL state to Start")
+	}
+	o.redirectURL = strings.TrimSpace(o.redirectURL)
+	if o.redirectURL == "" {
+		o.redirectURL = redirectURL
+	}
+	if o.redirectURL == "" {
+		return nil, errors.New("dropbox oauth: redirect URL is required")
+	}
+
+	return &WebPKCEFlow{
 		opts: o,
 		conf: oauthConfig(appKey, o.domain, o.redirectURL, o.scopes),
 	}, nil
@@ -115,7 +218,8 @@ func WithRedirectURL(url string) Option {
 	}
 }
 
-// WithState configures the OAuth state value.
+// WithState configures the OAuth state value for PKCEFlow. WebPKCEFlow builds
+// state from its CSRF token and the urlState passed to Start.
 func WithState(state string) Option {
 	return func(opts *options) {
 		opts.state = state
@@ -150,6 +254,13 @@ func WithIncludeGrantedScopes(value IncludeGrantedScopes) Option {
 	}
 }
 
+// WithLocale configures the locale shown on the authorization page.
+func WithLocale(locale string) Option {
+	return func(opts *options) {
+		opts.locale = locale
+	}
+}
+
 // WithHTTPClient configures the HTTP client used for token exchange or refresh.
 func WithHTTPClient(client *http.Client) Option {
 	return func(opts *options) {
@@ -159,19 +270,12 @@ func WithHTTPClient(client *http.Client) Option {
 
 // AuthCodeURL returns the authorization URL for this PKCE flow.
 func (f *PKCEFlow) AuthCodeURL() string {
-	options := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(f.opts.verifier)}
-	if f.opts.tokenAccessType != "" {
-		options = append(options, oauth2.SetAuthURLParam(tokenAccessTypeParam, string(f.opts.tokenAccessType)))
-	}
-	if f.opts.includeGrantedScopes != "" {
-		options = append(options, oauth2.SetAuthURLParam(includeGrantedScopesParam, string(f.opts.includeGrantedScopes)))
-	}
-	return f.conf.AuthCodeURL(f.opts.state, options...)
+	return f.conf.AuthCodeURL(f.opts.state, authCodeOptions(f.opts)...)
 }
 
 // Exchange exchanges an authorization code for an OAuth token.
 func (f *PKCEFlow) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
-	return f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, oauth2.VerifierOption(f.opts.verifier))
+	return f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, exchangeOptions(f.opts)...)
 }
 
 // State returns the OAuth state for this flow.
@@ -182,6 +286,65 @@ func (f *PKCEFlow) State() string {
 // Verifier returns the PKCE verifier for this flow.
 func (f *PKCEFlow) Verifier() string {
 	return f.opts.verifier
+}
+
+// Start returns the authorization URL and CSRF token for this web PKCE flow.
+func (f *WebPKCEFlow) Start(urlState string) (authURL string, csrfToken string, err error) {
+	csrfToken, err = generateCSRFToken()
+	if err != nil {
+		return "", "", err
+	}
+
+	state := csrfToken
+	if urlState != "" {
+		state += stateSeparator + urlState
+	}
+
+	return f.conf.AuthCodeURL(state, authCodeOptions(f.opts)...), csrfToken, nil
+}
+
+// Finish validates a redirect query and exchanges its authorization code for an OAuth token.
+func (f *WebPKCEFlow) Finish(ctx context.Context, query url.Values, csrfToken string) (*FlowResult, error) {
+	state := query.Get("state")
+	if state == "" {
+		return nil, &BadRequestError{Message: "missing query parameter state"}
+	}
+
+	code := query.Get("code")
+	errorCode := query.Get("error")
+	if code != "" && errorCode != "" {
+		return nil, &BadRequestError{Message: "query parameters code and error are both set"}
+	}
+	if code == "" && errorCode == "" {
+		return nil, &BadRequestError{Message: "neither query parameter code nor error is set"}
+	}
+
+	if csrfToken == "" {
+		return nil, &BadStateError{Message: "missing csrf token"}
+	}
+
+	givenCSRF, urlState := splitState(state)
+	if !safeEquals(csrfToken, givenCSRF) {
+		return nil, &CSRFError{}
+	}
+
+	if errorCode != "" {
+		description := query.Get("error_description")
+		if errorCode == "access_denied" {
+			return nil, &NotApprovedError{Description: description}
+		}
+		return nil, &ProviderError{ErrorCode: errorCode, Description: description}
+	}
+
+	token, err := f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, exchangeOptions(f.opts)...)
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, errors.New("dropbox oauth: token exchange returned nil token")
+	}
+
+	return flowResultFromToken(token, urlState), nil
 }
 
 // Refresh refreshes a Dropbox OAuth token.
@@ -229,6 +392,43 @@ func applyOptions(o *options, opts []Option) {
 	}
 }
 
+func cleanAppKey(appKey string) (string, error) {
+	appKey = strings.TrimSpace(appKey)
+	if appKey == "" {
+		return "", errors.New("dropbox oauth: app key is required")
+	}
+	return appKey, nil
+}
+
+func newFlowOptions(opts []Option) options {
+	o := options{
+		tokenAccessType: TokenAccessTypeOffline,
+	}
+	applyOptions(&o, opts)
+	if o.verifier == "" {
+		o.verifier = oauth2.GenerateVerifier()
+	}
+	return o
+}
+
+func authCodeOptions(o options) []oauth2.AuthCodeOption {
+	options := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(o.verifier)}
+	if o.tokenAccessType != "" {
+		options = append(options, oauth2.SetAuthURLParam(tokenAccessTypeParam, string(o.tokenAccessType)))
+	}
+	if o.includeGrantedScopes != "" {
+		options = append(options, oauth2.SetAuthURLParam(includeGrantedScopesParam, string(o.includeGrantedScopes)))
+	}
+	if o.locale != "" {
+		options = append(options, oauth2.SetAuthURLParam(localeParam, o.locale))
+	}
+	return options
+}
+
+func exchangeOptions(o options) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{oauth2.VerifierOption(o.verifier)}
+}
+
 func oauthConfig(appKey string, domain string, redirectURL string, scopes []string) *oauth2.Config {
 	endpoint := dropbox.OAuthEndpoint(domain)
 	endpoint.AuthStyle = oauth2.AuthStyleInParams
@@ -248,4 +448,70 @@ func withHTTPClient(ctx context.Context, client *http.Client) context.Context {
 		return ctx
 	}
 	return context.WithValue(ctx, oauth2.HTTPClient, client)
+}
+
+func generateCSRFToken() (string, error) {
+	b := make([]byte, csrfTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func splitState(state string) (csrfToken string, urlState string) {
+	csrfToken, urlState, _ = strings.Cut(state, stateSeparator)
+	return csrfToken, urlState
+}
+
+func safeEquals(a string, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func flowResultFromToken(token *oauth2.Token, urlState string) *FlowResult {
+	return &FlowResult{
+		Token:     token,
+		AccountID: extraString(token, "account_id"),
+		TeamID:    extraString(token, "team_id"),
+		UserID:    extraString(token, "uid"),
+		URLState:  urlState,
+		Scopes:    strings.Fields(extraString(token, "scope")),
+	}
+}
+
+func extraString(token *oauth2.Token, key string) string {
+	value := token.Extra(key)
+	switch v := value.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case json.Number:
+		return v.String()
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
 }

--- a/v6/dropbox/oauth/oauth_test.go
+++ b/v6/dropbox/oauth/oauth_test.go
@@ -22,6 +22,8 @@ package oauth_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -122,6 +124,260 @@ func TestPKCEFlowExchangeSendsVerifierAndAppKey(t *testing.T) {
 	assertQueryValue(t, form, "client_id", "app-key")
 	if got := form.Get("client_secret"); got != "" {
 		t.Fatalf("client_secret = %q, want empty", got)
+	}
+}
+
+func TestWebPKCEFlowStart(t *testing.T) {
+	flow, err := dropboxoauth.NewWebPKCEFlow(
+		"app-key",
+		"http://localhost/callback",
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithScopes("files.metadata.read", "files.content.write"),
+		dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopesUser),
+		dropboxoauth.WithLocale("en_US"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawAuthURL, csrfToken, err := flow.Start("url-state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if csrfToken == "" {
+		t.Fatal("expected csrf token")
+	}
+
+	authURL, err := url.Parse(rawAuthURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	if authURL.Scheme != "https" || authURL.Host != "www.dropbox.com" || authURL.Path != "/1/oauth2/authorize" {
+		t.Fatalf("auth URL = %s", authURL)
+	}
+	assertQueryValue(t, query, "client_id", "app-key")
+	assertQueryValue(t, query, "response_type", "code")
+	assertQueryValue(t, query, "redirect_uri", "http://localhost/callback")
+	assertQueryValue(t, query, "state", csrfToken+"|url-state")
+	assertQueryValue(t, query, "scope", "files.metadata.read files.content.write")
+	assertQueryValue(t, query, "include_granted_scopes", "user")
+	assertQueryValue(t, query, "token_access_type", "offline")
+	assertQueryValue(t, query, "code_challenge", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	assertQueryValue(t, query, "code_challenge_method", "S256")
+	assertQueryValue(t, query, "locale", "en_US")
+}
+
+func TestWebPKCEFlowStartGeneratesVerifierAndCSRFOnlyState(t *testing.T) {
+	flow, err := dropboxoauth.NewWebPKCEFlow("app-key", "http://localhost/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawAuthURL, csrfToken, err := flow.Start("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(rawAuthURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	assertQueryValue(t, query, "state", csrfToken)
+	if got := query.Get("code_challenge"); got == "" || got == "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU" {
+		t.Fatalf("code_challenge = %q, want generated verifier challenge", got)
+	}
+	assertQueryValue(t, query, "code_challenge_method", "S256")
+}
+
+func TestWebPKCEFlowFinishExchangesCodeAndReturnsResult(t *testing.T) {
+	var requestURL string
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		requestURL = req.URL.String()
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expires_in":3600,"account_id":"dbid:account","team_id":"dbtid:team","uid":12345,"scope":"files.metadata.read files.content.write"}`), nil
+	})
+
+	flow, err := dropboxoauth.NewWebPKCEFlow(
+		"app-key",
+		"http://localhost/callback",
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithHTTPClient(client),
+		dropboxoauth.WithLocale("en_US"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := flow.Finish(context.Background(), url.Values{
+		"state": {"stored-csrf|url-state"},
+		"code":  {"auth-code"},
+	}, "stored-csrf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Token.AccessToken != "access-token" || result.Token.RefreshToken != "refresh-token" || result.Token.TokenType != "Bearer" {
+		t.Fatalf("unexpected token: %#v", result.Token)
+	}
+	if result.Token.Expiry.IsZero() {
+		t.Fatal("expected token expiry")
+	}
+	if result.AccountID != "dbid:account" || result.TeamID != "dbtid:team" || result.UserID != "12345" {
+		t.Fatalf("unexpected account info: %#v", result)
+	}
+	if result.URLState != "url-state" {
+		t.Fatalf("url state = %q, want url-state", result.URLState)
+	}
+	assertScopes(t, result.Scopes, "files.metadata.read", "files.content.write")
+
+	if requestURL != "https://api.dropboxapi.com/1/oauth2/token" {
+		t.Fatalf("request URL = %q", requestURL)
+	}
+	assertQueryValue(t, form, "grant_type", "authorization_code")
+	assertQueryValue(t, form, "code", "auth-code")
+	assertQueryValue(t, form, "code_verifier", testVerifier)
+	assertQueryValue(t, form, "client_id", "app-key")
+	assertQueryValue(t, form, "redirect_uri", "http://localhost/callback")
+	if got := form.Get("locale"); got != "" {
+		t.Fatalf("locale = %q, want empty", got)
+	}
+	if got := form.Get("client_secret"); got != "" {
+		t.Fatalf("client_secret = %q, want empty", got)
+	}
+}
+
+func TestWebPKCEFlowStartUsesCustomDomainAndRedirectFallback(t *testing.T) {
+	flow, err := dropboxoauth.NewWebPKCEFlow(
+		"app-key",
+		"http://localhost/callback",
+		dropboxoauth.WithDomain(".example.com"),
+		dropboxoauth.WithRedirectURL(""),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawAuthURL, _, err := flow.Start("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(rawAuthURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authURL.Host != "meta.example.com" {
+		t.Fatalf("auth host = %q, want meta.example.com", authURL.Host)
+	}
+	assertQueryValue(t, authURL.Query(), "redirect_uri", "http://localhost/callback")
+}
+
+func TestWebPKCEFlowFinishRejectsRedirectErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     url.Values
+		csrfToken string
+		wantErr   error
+	}{
+		{
+			name: "missing state",
+			query: url.Values{
+				"code": {"auth-code"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.BadRequestError{},
+		},
+		{
+			name: "missing code and error",
+			query: url.Values{
+				"state": {"stored-csrf"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.BadRequestError{},
+		},
+		{
+			name: "code and error",
+			query: url.Values{
+				"state": {"stored-csrf"},
+				"code":  {"auth-code"},
+				"error": {"access_denied"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.BadRequestError{},
+		},
+		{
+			name: "missing csrf token",
+			query: url.Values{
+				"state": {"stored-csrf"},
+				"code":  {"auth-code"},
+			},
+			wantErr: &dropboxoauth.BadStateError{},
+		},
+		{
+			name: "csrf mismatch",
+			query: url.Values{
+				"state": {"other-csrf"},
+				"code":  {"auth-code"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.CSRFError{},
+		},
+		{
+			name: "access denied",
+			query: url.Values{
+				"state":             {"stored-csrf"},
+				"error":             {"access_denied"},
+				"error_description": {"denied"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.NotApprovedError{},
+		},
+		{
+			name: "provider error",
+			query: url.Values{
+				"state":             {"stored-csrf"},
+				"error":             {"server_error"},
+				"error_description": {"bad"},
+			},
+			csrfToken: "stored-csrf",
+			wantErr:   &dropboxoauth.ProviderError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flow, err := dropboxoauth.NewWebPKCEFlow("app-key", "http://localhost/callback")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = flow.Finish(context.Background(), tt.query, tt.csrfToken)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if _, ok := tt.wantErr.(*dropboxoauth.CSRFError); ok && strings.Contains(fmt.Sprintf("%+v", err), tt.csrfToken) {
+				t.Fatalf("csrf error leaked stored token: %#v", err)
+			}
+			assertErrorAs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestNewWebPKCEFlowRejectsMissingInputs(t *testing.T) {
+	if _, err := dropboxoauth.NewWebPKCEFlow(" ", "http://localhost/callback"); err == nil {
+		t.Fatal("expected missing app key error")
+	}
+	if _, err := dropboxoauth.NewWebPKCEFlow("app-key", " "); err == nil {
+		t.Fatal("expected missing redirect URL error")
+	}
+	if _, err := dropboxoauth.NewWebPKCEFlow("app-key", "http://localhost/callback", dropboxoauth.WithState("state")); err == nil {
+		t.Fatal("expected unsupported state error")
 	}
 }
 
@@ -247,6 +503,51 @@ func assertQueryValue(t *testing.T, values url.Values, key string, want string) 
 	t.Helper()
 	if got := values.Get(key); got != want {
 		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func assertScopes(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("scopes = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scopes = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func assertErrorAs(t *testing.T, err error, want error) {
+	t.Helper()
+	switch want.(type) {
+	case *dropboxoauth.BadRequestError:
+		var target *dropboxoauth.BadRequestError
+		if !errors.As(err, &target) {
+			t.Fatalf("error = %T %v, want %T", err, err, want)
+		}
+	case *dropboxoauth.BadStateError:
+		var target *dropboxoauth.BadStateError
+		if !errors.As(err, &target) {
+			t.Fatalf("error = %T %v, want %T", err, err, want)
+		}
+	case *dropboxoauth.CSRFError:
+		var target *dropboxoauth.CSRFError
+		if !errors.As(err, &target) {
+			t.Fatalf("error = %T %v, want %T", err, err, want)
+		}
+	case *dropboxoauth.NotApprovedError:
+		var target *dropboxoauth.NotApprovedError
+		if !errors.As(err, &target) {
+			t.Fatalf("error = %T %v, want %T", err, err, want)
+		}
+	case *dropboxoauth.ProviderError:
+		var target *dropboxoauth.ProviderError
+		if !errors.As(err, &target) {
+			t.Fatalf("error = %T %v, want %T", err, err, want)
+		}
+	default:
+		t.Fatalf("unhandled wanted error type %T", want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `WebPKCEFlow` for redirect-based web apps, alongside the existing `PKCEFlow` (from #146).

- **`Start(urlState)`** generates a CSRF token and the authorization URL.
- **`Finish(ctx, query, csrfToken)`** validates the redirect query (state present, `code`/`error` mutually exclusive, constant-time CSRF match) and exchanges the code, returning a `FlowResult` with account/team/user IDs, granted scopes, and the caller-supplied URL state.
- Typed redirect errors: `BadRequestError`, `BadStateError`, `CSRFError`, `NotApprovedError`, `ProviderError`. `CSRFError` carries no secret.
- `WithLocale` sets the locale on the authorization page (not the token exchange).
- `NewWebPKCEFlow` rejects `WithState` (state is derived from the CSRF token + `urlState`) and falls back to the positional redirect URL when `WithRedirectURL` is unset.
- `extraString` handles both string and numeric JSON token fields.
- Shared construction between the two flows via `cleanAppKey` / `newFlowOptions`.

## Security

CSRF validation runs before the redirect `error` param is acted on and before the code exchange. The comparison is constant-time (`crypto/subtle`), the token is 128-bit `crypto/rand`, and the mismatch error exposes no secret.