### PR TITLE
Add general OAuth2 flows with app-secret and PKCE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ summarized from the repository history.
 - Added the `dropbox/oauth` package with PKCE authorization URL, code
   exchange, and refresh-token helpers.
 - Added web redirect PKCE OAuth helpers with caller-owned CSRF validation.
+- Added Python-style OAuth 2 no-redirect and web flows with app-secret support,
+  PKCE mode, legacy token access type compatibility, and option validation.
 - Added `dropbox.Config.TokenSource` for refreshable OAuth token sources.
 
 ## v6.3.0 - 2026-07-04

--- a/README.md
+++ b/README.md
@@ -137,10 +137,41 @@ config := dropbox.Config{
 }
 ```
 
-Existing apps that use an app secret can continue to use `golang.org/x/oauth2`
-directly with `dropbox.OAuthEndpoint(domain)`. The SDK still accepts a static
-access token through `dropbox.Config.Token`; for refreshable tokens, pass a
-token source through `dropbox.Config.TokenSource`.
+Confidential apps that can safely keep an app secret can use
+`NewOAuth2FlowNoRedirect` or `NewOAuth2Flow` instead. These helpers support the
+same token access types as Dropbox's Python SDK: omit the token access type to
+use the app default, use `TokenAccessTypeOffline` for refresh tokens, or use the
+deprecated `TokenAccessTypeLegacy` only for legacy compatibility.
+
+```go
+flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+  appKey,
+  dropboxoauth.WithAppSecret(appSecret),
+  dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessTypeOffline),
+)
+if err != nil {
+  return err
+}
+
+fmt.Printf("Go to %s\n", flow.Start())
+// Read the authorization code from the user.
+result, err := flow.Finish(ctx, code)
+if err != nil {
+  return err
+}
+
+config := dropbox.Config{
+  TokenSource: dropboxoauth.TokenSource(
+    ctx,
+    appKey,
+    result.Token,
+    dropboxoauth.WithAppSecret(appSecret),
+  ),
+}
+```
+
+The SDK still accepts a static access token through `dropbox.Config.Token`; for
+refreshable tokens, pass a token source through `dropbox.Config.TokenSource`.
 
 ### Making API calls
 

--- a/v6/dropbox/oauth/oauth.go
+++ b/v6/dropbox/oauth/oauth.go
@@ -54,6 +54,10 @@ const (
 	TokenAccessTypeOffline TokenAccessType = "offline"
 	// TokenAccessTypeOnline requests only a short-lived access token.
 	TokenAccessTypeOnline TokenAccessType = "online"
+	// TokenAccessTypeLegacy requests a long-lived access token.
+	//
+	// Deprecated: prefer TokenAccessTypeOffline and refresh tokens.
+	TokenAccessTypeLegacy TokenAccessType = "legacy"
 )
 
 // IncludeGrantedScopes controls whether Dropbox reuses previously granted scopes.
@@ -71,9 +75,11 @@ type Option func(*options)
 
 type options struct {
 	domain               string
+	appSecret            string
 	redirectURL          string
 	state                string
 	verifier             string
+	usePKCE              bool
 	scopes               []string
 	tokenAccessType      TokenAccessType
 	includeGrantedScopes IncludeGrantedScopes
@@ -83,6 +89,20 @@ type options struct {
 
 // PKCEFlow manages authorization URL generation and code exchange for PKCE.
 type PKCEFlow struct {
+	opts options
+	conf *oauth2.Config
+}
+
+// OAuth2FlowNoRedirect manages authorization URL generation and code exchange
+// for OAuth 2 apps that do not use a redirect URI.
+type OAuth2FlowNoRedirect struct {
+	opts options
+	conf *oauth2.Config
+}
+
+// OAuth2Flow manages redirect-based authorization URL generation and code
+// exchange for OAuth 2 web apps.
+type OAuth2Flow struct {
 	opts options
 	conf *oauth2.Config
 }
@@ -167,14 +187,73 @@ func NewPKCEFlow(appKey string, opts ...Option) (*PKCEFlow, error) {
 		return nil, err
 	}
 
-	o := newFlowOptions(opts)
+	o, err := newPKCEOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if o.appSecret != "" {
+		return nil, errors.New("dropbox oauth: WithAppSecret is not supported by PKCEFlow")
+	}
 	if o.state == "" {
-		o.state = oauth2.GenerateVerifier()
+		o.state, err = generateVerifier()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &PKCEFlow{
 		opts: o,
-		conf: oauthConfig(appKey, o.domain, o.redirectURL, o.scopes),
+		conf: oauthConfig(appKey, "", o.domain, o.redirectURL, o.scopes),
+	}, nil
+}
+
+// NewOAuth2FlowNoRedirect creates a Dropbox OAuth 2 flow for apps that do not
+// use a redirect URI. Pass WithAppSecret for confidential apps or WithPKCE for
+// public clients.
+func NewOAuth2FlowNoRedirect(appKey string, opts ...Option) (*OAuth2FlowNoRedirect, error) {
+	appKey, err := cleanAppKey(appKey)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := newOAuth2Options(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OAuth2FlowNoRedirect{
+		opts: o,
+		conf: oauthConfig(appKey, flowAppSecret(o), o.domain, "", o.scopes),
+	}, nil
+}
+
+// NewOAuth2Flow creates a Dropbox OAuth 2 flow for web redirects. Pass
+// WithAppSecret for confidential apps or WithPKCE for public clients.
+func NewOAuth2Flow(appKey string, redirectURL string, opts ...Option) (*OAuth2Flow, error) {
+	appKey, err := cleanAppKey(appKey)
+	if err != nil {
+		return nil, err
+	}
+
+	redirectURL = strings.TrimSpace(redirectURL)
+	o, err := newOAuth2Options(opts)
+	if err != nil {
+		return nil, err
+	}
+	if o.state != "" {
+		return nil, errors.New("dropbox oauth: WithState is not supported by OAuth2Flow; pass URL state to Start")
+	}
+	o.redirectURL = strings.TrimSpace(o.redirectURL)
+	if o.redirectURL == "" {
+		o.redirectURL = redirectURL
+	}
+	if o.redirectURL == "" {
+		return nil, errors.New("dropbox oauth: redirect URL is required")
+	}
+
+	return &OAuth2Flow{
+		opts: o,
+		conf: oauthConfig(appKey, flowAppSecret(o), o.domain, o.redirectURL, o.scopes),
 	}, nil
 }
 
@@ -186,7 +265,13 @@ func NewWebPKCEFlow(appKey string, redirectURL string, opts ...Option) (*WebPKCE
 	}
 
 	redirectURL = strings.TrimSpace(redirectURL)
-	o := newFlowOptions(opts)
+	o, err := newPKCEOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	if o.appSecret != "" {
+		return nil, errors.New("dropbox oauth: WithAppSecret is not supported by WebPKCEFlow")
+	}
 	if o.state != "" {
 		return nil, errors.New("dropbox oauth: WithState is not supported by WebPKCEFlow; pass URL state to Start")
 	}
@@ -200,7 +285,7 @@ func NewWebPKCEFlow(appKey string, redirectURL string, opts ...Option) (*WebPKCE
 
 	return &WebPKCEFlow{
 		opts: o,
-		conf: oauthConfig(appKey, o.domain, o.redirectURL, o.scopes),
+		conf: oauthConfig(appKey, "", o.domain, o.redirectURL, o.scopes),
 	}, nil
 }
 
@@ -211,6 +296,20 @@ func WithDomain(domain string) Option {
 	}
 }
 
+// WithAppSecret configures the Dropbox API app secret for confidential OAuth apps.
+func WithAppSecret(secret string) Option {
+	return func(opts *options) {
+		opts.appSecret = strings.TrimSpace(secret)
+	}
+}
+
+// WithPKCE configures general OAuth flows to use PKCE instead of an app secret.
+func WithPKCE() Option {
+	return func(opts *options) {
+		opts.usePKCE = true
+	}
+}
+
 // WithRedirectURL configures the OAuth redirect URL.
 func WithRedirectURL(url string) Option {
 	return func(opts *options) {
@@ -218,8 +317,8 @@ func WithRedirectURL(url string) Option {
 	}
 }
 
-// WithState configures the OAuth state value for PKCEFlow. WebPKCEFlow builds
-// state from its CSRF token and the urlState passed to Start.
+// WithState configures the OAuth state value for no-redirect flows. Web flows
+// build state from their CSRF token and the urlState passed to Start.
 func WithState(state string) Option {
 	return func(opts *options) {
 		opts.state = state
@@ -230,13 +329,14 @@ func WithState(state string) Option {
 func WithVerifier(verifier string) Option {
 	return func(opts *options) {
 		opts.verifier = verifier
+		opts.usePKCE = true
 	}
 }
 
 // WithScopes configures OAuth scopes.
 func WithScopes(scopes ...string) Option {
 	return func(opts *options) {
-		opts.scopes = append([]string(nil), scopes...)
+		opts.scopes = append(make([]string, 0, len(scopes)), scopes...)
 	}
 }
 
@@ -254,7 +354,7 @@ func WithIncludeGrantedScopes(value IncludeGrantedScopes) Option {
 	}
 }
 
-// WithLocale configures the locale shown on the authorization page.
+// WithLocale configures the locale sent to Dropbox during OAuth.
 func WithLocale(locale string) Option {
 	return func(opts *options) {
 		opts.locale = locale
@@ -288,8 +388,40 @@ func (f *PKCEFlow) Verifier() string {
 	return f.opts.verifier
 }
 
+// Start returns the authorization URL for this no-redirect OAuth flow.
+func (f *OAuth2FlowNoRedirect) Start() string {
+	return f.conf.AuthCodeURL(f.opts.state, authCodeOptions(f.opts)...)
+}
+
+// Finish exchanges an authorization code for OAuth authorization information.
+func (f *OAuth2FlowNoRedirect) Finish(ctx context.Context, code string) (*FlowResult, error) {
+	token, err := f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, exchangeOptions(f.opts)...)
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, errors.New("dropbox oauth: token exchange returned nil token")
+	}
+	return flowResultFromToken(token, ""), nil
+}
+
+// Start returns the authorization URL and CSRF token for this web OAuth flow.
+func (f *OAuth2Flow) Start(urlState string) (authURL string, csrfToken string, err error) {
+	return startWebFlow(f.conf, f.opts, urlState)
+}
+
+// Finish validates a redirect query and exchanges its authorization code for
+// OAuth authorization information.
+func (f *OAuth2Flow) Finish(ctx context.Context, query url.Values, csrfToken string) (*FlowResult, error) {
+	return finishWebFlow(ctx, f.conf, f.opts, query, csrfToken)
+}
+
 // Start returns the authorization URL and CSRF token for this web PKCE flow.
 func (f *WebPKCEFlow) Start(urlState string) (authURL string, csrfToken string, err error) {
+	return startWebFlow(f.conf, f.opts, urlState)
+}
+
+func startWebFlow(conf *oauth2.Config, opts options, urlState string) (authURL string, csrfToken string, err error) {
 	csrfToken, err = generateCSRFToken()
 	if err != nil {
 		return "", "", err
@@ -300,11 +432,15 @@ func (f *WebPKCEFlow) Start(urlState string) (authURL string, csrfToken string, 
 		state += stateSeparator + urlState
 	}
 
-	return f.conf.AuthCodeURL(state, authCodeOptions(f.opts)...), csrfToken, nil
+	return conf.AuthCodeURL(state, authCodeOptions(opts)...), csrfToken, nil
 }
 
 // Finish validates a redirect query and exchanges its authorization code for an OAuth token.
 func (f *WebPKCEFlow) Finish(ctx context.Context, query url.Values, csrfToken string) (*FlowResult, error) {
+	return finishWebFlow(ctx, f.conf, f.opts, query, csrfToken)
+}
+
+func finishWebFlow(ctx context.Context, conf *oauth2.Config, opts options, query url.Values, csrfToken string) (*FlowResult, error) {
 	state := query.Get("state")
 	if state == "" {
 		return nil, &BadRequestError{Message: "missing query parameter state"}
@@ -336,7 +472,7 @@ func (f *WebPKCEFlow) Finish(ctx context.Context, query url.Values, csrfToken st
 		return nil, &ProviderError{ErrorCode: errorCode, Description: description}
 	}
 
-	token, err := f.conf.Exchange(withHTTPClient(ctx, f.opts.httpClient), code, exchangeOptions(f.opts)...)
+	token, err := conf.Exchange(withHTTPClient(ctx, opts.httpClient), code, exchangeOptions(opts)...)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +502,7 @@ func Refresh(ctx context.Context, appKey string, token *oauth2.Token, opts ...Op
 	expired := *token
 	expired.Expiry = time.Now().Add(-time.Second)
 
-	refreshed, err := oauthConfig(appKey, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), &expired).Token()
+	refreshed, err := oauthConfig(appKey, o.appSecret, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), &expired).Token()
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +517,7 @@ func TokenSource(ctx context.Context, appKey string, token *oauth2.Token, opts .
 	appKey = strings.TrimSpace(appKey)
 	o := options{}
 	applyOptions(&o, opts)
-	return oauthConfig(appKey, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), token)
+	return oauthConfig(appKey, o.appSecret, o.domain, "", nil).TokenSource(withHTTPClient(ctx, o.httpClient), token)
 }
 
 func applyOptions(o *options, opts []Option) {
@@ -400,19 +536,99 @@ func cleanAppKey(appKey string) (string, error) {
 	return appKey, nil
 }
 
-func newFlowOptions(opts []Option) options {
+func newPKCEOptions(opts []Option) (options, error) {
 	o := options{
+		usePKCE:         true,
 		tokenAccessType: TokenAccessTypeOffline,
 	}
 	applyOptions(&o, opts)
 	if o.verifier == "" {
-		o.verifier = oauth2.GenerateVerifier()
+		verifier, err := generateVerifier()
+		if err != nil {
+			return options{}, err
+		}
+		o.verifier = verifier
 	}
-	return o
+	if err := validateOAuth2Options(o); err != nil {
+		return options{}, err
+	}
+	return o, nil
+}
+
+func newOAuth2Options(opts []Option) (options, error) {
+	o := options{}
+	applyOptions(&o, opts)
+	o.appSecret = strings.TrimSpace(o.appSecret)
+	if o.verifier != "" {
+		o.usePKCE = true
+	}
+	if o.appSecret != "" && o.usePKCE {
+		return options{}, errors.New("dropbox oauth: WithAppSecret cannot be combined with WithPKCE or WithVerifier")
+	}
+	if o.usePKCE && o.verifier == "" {
+		verifier, err := generateVerifier()
+		if err != nil {
+			return options{}, err
+		}
+		o.verifier = verifier
+	}
+	if o.appSecret == "" && !o.usePKCE {
+		return options{}, errors.New("dropbox oauth: either WithAppSecret or WithPKCE is required")
+	}
+	if err := validateOAuth2Options(o); err != nil {
+		return options{}, err
+	}
+	return o, nil
+}
+
+func flowAppSecret(o options) string {
+	if o.usePKCE {
+		return ""
+	}
+	return o.appSecret
+}
+
+func validateOAuth2Options(o options) error {
+	if o.tokenAccessType != "" && !validTokenAccessType(o.tokenAccessType) {
+		return errors.New("dropbox oauth: token access type must be offline, online, or legacy")
+	}
+	if o.scopes != nil && len(o.scopes) == 0 {
+		return errors.New("dropbox oauth: scopes must not be empty")
+	}
+	if o.includeGrantedScopes != "" {
+		if !validIncludeGrantedScopes(o.includeGrantedScopes) {
+			return errors.New("dropbox oauth: include granted scopes must be user or team")
+		}
+		if o.scopes == nil {
+			return errors.New("dropbox oauth: scopes are required when include granted scopes is set")
+		}
+	}
+	return nil
+}
+
+func validTokenAccessType(value TokenAccessType) bool {
+	switch value {
+	case TokenAccessTypeOffline, TokenAccessTypeOnline, TokenAccessTypeLegacy:
+		return true
+	default:
+		return false
+	}
+}
+
+func validIncludeGrantedScopes(value IncludeGrantedScopes) bool {
+	switch value {
+	case IncludeGrantedScopesUser, IncludeGrantedScopesTeam:
+		return true
+	default:
+		return false
+	}
 }
 
 func authCodeOptions(o options) []oauth2.AuthCodeOption {
-	options := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(o.verifier)}
+	options := []oauth2.AuthCodeOption{}
+	if o.usePKCE {
+		options = append(options, oauth2.S256ChallengeOption(o.verifier))
+	}
 	if o.tokenAccessType != "" {
 		options = append(options, oauth2.SetAuthURLParam(tokenAccessTypeParam, string(o.tokenAccessType)))
 	}
@@ -426,17 +642,25 @@ func authCodeOptions(o options) []oauth2.AuthCodeOption {
 }
 
 func exchangeOptions(o options) []oauth2.AuthCodeOption {
-	return []oauth2.AuthCodeOption{oauth2.VerifierOption(o.verifier)}
+	options := []oauth2.AuthCodeOption{}
+	if o.usePKCE {
+		options = append(options, oauth2.VerifierOption(o.verifier))
+	}
+	if o.locale != "" {
+		options = append(options, oauth2.SetAuthURLParam(localeParam, o.locale))
+	}
+	return options
 }
 
-func oauthConfig(appKey string, domain string, redirectURL string, scopes []string) *oauth2.Config {
+func oauthConfig(appKey string, appSecret string, domain string, redirectURL string, scopes []string) *oauth2.Config {
 	endpoint := dropbox.OAuthEndpoint(domain)
 	endpoint.AuthStyle = oauth2.AuthStyleInParams
 	return &oauth2.Config{
-		ClientID:    appKey,
-		Endpoint:    endpoint,
-		RedirectURL: redirectURL,
-		Scopes:      append([]string(nil), scopes...),
+		ClientID:     appKey,
+		ClientSecret: appSecret,
+		Endpoint:     endpoint,
+		RedirectURL:  redirectURL,
+		Scopes:       append([]string(nil), scopes...),
 	}
 }
 
@@ -448,6 +672,14 @@ func withHTTPClient(ctx context.Context, client *http.Client) context.Context {
 		return ctx
 	}
 	return context.WithValue(ctx, oauth2.HTTPClient, client)
+}
+
+func generateVerifier() (string, error) {
+	data := make([]byte, 32)
+	if _, err := rand.Read(data); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
 }
 
 func generateCSRFToken() (string, error) {
@@ -468,10 +700,15 @@ func safeEquals(a string, b string) bool {
 }
 
 func flowResultFromToken(token *oauth2.Token, urlState string) *FlowResult {
+	accountID := extraString(token, "account_id")
+	teamID := extraString(token, "team_id")
+	if accountID == "" {
+		accountID = teamID
+	}
 	return &FlowResult{
 		Token:     token,
-		AccountID: extraString(token, "account_id"),
-		TeamID:    extraString(token, "team_id"),
+		AccountID: accountID,
+		TeamID:    teamID,
 		UserID:    extraString(token, "uid"),
 		URLState:  urlState,
 		Scopes:    strings.Fields(extraString(token, "scope")),

--- a/v6/dropbox/oauth/oauth_test.go
+++ b/v6/dropbox/oauth/oauth_test.go
@@ -127,6 +127,194 @@ func TestPKCEFlowExchangeSendsVerifierAndAppKey(t *testing.T) {
 	}
 }
 
+func TestOAuth2FlowNoRedirectAppSecretStartAndFinish(t *testing.T) {
+	var requestURL string
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		requestURL = req.URL.String()
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expires_in":3600,"account_id":"dbid:account","uid":"12345","scope":"files.metadata.read files.content.write"}`), nil
+	})
+
+	flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+		"app-key",
+		dropboxoauth.WithAppSecret("app-secret"),
+		dropboxoauth.WithState("test-state"),
+		dropboxoauth.WithScopes("files.metadata.read", "files.content.write"),
+		dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopesUser),
+		dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessTypeLegacy),
+		dropboxoauth.WithLocale("en_US"),
+		dropboxoauth.WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.Start())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	assertQueryValue(t, query, "client_id", "app-key")
+	assertQueryValue(t, query, "response_type", "code")
+	assertQueryValue(t, query, "state", "test-state")
+	assertQueryValue(t, query, "scope", "files.metadata.read files.content.write")
+	assertQueryValue(t, query, "include_granted_scopes", "user")
+	assertQueryValue(t, query, "token_access_type", "legacy")
+	assertQueryValue(t, query, "locale", "en_US")
+	assertNoQueryValue(t, query, "redirect_uri")
+	assertNoQueryValue(t, query, "code_challenge")
+	assertNoQueryValue(t, query, "code_challenge_method")
+
+	result, err := flow.Finish(context.Background(), "auth-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Token.AccessToken != "access-token" || result.Token.RefreshToken != "refresh-token" || result.Token.TokenType != "Bearer" {
+		t.Fatalf("unexpected token: %#v", result.Token)
+	}
+	if result.Token.Expiry.IsZero() {
+		t.Fatal("expected token expiry")
+	}
+	if result.AccountID != "dbid:account" || result.UserID != "12345" {
+		t.Fatalf("unexpected account info: %#v", result)
+	}
+	assertScopes(t, result.Scopes, "files.metadata.read", "files.content.write")
+
+	if requestURL != "https://api.dropboxapi.com/1/oauth2/token" {
+		t.Fatalf("request URL = %q", requestURL)
+	}
+	assertQueryValue(t, form, "grant_type", "authorization_code")
+	assertQueryValue(t, form, "code", "auth-code")
+	assertQueryValue(t, form, "client_id", "app-key")
+	assertQueryValue(t, form, "client_secret", "app-secret")
+	assertQueryValue(t, form, "locale", "en_US")
+	assertNoQueryValue(t, form, "redirect_uri")
+	assertNoQueryValue(t, form, "code_verifier")
+}
+
+func TestOAuth2FlowNoRedirectPKCEStartAndFinish(t *testing.T) {
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"access-token","token_type":"Bearer"}`), nil
+	})
+
+	flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+		"app-key",
+		dropboxoauth.WithPKCE(),
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.Start())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	assertQueryValue(t, query, "code_challenge", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	assertQueryValue(t, query, "code_challenge_method", "S256")
+
+	if _, err := flow.Finish(context.Background(), "auth-code"); err != nil {
+		t.Fatal(err)
+	}
+	assertQueryValue(t, form, "grant_type", "authorization_code")
+	assertQueryValue(t, form, "code", "auth-code")
+	assertQueryValue(t, form, "client_id", "app-key")
+	assertQueryValue(t, form, "code_verifier", testVerifier)
+	assertNoQueryValue(t, form, "client_secret")
+}
+
+func TestOAuth2FlowNoRedirectAppSecretOmitsTokenAccessTypeByDefault(t *testing.T) {
+	flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+		"app-key",
+		dropboxoauth.WithAppSecret("app-secret"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.Start())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNoQueryValue(t, authURL.Query(), "token_access_type")
+}
+
+func TestOAuth2FlowAppSecretStartAndFinish(t *testing.T) {
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expires_in":3600,"team_id":"dbtid:team","uid":12345}`), nil
+	})
+
+	flow, err := dropboxoauth.NewOAuth2Flow(
+		"app-key",
+		"http://localhost/callback",
+		dropboxoauth.WithAppSecret("app-secret"),
+		dropboxoauth.WithLocale("en_US"),
+		dropboxoauth.WithHTTPClient(client),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawAuthURL, csrfToken, err := flow.Start("url-state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authURL, err := url.Parse(rawAuthURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := authURL.Query()
+	assertQueryValue(t, query, "redirect_uri", "http://localhost/callback")
+	assertQueryValue(t, query, "state", csrfToken+"|url-state")
+	assertQueryValue(t, query, "locale", "en_US")
+	assertNoQueryValue(t, query, "code_challenge")
+	assertNoQueryValue(t, query, "code_challenge_method")
+
+	result, err := flow.Finish(context.Background(), url.Values{
+		"state": {csrfToken + "|url-state"},
+		"code":  {"auth-code"},
+	}, csrfToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Token.AccessToken != "access-token" || result.Token.RefreshToken != "refresh-token" {
+		t.Fatalf("unexpected token: %#v", result.Token)
+	}
+	if result.AccountID != "dbtid:team" || result.TeamID != "dbtid:team" || result.UserID != "12345" {
+		t.Fatalf("unexpected account info: %#v", result)
+	}
+	if result.URLState != "url-state" {
+		t.Fatalf("url state = %q, want url-state", result.URLState)
+	}
+
+	assertQueryValue(t, form, "grant_type", "authorization_code")
+	assertQueryValue(t, form, "code", "auth-code")
+	assertQueryValue(t, form, "client_id", "app-key")
+	assertQueryValue(t, form, "client_secret", "app-secret")
+	assertQueryValue(t, form, "redirect_uri", "http://localhost/callback")
+	assertQueryValue(t, form, "locale", "en_US")
+	assertNoQueryValue(t, form, "code_verifier")
+}
+
 func TestWebPKCEFlowStart(t *testing.T) {
 	flow, err := dropboxoauth.NewWebPKCEFlow(
 		"app-key",
@@ -244,9 +432,7 @@ func TestWebPKCEFlowFinishExchangesCodeAndReturnsResult(t *testing.T) {
 	assertQueryValue(t, form, "code_verifier", testVerifier)
 	assertQueryValue(t, form, "client_id", "app-key")
 	assertQueryValue(t, form, "redirect_uri", "http://localhost/callback")
-	if got := form.Get("locale"); got != "" {
-		t.Fatalf("locale = %q, want empty", got)
-	}
+	assertQueryValue(t, form, "locale", "en_US")
 	if got := form.Get("client_secret"); got != "" {
 		t.Fatalf("client_secret = %q, want empty", got)
 	}
@@ -379,6 +565,202 @@ func TestNewWebPKCEFlowRejectsMissingInputs(t *testing.T) {
 	if _, err := dropboxoauth.NewWebPKCEFlow("app-key", "http://localhost/callback", dropboxoauth.WithState("state")); err == nil {
 		t.Fatal("expected unsupported state error")
 	}
+	if _, err := dropboxoauth.NewWebPKCEFlow("app-key", "http://localhost/callback", dropboxoauth.WithAppSecret("secret")); err == nil {
+		t.Fatal("expected unsupported app secret error")
+	}
+}
+
+func TestNewPKCEFlowRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "invalid token access type",
+			fn: func() error {
+				_, err := dropboxoauth.NewPKCEFlow(
+					"app-key",
+					dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessType("invalid")),
+				)
+				return err
+			},
+		},
+		{
+			name: "empty scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewPKCEFlow("app-key", dropboxoauth.WithScopes())
+				return err
+			},
+		},
+		{
+			name: "include granted scopes without scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewPKCEFlow(
+					"app-key",
+					dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopesUser),
+				)
+				return err
+			},
+		},
+		{
+			name: "invalid include granted scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewPKCEFlow(
+					"app-key",
+					dropboxoauth.WithScopes("files.metadata.read"),
+					dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopes("invalid")),
+				)
+				return err
+			},
+		},
+		{
+			name: "web invalid option",
+			fn: func() error {
+				_, err := dropboxoauth.NewWebPKCEFlow(
+					"app-key",
+					"http://localhost/callback",
+					dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessType("invalid")),
+				)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestNewOAuth2FlowRejectsInvalidOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "missing secret or pkce",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect("app-key")
+				return err
+			},
+		},
+		{
+			name: "invalid token access type",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessType("invalid")),
+				)
+				return err
+			},
+		},
+		{
+			name: "empty scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithScopes(),
+				)
+				return err
+			},
+		},
+		{
+			name: "include granted scopes without scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopesUser),
+				)
+				return err
+			},
+		},
+		{
+			name: "invalid include granted scopes",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithScopes("files.metadata.read"),
+					dropboxoauth.WithIncludeGrantedScopes(dropboxoauth.IncludeGrantedScopes("invalid")),
+				)
+				return err
+			},
+		},
+		{
+			name: "web missing redirect url",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2Flow("app-key", " ", dropboxoauth.WithAppSecret("secret"))
+				return err
+			},
+		},
+		{
+			name: "web state option",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2Flow(
+					"app-key",
+					"http://localhost/callback",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithState("state"),
+				)
+				return err
+			},
+		},
+		{
+			name: "pkce constructor app secret",
+			fn: func() error {
+				_, err := dropboxoauth.NewPKCEFlow("app-key", dropboxoauth.WithAppSecret("secret"))
+				return err
+			},
+		},
+		{
+			name: "app secret with pkce",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithPKCE(),
+				)
+				return err
+			},
+		},
+		{
+			name: "app secret with verifier",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+					"app-key",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithVerifier(testVerifier),
+				)
+				return err
+			},
+		},
+		{
+			name: "web app secret with pkce",
+			fn: func() error {
+				_, err := dropboxoauth.NewOAuth2Flow(
+					"app-key",
+					"http://localhost/callback",
+					dropboxoauth.WithAppSecret("secret"),
+					dropboxoauth.WithPKCE(),
+				)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fn(); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
 }
 
 func TestRefreshSendsRefreshTokenAndPreservesRefreshToken(t *testing.T) {
@@ -416,6 +798,31 @@ func TestRefreshSendsRefreshTokenAndPreservesRefreshToken(t *testing.T) {
 	if got := form.Get("client_secret"); got != "" {
 		t.Fatalf("client_secret = %q, want empty", got)
 	}
+}
+
+func TestRefreshSendsAppSecret(t *testing.T) {
+	var form url.Values
+	client := httpClient(func(req *http.Request) (*http.Response, error) {
+		var err error
+		form, err = readForm(req)
+		if err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, `{"access_token":"new-access","expires_in":3600}`), nil
+	})
+
+	_, err := dropboxoauth.Refresh(context.Background(), "app-key", &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, dropboxoauth.WithAppSecret("app-secret"), dropboxoauth.WithHTTPClient(client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertQueryValue(t, form, "grant_type", "refresh_token")
+	assertQueryValue(t, form, "refresh_token", "old-refresh")
+	assertQueryValue(t, form, "client_id", "app-key")
+	assertQueryValue(t, form, "client_secret", "app-secret")
 }
 
 func TestTokenSourceRefreshesExpiredToken(t *testing.T) {
@@ -503,6 +910,13 @@ func assertQueryValue(t *testing.T, values url.Values, key string, want string) 
 	t.Helper()
 	if got := values.Get(key); got != want {
 		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func assertNoQueryValue(t *testing.T, values url.Values, key string) {
+	t.Helper()
+	if got, ok := values[key]; ok {
+		t.Fatalf("%s = %#v, want absent", key, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds general OAuth2 flows matching the Python SDK's OAuth surface, so confidential apps (app secret) and public clients (PKCE) are both first-class. Builds on the PKCE work in #146/#147.

- **`OAuth2FlowNoRedirect`** — `Start()` / `Finish(ctx, code)` for the no-redirect code flow.
- **`OAuth2Flow`** — `Start(urlState)` / `Finish(ctx, query, csrfToken)` for web redirects, reusing the shared CSRF-validated web flow (`startWebFlow` / `finishWebFlow`, also used by `WebPKCEFlow`).
- New options: `WithAppSecret` (confidential), `WithPKCE` (public), and `TokenAccessTypeLegacy`.
- `Refresh` and `TokenSource` now forward the app secret for confidential apps.

## Validation & safety

- Uniform option validation across all constructors: reject invalid token access types, empty scopes, `include_granted_scopes` without scopes, and the mutually exclusive `WithAppSecret` + `WithPKCE`/`WithVerifier` combination.
- `PKCEFlow` / `WebPKCEFlow` continue to reject `WithAppSecret`.
- PKCE verifiers are generated by a local helper that propagates the `crypto/rand` error through the constructors, rather than discarding it as `oauth2.GenerateVerifier` does.
- `FlowResult` falls back to the team ID for `AccountID` when a team token omits `account_id`.