### PR TITLE
Export GenerateVerifier helper for PKCE flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ will then have to take users through the OAuth flow, as part of which users
 will explicitly grant permissions to your app. At the end of this process, your
 app exchanges the authorization code for a token.
 
+Choose the OAuth helper that matches your app type:
+
+| App type | Helper |
+| --- | --- |
+| CLI or native public app | `NewPKCEFlow` |
+| Web public app | `NewWebPKCEFlow` |
+| Confidential app without redirect | `NewOAuth2FlowNoRedirect` |
+| Confidential web app | `NewOAuth2Flow` |
+| Refreshable SDK client | `TokenSource` |
+
 ```go
 import "context"
 import "fmt"
@@ -96,12 +106,15 @@ The PKCE helper requests offline access by default. Use
 
 For redirect-based web apps, use `NewWebPKCEFlow`. Each login attempt needs a
 single PKCE verifier for both `Start` and `Finish`; generate it with
-`oauth2.GenerateVerifier` from `golang.org/x/oauth2`, store it with the
-returned CSRF token in the user's session, then pass both values back when
-finishing the flow:
+`dropboxoauth.GenerateVerifier`, store it with the returned CSRF token in the
+user's session, then pass both values back when finishing the flow:
 
 ```go
-verifier := oauth2.GenerateVerifier()
+verifier, err := dropboxoauth.GenerateVerifier()
+if err != nil {
+  return err
+}
+
 flow, err := dropboxoauth.NewWebPKCEFlow(
   appKey,
   redirectURL,

--- a/v6/dropbox/oauth/example_test.go
+++ b/v6/dropbox/oauth/example_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package oauth_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	dropboxoauth "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+	"golang.org/x/oauth2"
+)
+
+func ExampleNewPKCEFlow() {
+	ctx := context.Background()
+
+	flow, err := dropboxoauth.NewPKCEFlow(
+		"APP_KEY",
+		dropboxoauth.WithScopes("files.metadata.read"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	authURL := flow.AuthCodeURL()
+	_ = authURL // Redirect the user to authURL and read the authorization code.
+
+	code := "AUTHORIZATION_CODE"
+	_ = code
+	_ = ctx
+	// token, err := flow.Exchange(ctx, code)
+}
+
+func ExampleNewWebPKCEFlow() {
+	verifier, err := dropboxoauth.GenerateVerifier()
+	if err != nil {
+		panic(err)
+	}
+
+	flow, err := dropboxoauth.NewWebPKCEFlow(
+		"APP_KEY",
+		"https://example.com/dropbox/callback",
+		dropboxoauth.WithVerifier(verifier),
+		dropboxoauth.WithScopes("files.metadata.read"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	authURL, csrfToken, err := flow.Start("optional-url-state")
+	if err != nil {
+		panic(err)
+	}
+
+	_ = authURL   // Redirect the user to authURL.
+	_ = csrfToken // Store csrfToken and verifier in the user's web session.
+
+	// In the callback handler, rebuild the flow with the stored verifier.
+	flow, err = dropboxoauth.NewWebPKCEFlow(
+		"APP_KEY",
+		"https://example.com/dropbox/callback",
+		dropboxoauth.WithVerifier(verifier),
+	)
+	if err != nil {
+		panic(err)
+	}
+	_ = flow
+	// result, err := flow.Finish(r.Context(), r.URL.Query(), csrfToken)
+}
+
+func ExampleNewOAuth2FlowNoRedirect() {
+	flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
+		"APP_KEY",
+		dropboxoauth.WithAppSecret("APP_SECRET"),
+		dropboxoauth.WithScopes("files.metadata.read"),
+		dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessTypeOffline),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	authURL := flow.Start()
+	_ = authURL // Send the user to authURL and read the authorization code.
+
+	code := "AUTHORIZATION_CODE"
+	_ = code
+	// result, err := flow.Finish(context.Background(), code)
+}
+
+func ExampleTokenSource() {
+	ctx := context.Background()
+	token := &oauth2.Token{
+		AccessToken:  "ACCESS_TOKEN",
+		RefreshToken: "REFRESH_TOKEN",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+
+	config := dropbox.Config{
+		TokenSource: dropboxoauth.TokenSource(ctx, "APP_KEY", token),
+	}
+
+	dbx := users.New(config)
+	_ = dbx
+	// account, err := dbx.GetCurrentAccount()
+}

--- a/v6/dropbox/oauth/oauth.go
+++ b/v6/dropbox/oauth/oauth.go
@@ -289,6 +289,11 @@ func NewWebPKCEFlow(appKey string, redirectURL string, opts ...Option) (*WebPKCE
 	}, nil
 }
 
+// GenerateVerifier returns a random PKCE code verifier.
+func GenerateVerifier() (string, error) {
+	return generateVerifier()
+}
+
 // WithDomain configures the Dropbox API domain.
 func WithDomain(domain string) Option {
 	return func(opts *options) {

--- a/v6/dropbox/oauth/oauth_test.go
+++ b/v6/dropbox/oauth/oauth_test.go
@@ -86,6 +86,19 @@ func TestPKCEFlowGeneratesStateAndVerifier(t *testing.T) {
 	}
 }
 
+func TestGenerateVerifier(t *testing.T) {
+	verifier, err := dropboxoauth.GenerateVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verifier == "" {
+		t.Fatal("expected verifier")
+	}
+	if strings.ContainsAny(verifier, "+/=") {
+		t.Fatalf("verifier is not raw URL-safe base64: %q", verifier)
+	}
+}
+
 func TestPKCEFlowExchangeSendsVerifierAndAppKey(t *testing.T) {
 	var requestURL string
 	var form url.Values


### PR DESCRIPTION
## Summary

Adds a public `dropboxoauth.GenerateVerifier` so web-app callers can produce PKCE code verifiers without reaching into `golang.org/x/oauth2` directly. Also documents helper selection and adds runnable godoc examples for the OAuth flows.

## Changes

- **`v6/dropbox/oauth/oauth.go`** — export `GenerateVerifier() (string, error)` wrapping the existing internal generator (surfaces the `crypto/rand` error).
- **`README.md`** — add an app-type → helper selection table, and switch the web-PKCE docs from `oauth2.GenerateVerifier` to `dropboxoauth.GenerateVerifier` with proper error handling.
- **`v6/dropbox/oauth/example_test.go`** — new runnable godoc examples for `NewPKCEFlow`, `NewWebPKCEFlow`, `NewOAuth2FlowNoRedirect`, and `TokenSource`.
- **`v6/dropbox/oauth/oauth_test.go`** — add `TestGenerateVerifier`.