### PR TITLE
Add OpenID Connect scope helpers and identity examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For most applications, you should just import the relevant namespace(s) only. Th
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files`
+* `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth`
+* `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/openid`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users`
@@ -185,6 +187,36 @@ config := dropbox.Config{
 
 The SDK still accepts a static access token through `dropbox.Config.Token`; for
 refreshable tokens, pass a token source through `dropbox.Config.TokenSource`.
+
+If your app uses Dropbox as a login identity provider, request OpenID Connect
+scopes during OAuth, then call `UserinfoContext` on an `openid` client with the
+resulting token. Normal Dropbox API access does not require OpenID scopes.
+
+```go
+flow, err := dropboxoauth.NewWebPKCEFlow(
+  appKey,
+  redirectURL,
+  dropboxoauth.WithVerifier(verifier),
+  dropboxoauth.WithScopes(
+    dropboxoauth.ScopeOpenID,
+    dropboxoauth.ScopeEmail,
+    dropboxoauth.ScopeProfile,
+  ),
+)
+if err != nil {
+  return err
+}
+
+// Finish the OAuth flow as shown above.
+identityClient := openid.NewContext(dropbox.Config{
+  TokenSource: dropboxoauth.TokenSource(ctx, appKey, result.Token),
+})
+info, err := identityClient.UserinfoContext(ctx, openid.NewUserInfoArgs())
+if err != nil {
+  return err
+}
+_ = info
+```
 
 ### Making API calls
 

--- a/v6/dropbox/oauth/example_test.go
+++ b/v6/dropbox/oauth/example_test.go
@@ -87,6 +87,35 @@ func ExampleNewWebPKCEFlow() {
 	// result, err := flow.Finish(r.Context(), r.URL.Query(), csrfToken)
 }
 
+func ExampleNewWebPKCEFlow_openID() {
+	verifier, err := dropboxoauth.GenerateVerifier()
+	if err != nil {
+		panic(err)
+	}
+
+	flow, err := dropboxoauth.NewWebPKCEFlow(
+		"APP_KEY",
+		"https://example.com/dropbox/callback",
+		dropboxoauth.WithVerifier(verifier),
+		dropboxoauth.WithScopes(
+			dropboxoauth.ScopeOpenID,
+			dropboxoauth.ScopeEmail,
+			dropboxoauth.ScopeProfile,
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	authURL, csrfToken, err := flow.Start("optional-url-state")
+	if err != nil {
+		panic(err)
+	}
+	_ = authURL
+	_ = csrfToken
+	// After Finish succeeds, call UserinfoContext on an openid client.
+}
+
 func ExampleNewOAuth2FlowNoRedirect() {
 	flow, err := dropboxoauth.NewOAuth2FlowNoRedirect(
 		"APP_KEY",

--- a/v6/dropbox/oauth/oauth.go
+++ b/v6/dropbox/oauth/oauth.go
@@ -70,6 +70,15 @@ const (
 	IncludeGrantedScopesTeam IncludeGrantedScopes = "team"
 )
 
+const (
+	// ScopeOpenID requests OpenID Connect identity information.
+	ScopeOpenID = "openid"
+	// ScopeEmail requests email identity information through OpenID Connect.
+	ScopeEmail = "email"
+	// ScopeProfile requests profile identity information through OpenID Connect.
+	ScopeProfile = "profile"
+)
+
 // Option configures Dropbox OAuth helpers.
 type Option func(*options)
 

--- a/v6/dropbox/oauth/oauth_test.go
+++ b/v6/dropbox/oauth/oauth_test.go
@@ -69,6 +69,24 @@ func TestPKCEFlowAuthCodeURL(t *testing.T) {
 	assertQueryValue(t, query, "code_challenge_method", "S256")
 }
 
+func TestPKCEFlowAuthCodeURLOpenIDScopes(t *testing.T) {
+	flow, err := dropboxoauth.NewPKCEFlow(
+		"app-key",
+		dropboxoauth.WithState("test-state"),
+		dropboxoauth.WithVerifier(testVerifier),
+		dropboxoauth.WithScopes(dropboxoauth.ScopeOpenID, dropboxoauth.ScopeEmail, dropboxoauth.ScopeProfile),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authURL, err := url.Parse(flow.AuthCodeURL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertQueryValue(t, authURL.Query(), "scope", "openid email profile")
+}
+
 func TestPKCEFlowGeneratesStateAndVerifier(t *testing.T) {
 	flow, err := dropboxoauth.NewPKCEFlow("app-key")
 	if err != nil {

--- a/v6/dropbox/openid/example_test.go
+++ b/v6/dropbox/openid/example_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package openid_test
+
+import (
+	"context"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/openid"
+)
+
+func ExampleContextClient_UserinfoContext() {
+	ctx := context.Background()
+
+	config := dropbox.Config{
+		Token: "ACCESS_TOKEN",
+	}
+	client := openid.NewContext(config)
+
+	_ = ctx
+	_ = client
+	// The access token must have been granted the openid scope.
+	// info, err := client.UserinfoContext(ctx, openid.NewUserInfoArgs())
+}


### PR DESCRIPTION
## Summary
- Export `ScopeOpenID`, `ScopeEmail`, and `ScopeProfile` constants so callers can request OpenID Connect scopes during OAuth without hardcoding string literals.
- Add example tests demonstrating the OpenID identity flow (`ExampleNewWebPKCEFlow_openID` and `ExampleContextClient_UserinfoContext`).
- Document the OpenID Connect usage flow in the README.