### PR TITLE
Document OAuth verifier, OpenID scopes, and online access type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ summarized from the repository history.
 - Added Python-style OAuth 2 no-redirect and web flows with app-secret support,
   PKCE mode, legacy token access type compatibility, and option validation.
 - Added `dropbox.Config.TokenSource` for refreshable OAuth token sources.
+- Added `oauth.GenerateVerifier` for generating PKCE code verifiers.
+- Added `oauth.ScopeOpenID`, `oauth.ScopeEmail`, and `oauth.ScopeProfile`
+  constants and `dropbox/openid` identity-flow examples for OpenID Connect.
 
 ## v6.3.0 - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ func main() {
 }
 ```
 
-The PKCE helper requests offline access by default. Use
-`dropboxoauth.TokenSource` in `dropbox.Config` for automatic refresh, or call
-`dropboxoauth.Refresh` directly when you manage token storage yourself.
+The PKCE helpers request offline access by default so refresh tokens are
+returned. Use `dropboxoauth.TokenSource` in `dropbox.Config` for automatic
+refresh, or call `dropboxoauth.Refresh` directly when you manage token storage
+yourself. If your app only calls Dropbox while the user is actively present and
+does not need background access, pass
+`dropboxoauth.WithTokenAccessType(dropboxoauth.TokenAccessTypeOnline)`.
 
 For redirect-based web apps, use `NewWebPKCEFlow`. Each login attempt needs a
 single PKCE verifier for both `Start` and `Finish`; generate it with


### PR DESCRIPTION
## Summary
- Add CHANGELOG entries for the `oauth.GenerateVerifier` export (#149) and the OpenID Connect scope constants plus `dropbox/openid` identity-flow examples (#150).
- Clarify in the README that the PKCE helpers request offline access by default (returning refresh tokens), and document `WithTokenAccessType(TokenAccessTypeOnline)` for apps that only need access while the user is present.