### PR TITLE
Use supported Go versions in CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23.x'
+        go-version: '1.25.12'
         cache-dependency-path: v6/go.sum
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23.x'
+          go-version: '1.25.12'
           cache-dependency-path: v6/go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.25.12, 1.26.5]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary
- move CI, lint, and CodeQL workflows off EOL Go versions
- pin supported Go patch releases for deterministic setup-go behavior
- update the test matrix to Go 1.25.12 and 1.26.5

## Testing
- not run; workflow-only change