### PR TITLE
Add configurable retry policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For most applications, you should just import the relevant namespace(s) only. Th
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/openid`
+* `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users`
@@ -239,6 +240,71 @@ Here's an example:
     fmt.Printf("Name: %v", resp.Name)
   }
 ```
+
+### Retrying API calls
+
+Retries are disabled by default. To opt in for all calls made by a client, set
+`Config.RetryPolicy`:
+
+```go
+import "time"
+
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry"
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
+
+policy := retry.Policy{
+  MaxRetries:     3,
+  InitialBackoff: 500 * time.Millisecond,
+  MaxBackoff:     30 * time.Second,
+  MaxRetryAfter:  30 * time.Second,
+}
+
+dbx := users.New(dropbox.Config{
+  Token:       accessToken,
+  RetryPolicy: &policy,
+})
+
+arg := users.NewGetAccountArg(accountId)
+resp, err := dbx.GetAccount(arg)
+```
+
+`MaxRetries` is the number of attempts after the initial request. If left unset,
+`InitialBackoff`, `MaxBackoff`, and `MaxRetryAfter` default to 500ms, 30s, and
+30s respectively.
+
+The SDK retries HTTP `429 Too Many Requests` and `503 Service Unavailable`
+responses. `Retry-After` headers and Dropbox 429 `retry_after` response bodies
+are honored up to `MaxRetryAfter`; longer delays are not retried. Network errors
+where no HTTP response is received are not retried.
+
+Use standard context deadlines to bound the whole operation, including retry
+sleeps and all attempts:
+
+```go
+baseCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+resp, err := dbx.GetAccountContext(baseCtx, arg)
+```
+
+Some Dropbox API `409 Conflict` responses are also safe to retry. Opt in by
+listing the top-level Stone error tags that should be retried:
+
+```go
+policy := retry.Policy{
+  MaxRetries:       3,
+  InitialBackoff:   time.Second,
+  MaxBackoff:       30 * time.Second,
+  MaxRetryAfter:    30 * time.Second,
+  Retryable409Tags: []string{"too_many_write_operations"},
+}
+```
+
+Upload retries require a seekable request body (for example `*os.File`,
+`*bytes.Reader`, or `*strings.Reader`) so the SDK can rewind the body before
+each attempt. Non-seekable upload bodies are sent once and are not retried.
+Leave `Config.RetryPolicy` nil to disable retries.
 
 ### Automatic upload integrity (`content_hash`)
 

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry"
 	"golang.org/x/oauth2"
 )
 
@@ -90,6 +91,9 @@ type Config struct {
 	Domain string
 	// No need to set -- for testing only
 	Client *http.Client
+	// RetryPolicy controls automatic retries for Dropbox API calls. If nil, retries
+	// are disabled.
+	RetryPolicy *retry.Policy
 	// No need to set -- for testing only
 	HeaderGenerator func(hostType string, namespace string, route string) map[string]string
 	// No need to set -- for testing only
@@ -172,11 +176,106 @@ func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, e
 }
 
 // ExecuteContext executes a Dropbox API request with the provided context.
+// Retries use Config.RetryPolicy when set.
 func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
+	var policy retry.Policy
+	retryConfigured := c.Config.RetryPolicy != nil
+	if retryConfigured {
+		policy = c.Config.RetryPolicy.Normalized()
+	}
+	bodyOffset, bodySeeker, bodyRetryable := retryableBody(body)
+	canRetry := retryConfigured && bodyRetryable
+
+	client := c.Client
+	if req.Auth == "noauth" {
+		client = c.NoAuthClient
+	}
+
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 && bodySeeker != nil {
+			if _, err := bodySeeker.Seek(bodyOffset, io.SeekStart); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		httpReq, err := c.newHTTPRequest(ctx, req, body)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
+			switch req.Style {
+			case "rpc", "upload":
+				if resp.Body == nil {
+					return nil, nil, errors.New("expected body in RPC response, got nil")
+				}
+
+				b, err := io.ReadAll(resp.Body)
+				if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+					err = closeErr
+				}
+				if err != nil {
+					return nil, nil, err
+				}
+
+				return b, nil, nil
+			case "download":
+				b := []byte(resp.Header.Get("Dropbox-API-Result"))
+				return b, resp.Body, nil
+			}
+		}
+
+		b, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		bodyErr := readErr
+		if bodyErr == nil {
+			bodyErr = closeErr
+		}
+		if bodyErr != nil {
+			if canRetry {
+				retryBody := b
+				if readErr != nil {
+					retryBody = nil
+				}
+				if wait, ok := policy.Delay(resp, retryBody, attempt); ok {
+					if err := retry.Sleep(ctx, wait); err != nil {
+						return nil, nil, err
+					}
+					continue
+				}
+			}
+			return nil, nil, bodyErr
+		}
+
+		if canRetry {
+			if wait, ok := policy.Delay(resp, b, attempt); ok {
+				if err := retry.Sleep(ctx, wait); err != nil {
+					return nil, nil, err
+				}
+				continue
+			}
+		}
+
+		return nil, nil, SDKInternalError{
+			StatusCode: resp.StatusCode,
+			Content:    string(b),
+		}
+	}
+}
+
+func (c *Context) newHTTPRequest(ctx context.Context, req Request, body io.Reader) (*http.Request, error) {
 	url := c.URLGenerator(req.Host, req.Namespace, req.Route)
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, body)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+	if body != nil {
+		httpReq.Body = io.NopCloser(body)
 	}
 
 	for k, v := range req.ExtraHeaders {
@@ -207,13 +306,13 @@ func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reade
 	if req.Arg != nil {
 		serializedArg, err := json.Marshal(req.Arg)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		switch req.Style {
 		case "rpc":
 			if body != nil {
-				return nil, nil, errors.New("RPC style requests can not have body")
+				return nil, errors.New("RPC style requests can not have body")
 			}
 
 			httpReq.Header.Set("Content-Type", "application/json")
@@ -225,46 +324,22 @@ func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reade
 		}
 	}
 
-	client := c.Client
-	if req.Auth == "noauth" {
-		client = c.NoAuthClient
-	}
+	return httpReq, nil
+}
 
-	resp, err := client.Do(httpReq)
+func retryableBody(body io.Reader) (int64, io.Seeker, bool) {
+	if body == nil {
+		return 0, nil, true
+	}
+	seeker, ok := body.(io.Seeker)
+	if !ok {
+		return 0, nil, false
+	}
+	offset, err := seeker.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, false
 	}
-
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
-		switch req.Style {
-		case "rpc", "upload":
-			if resp.Body == nil {
-				return nil, nil, errors.New("Expected body in RPC response, got nil")
-			}
-
-			b, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				return nil, nil, err
-			}
-
-			return b, nil, nil
-		case "download":
-			b := []byte(resp.Header.Get("Dropbox-API-Result"))
-			return b, resp.Body, nil
-		}
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return nil, nil, SDKInternalError{
-		StatusCode: resp.StatusCode,
-		Content:    string(b),
-	}
+	return offset, seeker, true
 }
 
 // NewContext returns a new Context with the given Config.

--- a/v6/dropbox/retry/retry.go
+++ b/v6/dropbox/retry/retry.go
@@ -1,0 +1,257 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package retry implements the retry and exponential-backoff policy used by the
+// Dropbox SDK. A Policy drives which HTTP responses are retried and how long to
+// wait between attempts.
+package retry
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxRetryAfterSeconds is the largest whole-second Retry-After value that can be
+// converted to a time.Duration without overflowing int64. Anything larger is
+// treated as "effectively unbounded" so it is rejected by the MaxRetryAfter cap
+// rather than wrapping to a negative duration.
+const maxRetryAfterSeconds = int64(math.MaxInt64 / int64(time.Second))
+
+// Default backoff and Retry-After bounds applied when a Policy leaves them unset.
+const (
+	defaultInitialBackoff = 500 * time.Millisecond
+	defaultMaxBackoff     = 30 * time.Second
+	defaultMaxRetryAfter  = 30 * time.Second
+)
+
+// Policy controls automatic retries for a request. MaxRetries is the number of
+// attempts after the initial request. A zero MaxRetries disables retries.
+type Policy struct {
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	MaxRetryAfter  time.Duration
+	// Retryable409Tags are top-level Stone error tags that should be retried
+	// when an API route returns HTTP 409 Conflict.
+	Retryable409Tags []string
+}
+
+// Normalized returns a copy of p with invalid or unset fields replaced by their
+// defaults.
+func (p Policy) Normalized() Policy {
+	if p.MaxRetries < 0 {
+		p.MaxRetries = 0
+	}
+	if p.InitialBackoff <= 0 {
+		p.InitialBackoff = defaultInitialBackoff
+	}
+	if p.MaxBackoff <= 0 {
+		p.MaxBackoff = defaultMaxBackoff
+	}
+	if p.MaxRetryAfter <= 0 {
+		p.MaxRetryAfter = defaultMaxRetryAfter
+	}
+	return p
+}
+
+// CanRetry reports whether another attempt is permitted after the given
+// zero-based attempt, i.e. whether attempt is below MaxRetries.
+func (p Policy) CanRetry(attempt int) bool {
+	return attempt < p.MaxRetries
+}
+
+// Backoff returns the exponential backoff duration for the given zero-based
+// attempt, capped at MaxBackoff.
+func (p Policy) Backoff(attempt int) time.Duration {
+	wait := p.InitialBackoff
+	for i := 0; i < attempt; i++ {
+		if wait >= p.MaxBackoff || wait > p.MaxBackoff-wait {
+			return p.MaxBackoff
+		}
+		wait *= 2
+		if wait >= p.MaxBackoff {
+			return p.MaxBackoff
+		}
+	}
+	if wait > p.MaxBackoff {
+		return p.MaxBackoff
+	}
+	return wait
+}
+
+// Delay reports whether the HTTP response should be retried and, if so, how long
+// to wait before the next attempt. body is the fully read response body.
+func (p Policy) Delay(resp *http.Response, body []byte, attempt int) (time.Duration, bool) {
+	if attempt >= p.MaxRetries || !p.isRetryableStatus(resp.StatusCode, body) {
+		return 0, false
+	}
+
+	if wait, ok := retryAfter(resp.Header.Get("Retry-After")); ok {
+		return p.cappedRetryAfter(wait)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		if wait, ok := retryAfterBody(body); ok {
+			return p.cappedRetryAfter(wait)
+		}
+	}
+
+	return p.Backoff(attempt), true
+}
+
+func (p Policy) isRetryableStatus(statusCode int, body []byte) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests,
+		http.StatusServiceUnavailable:
+		return true
+	case http.StatusConflict:
+		return isRetryable409(body, p.Retryable409Tags)
+	default:
+		return false
+	}
+}
+
+func (p Policy) cappedRetryAfter(wait time.Duration) (time.Duration, bool) {
+	if wait > p.MaxRetryAfter {
+		return 0, false
+	}
+	return wait, true
+}
+
+func isRetryable409(body []byte, retryableTags []string) bool {
+	if len(retryableTags) == 0 {
+		return false
+	}
+	tag, ok := stoneErrorTag(body)
+	if !ok {
+		return false
+	}
+	for _, retryableTag := range retryableTags {
+		if tag == retryableTag {
+			return true
+		}
+	}
+	return false
+}
+
+func stoneErrorTag(body []byte) (string, bool) {
+	var payload struct {
+		ErrorSummary string `json:"error_summary"`
+		Error        struct {
+			Tag string `json:".tag"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", false
+	}
+	if payload.Error.Tag != "" {
+		return payload.Error.Tag, true
+	}
+	if payload.ErrorSummary == "" {
+		return "", false
+	}
+	tag, _, _ := strings.Cut(payload.ErrorSummary, "/")
+	return tag, tag != ""
+}
+
+func retryAfter(value string) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, ok := parseRetryAfterSeconds(value); ok {
+		return secondsToDuration(seconds), true
+	}
+
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	wait := time.Until(when)
+	if wait < 0 {
+		wait = 0
+	}
+	return wait, true
+}
+
+func retryAfterBody(body []byte) (time.Duration, bool) {
+	var payload struct {
+		Error struct {
+			RetryAfter *uint64 `json:"retry_after"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || payload.Error.RetryAfter == nil {
+		return 0, false
+	}
+	seconds := *payload.Error.RetryAfter
+	if seconds > uint64(maxRetryAfterSeconds) {
+		return time.Duration(math.MaxInt64), true
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
+func parseRetryAfterSeconds(value string) (int64, bool) {
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		return seconds, true
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return r < '0' || r > '9'
+	}) == -1 {
+		return math.MaxInt64, true
+	}
+	return 0, false
+}
+
+// secondsToDuration converts a whole-second Retry-After value to a Duration,
+// clamping negatives to zero and saturating at math.MaxInt64 instead of
+// overflowing (which would wrap to a negative duration and bypass MaxRetryAfter).
+func secondsToDuration(seconds int64) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	if seconds > maxRetryAfterSeconds {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// Sleep waits for d or until ctx is done, whichever comes first. It returns the
+// context error if the context is cancelled during the wait.
+func Sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/v6/dropbox/retry/retry_test.go
+++ b/v6/dropbox/retry/retry_test.go
@@ -1,0 +1,401 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package retry_test
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry"
+)
+
+func TestPolicyNormalizedAppliesDefaults(t *testing.T) {
+	// A policy with unset backoff fields should be normalized to the defaults.
+	p := retry.Policy{MaxRetries: -5}.Normalized()
+
+	if p.MaxRetries != 0 {
+		t.Fatalf("negative MaxRetries = %d, want clamped to 0", p.MaxRetries)
+	}
+	if p.InitialBackoff != 500*time.Millisecond {
+		t.Fatalf("InitialBackoff = %v, want default 500ms", p.InitialBackoff)
+	}
+	if p.MaxBackoff != 30*time.Second {
+		t.Fatalf("MaxBackoff = %v, want default 30s", p.MaxBackoff)
+	}
+	if p.MaxRetryAfter != 30*time.Second {
+		t.Fatalf("MaxRetryAfter = %v, want default 30s", p.MaxRetryAfter)
+	}
+}
+
+func TestCanRetry(t *testing.T) {
+	p := retry.Policy{MaxRetries: 2}
+	for attempt, want := range map[int]bool{0: true, 1: true, 2: false, 3: false} {
+		if got := p.CanRetry(attempt); got != want {
+			t.Errorf("CanRetry(%d) = %v, want %v", attempt, got, want)
+		}
+	}
+}
+
+func TestBackoffIsExponentialAndCapped(t *testing.T) {
+	p := retry.Policy{InitialBackoff: time.Second, MaxBackoff: 5 * time.Second}
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 5 * time.Second}, // 8s capped to 5s
+		{10, 5 * time.Second},
+	}
+	for _, c := range cases {
+		if got := p.Backoff(c.attempt); got != c.want {
+			t.Errorf("Backoff(%d) = %v, want %v", c.attempt, got, c.want)
+		}
+	}
+}
+
+func TestBackoffCapsAfterDoublingToMax(t *testing.T) {
+	p := retry.Policy{InitialBackoff: 3 * time.Second, MaxBackoff: 6 * time.Second}
+	if got := p.Backoff(1); got != 6*time.Second {
+		t.Fatalf("Backoff(1) = %v, want capped 6s", got)
+	}
+}
+
+func TestBackoffSaturatesBeforeDurationOverflow(t *testing.T) {
+	p := retry.Policy{
+		InitialBackoff: time.Duration(math.MaxInt64/2 + 1),
+		MaxBackoff:     time.Duration(math.MaxInt64),
+	}
+	if got := p.Backoff(1); got != time.Duration(math.MaxInt64) {
+		t.Fatalf("Backoff(1) = %v, want saturated MaxBackoff", got)
+	}
+}
+
+func TestDelayRetryableStatuses(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetryAfter: time.Minute}
+	retryable := []int{
+		http.StatusTooManyRequests,
+		http.StatusServiceUnavailable,
+	}
+	for _, code := range retryable {
+		resp := &http.Response{StatusCode: code, Header: http.Header{}}
+		if _, ok := p.Delay(resp, nil, 0); !ok {
+			t.Errorf("status %d should be retryable", code)
+		}
+	}
+
+	notRetryable := []int{
+		http.StatusOK,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusRequestTimeout,
+		http.StatusConflict, // 409 needs a configured tag
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusGatewayTimeout,
+	}
+	for _, code := range notRetryable {
+		resp := &http.Response{StatusCode: code, Header: http.Header{}}
+		if _, ok := p.Delay(resp, nil, 0); ok {
+			t.Errorf("status %d should not be retryable", code)
+		}
+	}
+}
+
+func TestDelayStopsAtMaxRetries(t *testing.T) {
+	p := retry.Policy{MaxRetries: 1, InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{}}
+
+	if _, ok := p.Delay(resp, nil, 0); !ok {
+		t.Fatal("attempt 0 should be retryable")
+	}
+	if _, ok := p.Delay(resp, nil, 1); ok {
+		t.Fatal("attempt 1 should exhaust MaxRetries")
+	}
+}
+
+func TestDelayHonorsRetryAfterSeconds(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {"5"}}}
+
+	wait, ok := p.Delay(resp, nil, 0)
+	if !ok {
+		t.Fatal("expected retry")
+	}
+	if wait != 5*time.Second {
+		t.Fatalf("wait = %v, want 5s from Retry-After header", wait)
+	}
+}
+
+func TestDelayRetryAfterOverMaxIsNotRetried(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: 10 * time.Second}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {"60"}}}
+
+	if _, ok := p.Delay(resp, nil, 0); ok {
+		t.Fatal("Retry-After beyond MaxRetryAfter should not be retried")
+	}
+}
+
+func TestDelayRetryAfterHTTPDate(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Hour}
+	when := time.Now().Add(20 * time.Second).UTC().Format(http.TimeFormat)
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {when}}}
+
+	wait, ok := p.Delay(resp, nil, 0)
+	if !ok {
+		t.Fatal("expected retry")
+	}
+	// Allow slack for the second-granularity HTTP date and test execution time.
+	if wait <= 0 || wait > 21*time.Second {
+		t.Fatalf("wait = %v, want roughly 20s", wait)
+	}
+}
+
+func TestDelayRetryAfterPastDate(t *testing.T) {
+	// An HTTP-date already in the past means "retry now": wait clamps to 0 but
+	// the response is still retryable.
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Hour}
+	past := time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {past}}}
+
+	wait, ok := p.Delay(resp, nil, 0)
+	if !ok {
+		t.Fatal("past Retry-After date should still be retryable")
+	}
+	if wait != 0 {
+		t.Fatalf("wait = %v, want 0 for a past date", wait)
+	}
+}
+
+func TestDelayRetryAfterOverflowRejected(t *testing.T) {
+	// A Retry-After value large enough to overflow time.Duration must not wrap to
+	// a negative duration and slip past the MaxRetryAfter cap (which would cause a
+	// tight retry loop). It should saturate and be rejected by the cap instead.
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: 30 * time.Second}
+
+	// Header path (int64 seconds).
+	huge := strconv.FormatInt(math.MaxInt64/int64(time.Second)+1, 10)
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {huge}}}
+	if wait, ok := p.Delay(resp, nil, 0); ok {
+		t.Fatalf("overflowing header Retry-After should be rejected, got ok=true wait=%v", wait)
+	}
+
+	tooLargeForInt64 := strconv.FormatUint(uint64(math.MaxInt64)+1, 10)
+	resp.Header.Set("Retry-After", tooLargeForInt64)
+	if wait, ok := p.Delay(resp, nil, 0); ok {
+		t.Fatalf("uint64-sized header Retry-After should be rejected, got ok=true wait=%v", wait)
+	}
+
+	// Body path (uint64 seconds).
+	body := []byte(`{"error":{"retry_after":18446744073}}`)
+	resp2 := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+	if wait, ok := p.Delay(resp2, body, 0); ok {
+		t.Fatalf("overflowing body retry_after should be rejected, got ok=true wait=%v", wait)
+	}
+}
+
+func TestDelay429RetryAfterBody(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute}
+	body := []byte(`{"error_summary":"too_many_requests/..","error":{"reason":{".tag":"too_many_requests"},"retry_after":7}}`)
+	resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+
+	wait, ok := p.Delay(resp, body, 0)
+	if !ok {
+		t.Fatal("expected retry")
+	}
+	if wait != 7*time.Second {
+		t.Fatalf("wait = %v, want 7s from body retry_after", wait)
+	}
+}
+
+func TestDelay429UnparseableBodyFallsBackToBackoff(t *testing.T) {
+	// A 429 with no Retry-After header and a body that carries no usable
+	// retry_after must still be retried, using exponential backoff.
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: 3 * time.Second, MaxBackoff: time.Minute, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+
+	wait, ok := p.Delay(resp, []byte("not json at all"), 0)
+	if !ok {
+		t.Fatal("429 should be retryable even with an unparseable body")
+	}
+	if wait != 3*time.Second {
+		t.Fatalf("wait = %v, want backoff fallback of 3s", wait)
+	}
+}
+
+func TestDelayNegativeRetryAfterClampsToZero(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Second, MaxBackoff: time.Second, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {"-10"}}}
+
+	wait, ok := p.Delay(resp, nil, 0)
+	if !ok {
+		t.Fatal("expected retry")
+	}
+	if wait != 0 {
+		t.Fatalf("wait = %v, want 0 for a negative Retry-After", wait)
+	}
+}
+
+func TestBackoffInitialExceedingMaxIsCappedAtFirstAttempt(t *testing.T) {
+	// When InitialBackoff already exceeds MaxBackoff, even attempt 0 is capped.
+	p := retry.Policy{InitialBackoff: 10 * time.Second, MaxBackoff: 2 * time.Second}
+	if got := p.Backoff(0); got != 2*time.Second {
+		t.Fatalf("Backoff(0) = %v, want capped 2s", got)
+	}
+}
+
+func TestDelayFallsBackToBackoff(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: 2 * time.Second, MaxBackoff: time.Minute, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{}}
+
+	wait, ok := p.Delay(resp, nil, 1)
+	if !ok {
+		t.Fatal("expected retry")
+	}
+	if wait != 4*time.Second { // 2s * 2^1
+		t.Fatalf("wait = %v, want exponential backoff 4s", wait)
+	}
+}
+
+func TestDelay409TagMatching(t *testing.T) {
+	body := []byte(`{"error_summary":"too_many_write_operations/..","error":{".tag":"too_many_write_operations"}}`)
+	resp := &http.Response{StatusCode: http.StatusConflict, Header: http.Header{}}
+
+	// Configured tag: retried.
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute, Retryable409Tags: []string{"too_many_write_operations"}}
+	if _, ok := p.Delay(resp, body, 0); !ok {
+		t.Fatal("configured 409 tag should be retried")
+	}
+
+	// Unconfigured tag: not retried.
+	other := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute, Retryable409Tags: []string{"some_other_tag"}}
+	if _, ok := other.Delay(resp, body, 0); ok {
+		t.Fatal("unconfigured 409 tag should not be retried")
+	}
+
+	// No tags configured: not retried.
+	none := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute}
+	if _, ok := none.Delay(resp, body, 0); ok {
+		t.Fatal("409 with no configured tags should not be retried")
+	}
+}
+
+func TestDelay409TagFromErrorSummary(t *testing.T) {
+	// Body carries no ".tag" but a slash-delimited error_summary.
+	body := []byte(`{"error_summary":"too_many_write_operations/lock_conflict/..","error":{}}`)
+	resp := &http.Response{StatusCode: http.StatusConflict, Header: http.Header{}}
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute, Retryable409Tags: []string{"too_many_write_operations"}}
+
+	if _, ok := p.Delay(resp, body, 0); !ok {
+		t.Fatal("409 tag derived from error_summary should be retried")
+	}
+}
+
+func TestDelay409TagPresentButNoMatch(t *testing.T) {
+	// The response carries a valid Stone tag, but it isn't in Retryable409Tags.
+	body := []byte(`{"error_summary":"some_other_error/..","error":{".tag":"some_other_error"}}`)
+	resp := &http.Response{StatusCode: http.StatusConflict, Header: http.Header{}}
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute, Retryable409Tags: []string{"too_many_write_operations"}}
+
+	if _, ok := p.Delay(resp, body, 0); ok {
+		t.Fatal("409 with a non-matching tag should not be retried")
+	}
+}
+
+func TestDelay409MalformedBodyNotRetried(t *testing.T) {
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond, MaxRetryAfter: time.Minute, Retryable409Tags: []string{"too_many_write_operations"}}
+
+	cases := map[string][]byte{
+		"invalid json":     []byte("}{ not json"),
+		"empty summary":    []byte(`{"error_summary":"","error":{}}`),
+		"summary no slash": []byte(`{"error_summary":"noslashvalue","error":{}}`),
+	}
+	for name, body := range cases {
+		resp := &http.Response{StatusCode: http.StatusConflict, Header: http.Header{}}
+		if _, ok := p.Delay(resp, body, 0); ok {
+			t.Errorf("%s: 409 should not be retried, got ok=true", name)
+		}
+	}
+}
+
+func TestDelayUnparseableRetryAfterFallsBackToBackoff(t *testing.T) {
+	// A Retry-After header that is neither an integer nor an HTTP date is ignored,
+	// and the response falls back to exponential backoff.
+	p := retry.Policy{MaxRetries: 3, InitialBackoff: 2 * time.Second, MaxBackoff: time.Minute, MaxRetryAfter: time.Minute}
+	resp := &http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{"Retry-After": {"soon-ish"}}}
+
+	wait, ok := p.Delay(resp, nil, 0)
+	if !ok {
+		t.Fatal("expected retry with backoff fallback")
+	}
+	if wait != 2*time.Second {
+		t.Fatalf("wait = %v, want backoff fallback 2s", wait)
+	}
+}
+
+func TestSleepReturnsAfterDuration(t *testing.T) {
+	start := time.Now()
+	if err := retry.Sleep(context.Background(), 10*time.Millisecond); err != nil {
+		t.Fatalf("Sleep returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Fatalf("Sleep returned after %v, want >= 10ms", elapsed)
+	}
+}
+
+func TestSleepZeroReturnsImmediately(t *testing.T) {
+	if err := retry.Sleep(context.Background(), 0); err != nil {
+		t.Fatalf("Sleep(0) returned error: %v", err)
+	}
+	if err := retry.Sleep(context.Background(), -time.Second); err != nil {
+		t.Fatalf("Sleep(negative) returned error: %v", err)
+	}
+}
+
+func TestSleepCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := retry.Sleep(ctx, time.Hour)
+	if err == nil {
+		t.Fatal("expected context error from cancelled Sleep")
+	}
+	if err != context.Canceled {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestSleepDeadlineDuringWait(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := retry.Sleep(ctx, time.Hour)
+	if err != context.DeadlineExceeded {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+}

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry"
 	"golang.org/x/oauth2"
 )
 
@@ -93,6 +94,9 @@ type Config struct {
 	// HTTP client used for authenticated Dropbox API calls. If set, Client takes
 	// precedence over TokenSource and Token.
 	Client *http.Client
+	// RetryPolicy controls automatic retries for Dropbox API calls. If nil, retries
+	// are disabled.
+	RetryPolicy *retry.Policy
 	// No need to set -- for testing only
 	HeaderGenerator func(hostType string, namespace string, route string) map[string]string
 	// No need to set -- for testing only
@@ -178,11 +182,106 @@ func (c *Context) Execute(req Request, body io.Reader) ([]byte, io.ReadCloser, e
 }
 
 // ExecuteContext executes a Dropbox API request with the provided context.
+// Retries use Config.RetryPolicy when set.
 func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reader) ([]byte, io.ReadCloser, error) {
+	var policy retry.Policy
+	retryConfigured := c.Config.RetryPolicy != nil
+	if retryConfigured {
+		policy = c.Config.RetryPolicy.Normalized()
+	}
+	bodyOffset, bodySeeker, bodyRetryable := retryableBody(body)
+	canRetry := retryConfigured && bodyRetryable
+
+	client := c.Client
+	if req.Auth == "noauth" {
+		client = c.NoAuthClient
+	}
+
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 && bodySeeker != nil {
+			if _, err := bodySeeker.Seek(bodyOffset, io.SeekStart); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		httpReq, err := c.newHTTPRequest(ctx, req, body)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
+			switch req.Style {
+			case "rpc", "upload":
+				if resp.Body == nil {
+					return nil, nil, errors.New("expected body in RPC response, got nil")
+				}
+
+				b, err := io.ReadAll(resp.Body)
+				if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+					err = closeErr
+				}
+				if err != nil {
+					return nil, nil, err
+				}
+
+				return b, nil, nil
+			case "download":
+				b := []byte(resp.Header.Get("Dropbox-API-Result"))
+				return b, resp.Body, nil
+			}
+		}
+
+		b, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		bodyErr := readErr
+		if bodyErr == nil {
+			bodyErr = closeErr
+		}
+		if bodyErr != nil {
+			if canRetry {
+				retryBody := b
+				if readErr != nil {
+					retryBody = nil
+				}
+				if wait, ok := policy.Delay(resp, retryBody, attempt); ok {
+					if err := retry.Sleep(ctx, wait); err != nil {
+						return nil, nil, err
+					}
+					continue
+				}
+			}
+			return nil, nil, bodyErr
+		}
+
+		if canRetry {
+			if wait, ok := policy.Delay(resp, b, attempt); ok {
+				if err := retry.Sleep(ctx, wait); err != nil {
+					return nil, nil, err
+				}
+				continue
+			}
+		}
+
+		return nil, nil, SDKInternalError{
+			StatusCode: resp.StatusCode,
+			Content:    string(b),
+		}
+	}
+}
+
+func (c *Context) newHTTPRequest(ctx context.Context, req Request, body io.Reader) (*http.Request, error) {
 	url := c.URLGenerator(req.Host, req.Namespace, req.Route)
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, body)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+	if body != nil {
+		httpReq.Body = io.NopCloser(body)
 	}
 
 	for k, v := range req.ExtraHeaders {
@@ -213,13 +312,13 @@ func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reade
 	if req.Arg != nil {
 		serializedArg, err := json.Marshal(req.Arg)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		switch req.Style {
 		case "rpc":
 			if body != nil {
-				return nil, nil, errors.New("RPC style requests can not have body")
+				return nil, errors.New("RPC style requests can not have body")
 			}
 
 			httpReq.Header.Set("Content-Type", "application/json")
@@ -231,50 +330,22 @@ func (c *Context) ExecuteContext(ctx context.Context, req Request, body io.Reade
 		}
 	}
 
-	client := c.Client
-	if req.Auth == "noauth" {
-		client = c.NoAuthClient
-	}
+	return httpReq, nil
+}
 
-	resp, err := client.Do(httpReq)
+func retryableBody(body io.Reader) (int64, io.Seeker, bool) {
+	if body == nil {
+		return 0, nil, true
+	}
+	seeker, ok := body.(io.Seeker)
+	if !ok {
+		return 0, nil, false
+	}
+	offset, err := seeker.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, false
 	}
-
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
-		switch req.Style {
-		case "rpc", "upload":
-			if resp.Body == nil {
-				return nil, nil, errors.New("expected body in RPC response, got nil")
-			}
-
-			b, err := io.ReadAll(resp.Body)
-			if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
-				err = closeErr
-			}
-			if err != nil {
-				return nil, nil, err
-			}
-
-			return b, nil, nil
-		case "download":
-			b := []byte(resp.Header.Get("Dropbox-API-Result"))
-			return b, resp.Body, nil
-		}
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return nil, nil, SDKInternalError{
-		StatusCode: resp.StatusCode,
-		Content:    string(b),
-	}
+	return offset, seeker, true
 }
 
 // NewContext returns a new Context with the given Config.

--- a/v6/dropbox/sdk_test.go
+++ b/v6/dropbox/sdk_test.go
@@ -23,20 +23,47 @@ package dropbox_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/retry"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/users"
 	"golang.org/x/oauth2"
 )
 
 func generateURL(base string, namespace string, route string) string {
 	return fmt.Sprintf("%s/%s/%s", base, namespace, route)
+}
+
+func retryTestPolicy(maxRetries int) retry.Policy {
+	return retry.Policy{
+		MaxRetries:     maxRetries,
+		InitialBackoff: time.Nanosecond,
+		MaxBackoff:     time.Nanosecond,
+		MaxRetryAfter:  time.Second,
+	}
+}
+
+func retryTestPolicyPtr(maxRetries int) *retry.Policy {
+	policy := retryTestPolicy(maxRetries)
+	return &policy
+}
+
+func retryTestPolicyPtrWith409Tags(maxRetries int, tags ...string) *retry.Policy {
+	policy := retryTestPolicy(maxRetries)
+	policy.Retryable409Tags = tags
+	return &policy
 }
 
 type legacyUsersClient struct{}
@@ -77,8 +104,8 @@ func TestInternalError(t *testing.T) {
 		URLGenerator: func(hostType string, namespace string, route string) string {
 			return generateURL(ts.URL, namespace, route)
 		}}
-	client := users.New(config)
-	v, e := client.GetCurrentAccount()
+	client := users.NewContext(config)
+	v, e := client.GetCurrentAccountContext(context.Background())
 	if v != nil || strings.Trim(e.Error(), "\n") != eString {
 		t.Errorf("v: %v e: '%s'\n", v, e.Error())
 	}
@@ -99,8 +126,8 @@ func TestRateLimitJSON(t *testing.T) {
 		URLGenerator: func(hostType string, namespace string, route string) string {
 			return generateURL(ts.URL, namespace, route)
 		}}
-	client := users.New(config)
-	_, e := client.GetCurrentAccount()
+	client := users.NewContext(config)
+	_, e := client.GetCurrentAccountContext(context.Background())
 	re, ok := e.(auth.RateLimitAPIError)
 	if !ok {
 		t.Errorf("Unexpected error type: %T\n", e)
@@ -280,6 +307,201 @@ func TestExecuteBackwardCompatibility(t *testing.T) {
 	}
 }
 
+func TestExecuteDoesNotRetryByDefault(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
+func TestExecuteUsesConfigRetryPolicy(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "temporary", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	if string(resp) != "{}" {
+		t.Errorf("unexpected response: %s", string(resp))
+	}
+	if respBody != nil {
+		t.Errorf("unexpected response body: %v", respBody)
+	}
+}
+
+func TestExecuteContextDoesNotRetryWithoutPolicy(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	callCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(callCtx, dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
+func TestExecuteContextUsesConfigRetryPolicy(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "temporary", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	callCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(callCtx, dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestExecuteDoesNotRetryUnlistedStatus(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			http.Error(w, "temporary", http.StatusInternalServerError)
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
+func TestExecuteDoesNotRetryNetworkError(t *testing.T) {
+	var attempts atomic.Int32
+	networkErr := errors.New("network unavailable")
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			attempts.Add(1)
+			return nil, networkErr
+		}),
+	}
+
+	config := dropbox.Config{Client: client, LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL("http://example.com", namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.Execute(dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if !errors.Is(err, networkErr) {
+		t.Fatalf("expected network error, got %v", err)
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
 func TestNewContextUsesTokenSourceBeforeToken(t *testing.T) {
 	var authHeader string
 	ts := httptest.NewServer(http.HandlerFunc(
@@ -396,14 +618,399 @@ func TestContextCancellation(t *testing.T) {
 	}
 }
 
+func TestRetryRPCOn503ThenSuccess(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "temporary", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	if string(resp) != "{}" {
+		t.Errorf("unexpected response: %s", string(resp))
+	}
+	if respBody != nil {
+		t.Errorf("unexpected response body: %v", respBody)
+	}
+}
+
+func TestRetryStatusWhenErrorBodyReadFails(t *testing.T) {
+	var attempts atomic.Int32
+	readErr := errors.New("read response body")
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if attempts.Add(1) == 1 {
+				return &http.Response{
+					StatusCode: http.StatusServiceUnavailable,
+					Header:     http.Header{},
+					Body:       failingReadCloser{err: readErr},
+					Request:    r,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Request:    r,
+			}, nil
+		}),
+	}
+
+	config := dropbox.Config{Client: client, LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL("http://example.com", namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	if string(resp) != "{}" {
+		t.Errorf("unexpected response: %s", string(resp))
+	}
+	if respBody != nil {
+		t.Errorf("unexpected response body: %v", respBody)
+	}
+}
+
+func TestRetryAfterHeader(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				w.Header().Set("Retry-After", "0")
+				http.Error(w, "rate limited", http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRetry409ConfiguredStoneTag(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"error_summary":"too_many_write_operations/..","error":{".tag":"too_many_write_operations"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtrWith409Tags(1, "too_many_write_operations"),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "api",
+		Namespace: "files",
+		Route:     "upload",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRetry409UnconfiguredStoneTagNotRetried(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error_summary":"too_many_write_operations/..","error":{".tag":"too_many_write_operations"}}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "api",
+		Namespace: "files",
+		Route:     "upload",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
+func TestContextCancellationDuringRetryBackoff(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+		}))
+	defer ts.Close()
+
+	policy := retry.Policy{
+		MaxRetries:     1,
+		InitialBackoff: time.Hour,
+		MaxBackoff:     time.Hour,
+		MaxRetryAfter:  time.Hour,
+	}
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: &policy,
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	base, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(base, dropbox.Request{
+		Host:      "api",
+		Namespace: "users",
+		Route:     "get_current_account",
+		Auth:      "user",
+		Style:     "rpc",
+	}, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+}
+
+func TestUploadReadSeekCloserRetriedAndRewound(t *testing.T) {
+	var attempts atomic.Int32
+	var mu sync.Mutex
+	var bodies []string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			}
+			mu.Lock()
+			bodies = append(bodies, string(body))
+			mu.Unlock()
+
+			if attempts.Add(1) == 1 {
+				http.Error(w, "temporary", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	body, err := os.CreateTemp(t.TempDir(), "upload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := body.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	if _, err := body.WriteString("payload"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := body.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	ctx := dropbox.NewContext(config)
+	_, _, err = ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "content",
+		Namespace: "files",
+		Route:     "upload",
+		Auth:      "user",
+		Style:     "upload",
+		Arg:       map[string]string{"path": "/x"},
+	}, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 2 || bodies[0] != "payload" || bodies[1] != "payload" {
+		t.Fatalf("unexpected request bodies: %#v", bodies)
+	}
+}
+
+func TestUploadNonSeekableNotRetried(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			_, _ = io.Copy(io.Discard, r.Body)
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	body := struct{ io.Reader }{Reader: strings.NewReader("payload")}
+	ctx := dropbox.NewContext(config)
+	_, _, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "content",
+		Namespace: "files",
+		Route:     "upload",
+		Auth:      "user",
+		Style:     "upload",
+		Arg:       map[string]string{"path": "/x"},
+	}, body)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts.Load())
+	}
+}
+
+func TestDownloadRetryBeforeReturningBody(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				http.Error(w, "temporary", http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Dropbox-API-Result", `{"name":"x"}`)
+			_, _ = w.Write([]byte("content"))
+		}))
+	defer ts.Close()
+
+	config := dropbox.Config{Client: ts.Client(), LogLevel: dropbox.LogOff,
+		RetryPolicy: retryTestPolicyPtr(1),
+		URLGenerator: func(hostType string, namespace string, route string) string {
+			return generateURL(ts.URL, namespace, route)
+		}}
+	ctx := dropbox.NewContext(config)
+	resp, respBody, err := ctx.ExecuteContext(context.Background(), dropbox.Request{
+		Host:      "content",
+		Namespace: "files",
+		Route:     "download",
+		Auth:      "user",
+		Style:     "download",
+		Arg:       map[string]string{"path": "/x"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := respBody.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	content, err := io.ReadAll(respBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+	}
+	if string(resp) != `{"name":"x"}` {
+		t.Fatalf("unexpected response metadata: %s", string(resp))
+	}
+	if string(content) != "content" {
+		t.Fatalf("unexpected content: %s", string(content))
+	}
+}
+
 type failingTokenSource struct {
 	t *testing.T
 }
 
 func (s failingTokenSource) Token() (*oauth2.Token, error) {
 	s.t.Helper()
-	s.t.Fatal("TokenSource should not be used when Config.Client is set")
-	return nil, fmt.Errorf("unexpected TokenSource use")
+	s.t.Fatal("TokenSource should not be used")
+	return nil, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type failingReadCloser struct {
+	err error
+}
+
+func (r failingReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r failingReadCloser) Close() error {
+	return nil
 }
 
 func executeTestRequest(t *testing.T, config dropbox.Config) {


### PR DESCRIPTION
## Summary

Adds opt-in automatic retries for Dropbox API calls via a new stdlib-only `dropbox/retry` package.

Retries are disabled by default; existing behavior is unchanged unless callers set `dropbox.Config.RetryPolicy`.

## Retry behavior

- Retry configuration is per client through `dropbox.Config.RetryPolicy`.
- `MaxRetries` is the number of attempts after the initial request.
- Unset backoff fields default to:
  - `InitialBackoff`: 500ms
  - `MaxBackoff`: 30s
  - `MaxRetryAfter`: 30s
- Retry sleeps are context-aware, so cancelled or expired request contexts abort promptly during backoff.

The SDK retries only:

- HTTP `429 Too Many Requests`
- HTTP `503 Service Unavailable`
- HTTP `409 Conflict` when the top-level Stone error tag is explicitly listed in `Policy.Retryable409Tags`

Network errors where no HTTP response is received are not retried.

`Retry-After` headers and Dropbox 429 `retry_after` response bodies are honored up to `MaxRetryAfter`; longer delays are not retried. Oversized `Retry-After` values and large backoff durations saturate instead of overflowing `time.Duration`.

## Upload and download handling

- Upload retries require a seekable request body, such as `*os.File`, `*bytes.Reader`, or `*strings.Reader`.
- Seekable upload bodies are rewound before each retry attempt.
- Non-seekable upload bodies are sent once and are not retried.
- Download retries happen before the response body is returned to the caller.

## Implementation

- New `v6/dropbox/retry` package contains retry policy, backoff, `Retry-After`, and retry-decision logic.
- The request loop and body rewind handling remain in `dropbox`.
- The generator template (`generator/go_rsrc/sdk.go`) and generated runtime SDK (`v6/dropbox/sdk.go`) are kept in sync.
- README documents the feature and examples.

## Validation

- `go test ./... -count=1` from `v6`
- `go vet ./...` from `v6`
- `git diff --check upstream/master...HEAD`
