### PR TITLE
docs: support posture, retry docs/changelog, require Go 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ summarized from the repository history.
 - Added `oauth.GenerateVerifier` for generating PKCE code verifiers.
 - Added `oauth.ScopeOpenID`, `oauth.ScopeEmail`, and `oauth.ScopeProfile`
   constants and `dropbox/openid` identity-flow examples for OpenID Connect.
+- Added the `dropbox/retry` package with a configurable `Policy` for opt-in
+  automatic retries with exponential backoff.
+- Added `dropbox.Config.RetryPolicy` to enable retries for all calls made by a
+  client. Retries `429` and `503` responses (and configurable `409` Stone error
+  tags), honoring `Retry-After` headers and `retry_after` response bodies.
+
+### Changed
+
+- Raised the minimum supported Go version to 1.25.
+- Pinned CI Go versions.
 
 ## v6.3.0 - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,6 @@
-# Dropbox SDK for Go [UNOFFICIAL] [![GoDoc](https://pkg.go.dev/badge/github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox)](https://pkg.go.dev/github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox) [![Actions Status](https://github.com/dropbox/dropbox-sdk-go-unofficial/workflows/Test/badge.svg)](https://github.com/dropbox/dropbox-sdk-go-unofficial/actions) [![Actions Status](https://github.com/dropbox/dropbox-sdk-go-unofficial/workflows/Lint/badge.svg)](https://github.com/dropbox/dropbox-sdk-go-unofficial/actions)
+# Dropbox SDK for Go [![GoDoc](https://pkg.go.dev/badge/github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox)](https://pkg.go.dev/github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox) [![Actions Status](https://github.com/dropbox/dropbox-sdk-go-unofficial/workflows/Test/badge.svg)](https://github.com/dropbox/dropbox-sdk-go-unofficial/actions) [![Actions Status](https://github.com/dropbox/dropbox-sdk-go-unofficial/workflows/Lint/badge.svg)](https://github.com/dropbox/dropbox-sdk-go-unofficial/actions)
 
-An **UNOFFICIAL** Go SDK for integrating with the Dropbox API v2. Requires Go 1.23+
-
-:warning: WARNING: This SDK is **NOT yet official**. What does this mean?
-
-  * There is no formal Dropbox [support](https://www.dropbox.com/developers/support) for this SDK at this point
-  * Bugs may or may not get fixed
-  * Not all SDK features may be implemented and implemented features may be buggy or incorrect
-
-
-### Uh OK, so why are you releasing this?
-
-  * the SDK, while unofficial, _is_ usable. See [dbxcli](https://github.com/dropbox/dbxcli) for an example application built using the SDK
-  * we would like to get feedback from the community and evaluate the level of interest/enthusiasm before investing into official supporting one more SDK
+A Go SDK for integrating with the Dropbox API v2. Requires Go 1.25+
 
 ## Installation
 
@@ -278,14 +266,15 @@ responses. `Retry-After` headers and Dropbox 429 `retry_after` response bodies
 are honored up to `MaxRetryAfter`; longer delays are not retried. Network errors
 where no HTTP response is received are not retried.
 
-Use standard context deadlines to bound the whole operation, including retry
-sleeps and all attempts:
+Retry policies are client-wide; there is no per-call retry override. To set a
+per-call time budget, use a context deadline, which covers retry sleeps and all
+attempts:
 
 ```go
-baseCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
-resp, err := dbx.GetAccountContext(baseCtx, arg)
+resp, err := dbx.GetAccountContext(ctx, arg)
 ```
 
 Some Dropbox API `409 Conflict` responses are also safe to retry. Opt in by
@@ -431,8 +420,10 @@ Please read the [API docs](https://www.dropbox.com/developers/documentation/http
 This SDK is automatically generated using the public [Dropbox API spec](https://github.com/dropbox/dropbox-api-spec) and [Stone](https://github.com/dropbox/stone). See this [README](https://github.com/dropbox/dropbox-sdk-go-unofficial/blob/master/generator/README.md)
 for more details on how code is generated. 
 
-## Caveats
+## Support posture
 
-  * To re-iterate, this is an **UNOFFICIAL** SDK and thus has no official support from Dropbox
-  * Only supports the v2 API. Parts of the v2 API are still in beta, and thus subject to change
-  * This SDK itself is in beta, and so interfaces may change at any point
+This SDK is maintained in the Dropbox GitHub organization by Dropbox engineers,
+but it is not a formally supported Dropbox product. Use GitHub issues and pull
+requests for bugs and contributions; Dropbox [Support](https://www.dropbox.com/developers/support)
+does not provide support for this SDK. The SDK implements a practical subset of
+Dropbox API features, not the full API surface.

--- a/v6/go.mod
+++ b/v6/go.mod
@@ -1,5 +1,5 @@
 module github.com/dropbox/dropbox-sdk-go-unofficial/v6
 
-go 1.23.0
+go 1.25.0
 
 require golang.org/x/oauth2 v0.30.0


### PR DESCRIPTION
## Summary

Documentation and metadata follow-up to the retry policy work (#153).

- **README** — Replace the `[UNOFFICIAL]` / `:warning:` "NOT yet official" framing with a single, professional **Support posture** section at the bottom: maintained in the Dropbox org by Dropbox engineers, not a formally supported product, use GitHub issues/PRs for bugs, implements a practical subset of the API. Drops the now-stale "beta, interfaces may change" caveats.
- **Retry docs** — Clarify that retry policies are configured per client (`Config.RetryPolicy`) with no per-call override; a context deadline bounds retry sleeps and all attempts.
- **CHANGELOG** — Document the retry feature (`dropbox/retry` package and `Config.RetryPolicy`) under Unreleased, which was previously missing.
- **Go version** — Raise the module's minimum Go version to **1.25** (`v6/go.mod`) and update the README. Go 1.23 and 1.24 are end-of-life; this matches the versions CI already tests (1.25.12 / 1.26.5) and lints (1.25.12).

## Notes

- `v6/go.mod` `go 1.25.0` is the only change with compatibility impact — it drops build support for the EOL 1.23/1.24 toolchains.
- No functional code changes; the retry implementation from #153 is untouched.