### PR TITLE
Update API spec, regenerate SDK, and add live-API integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,55 @@
+name: Integration
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+permissions:
+  contents: read
+jobs:
+  integration:
+    name: integration
+    # Skip on fork PRs: they cannot assume the OIDC role, so the credential
+    # fetch below would fail. Runs on pushes to master and same-repo PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:  # required for OIDC
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.12'
+          cache-dependency-path: v6/go.sum
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          # Account 082972943155 hosts the shared API SDK integration secret.
+          # TODO: confirm this repo has an IAM role with an OIDC trust policy
+          # for its GitHub subject (mirrors the dropbox-sdk-python role). If the
+          # role name differs from the one below, update it here.
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-go-unofficial-repo
+          aws-region: us-west-2
+
+      - name: Get integration credentials from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          # Shared secret holding the scoped user/team credentials, reused
+          # across the API SDK repos.
+          secret-ids: |
+            CREDS,api-sdk-integration-test-creds
+          parse-json-secrets: true
+
+      - name: Run integration tests
+        working-directory: ./v6
+        env:
+          SCOPED_USER_CLIENT_ID: ${{ env.CREDS_SCOPED_USER_CLIENT_ID }}
+          SCOPED_USER_CLIENT_SECRET: ${{ env.CREDS_SCOPED_USER_CLIENT_SECRET }}
+          SCOPED_USER_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_USER_REFRESH_TOKEN }}
+          SCOPED_TEAM_CLIENT_ID: ${{ env.CREDS_SCOPED_TEAM_CLIENT_ID }}
+          SCOPED_TEAM_CLIENT_SECRET: ${{ env.CREDS_SCOPED_TEAM_CLIENT_SECRET }}
+          SCOPED_TEAM_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_TEAM_REFRESH_TOKEN }}
+        run: go test -tags integration -v ./dropbox/integration/...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Notable changes to this SDK are documented here. Historical entries are
 summarized from the repository history.
 
+## Unreleased
+
+### Added
+
+- Added `integration`-tagged live-API tests for the user and team clients
+  (folder create/delete round-trips) authenticated with scoped refresh tokens,
+  plus an Integration GitHub Actions workflow.
+
+### Changed
+
+- Exported generated inline Stone composite types, including
+  `riviera.MetadataUnion`.
+- Matched Python SDK serialization by omitting caller-restricted Stone fields
+  from generated public Go types.
+- Updated the Dropbox API spec to `7e5f668` and regenerated the SDK.
+
 ## v6.4.0 - 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -415,6 +415,39 @@ To use the Team API, you will need to create a Dropbox Business App. The OAuth t
 
 Please read the [API docs](https://www.dropbox.com/developers/documentation/http/teams) carefully to appropriate secure your apps and tokens when using the Team API.
 
+## Testing
+
+Unit tests run with the standard toolchain and require no credentials:
+
+```sh
+cd v6
+go test ./...
+```
+
+Integration tests exercise the live Dropbox API and are guarded by the
+`integration` build tag, so they are excluded from the command above. They
+authenticate with scoped user and team refresh tokens, minting short-lived
+access tokens on demand. Provide the credentials through the environment:
+
+```sh
+cd v6
+SCOPED_USER_CLIENT_ID=... SCOPED_USER_CLIENT_SECRET=... SCOPED_USER_REFRESH_TOKEN=... \
+SCOPED_TEAM_CLIENT_ID=... SCOPED_TEAM_CLIENT_SECRET=... SCOPED_TEAM_REFRESH_TOKEN=... \
+  go test -tags integration -v ./dropbox/integration/...
+```
+
+Alternatively, point `DROPBOX_SDK_SECRETS_FILE` at a JSON file containing those
+keys (values already set in the environment take precedence):
+
+```sh
+cd v6
+DROPBOX_SDK_SECRETS_FILE=/path/to/secrets.json \
+  go test -tags integration -v ./dropbox/integration/...
+```
+
+Any credential that is missing causes the corresponding test to be skipped
+rather than fail.
+
 ## Code Generation
 
 This SDK is automatically generated using the public [Dropbox API spec](https://github.com/dropbox/dropbox-api-spec) and [Stone](https://github.com/dropbox/stone). See this [README](https://github.com/dropbox/dropbox-sdk-go-unofficial/blob/master/generator/README.md)

--- a/generator/README.md
+++ b/generator/README.md
@@ -6,7 +6,8 @@ used to programmatically generate the [Dropbox Go SDK](https://github.com/dropbo
 ## Requirements
 
   * While not a hard requirement, this repo currently assumes `python3` in the path.
-  * Assumes you have already installed [Stone](https://github.com/dropbox/stone) and have `stone` in the path.
+  * Requires [Stone v3.5.2](https://github.com/dropbox/stone/releases/tag/v3.5.2)
+    in the path. Install it with `python3 -m pip install stone==3.5.2`.
   * Requires [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) in the path to fix up imports in the auto-generated code.
 
 ## Basic Setup
@@ -33,6 +34,10 @@ Void | struct{}
 ### Structs
 
 Stone [structs](https://github.com/dropbox/stone/blob/master/doc/lang_ref.rst#struct) are represented as Go [structs](https://gobyexample.com/structs) in a relatively straight-forward manner. Each struct member is exported and also gets assigned the correct json tag. The latter is used for serializing requests and deserializing responses. Non-primitive types are represented as pointers to the corresponding type.
+
+Fields annotated with Stone's `Omitted` annotation are caller-restricted and
+are not emitted in the public Go SDK, matching the public serialization maps
+generated for the Python SDK.
 
 ```
 struct Account

--- a/generator/generate-sdk.sh
+++ b/generator/generate-sdk.sh
@@ -7,7 +7,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 version=$(echo $1 | cut -f1 -d'.')
-loc=$(realpath -e $0)
+loc=$(realpath "$0")
 base_dir=$(dirname "$loc")
 spec_dir="$base_dir/dropbox-api-spec"
 gen_dir=$(dirname ${base_dir})/v$version/dropbox

--- a/generator/go_helpers.py
+++ b/generator/go_helpers.py
@@ -69,6 +69,11 @@ def _rename_if_reserved(s):
         return s
 
 
+def fmt_type_name(data_type, export=True):
+    """Format a Stone composite type name as a Go identifier."""
+    return fmt_var(data_type.name, export=export, check_reserved=True)
+
+
 def fmt_type(data_type, namespace=None, use_interface=False, raw=False):
     data_type, nullable = unwrap_nullable(data_type)
     if is_list_type(data_type):
@@ -81,7 +86,8 @@ def fmt_type(data_type, namespace=None, use_interface=False, raw=False):
         return 'map[string]%s' % fmt_type(data_type.value_data_type, namespace, use_interface, raw)
     if raw:
         return "json.RawMessage"
-    type_name = data_type.name
+    type_name = (fmt_type_name(data_type)
+                 if is_composite_type(data_type) else data_type.name)
     if use_interface and _needs_base_type(data_type):
         type_name = 'Is' + type_name
     if is_composite_type(data_type) and namespace is not None and \
@@ -158,6 +164,8 @@ def _needs_base_type(data_type):
 
 def needs_base_type(struct):
     for field in struct.fields:
+        if field.omitted_caller is not None:
+            continue
         if _needs_base_type(field.data_type):
             return True
     return False

--- a/generator/go_rsrc/sdk.go
+++ b/generator/go_rsrc/sdk.go
@@ -64,6 +64,8 @@ func (e APIError) Error() string {
 	return e.ErrorSummary
 }
 
+// SDKInternalError is returned when the Dropbox API responds with a status code
+// that does not carry a typed error body (e.g. 500 Internal Server Error).
 type SDKInternalError struct {
 	StatusCode int
 	Content    string
@@ -87,9 +89,10 @@ type Config struct {
 	AsAdminID string
 	// Path relative to which action should be taken
 	PathRoot string
-	// No need to set -- for testing only
+	// Dropbox API domain. The default is ".dropboxapi.com".
 	Domain string
-	// No need to set -- for testing only
+	// HTTP client used for authenticated Dropbox API calls. If set, Client takes
+	// precedence over TokenSource and Token.
 	Client *http.Client
 	// RetryPolicy controls automatic retries for Dropbox API calls. If nil, retries
 	// are disabled.

--- a/generator/go_types.stoneg.py
+++ b/generator/go_types.stoneg.py
@@ -16,11 +16,23 @@ from stone.ir import (
 from go_helpers import (
     HEADER,
     fmt_type,
+    fmt_type_name,
     fmt_var,
     generate_doc,
     needs_base_type,
     _needs_base_type
 )
+
+
+def _public_fields(fields):
+    """Return the fields exposed by the public SDK.
+
+    Stone's Omitted annotation assigns an ``omitted_caller`` to permissioned
+    fields. The public Python SDK excludes those fields from its public field
+    maps; the Go SDK has no caller-specific serialization path, so omit them
+    from the generated public types entirely.
+    """
+    return [field for field in fields if field.omitted_caller is None]
 
 
 class GoTypesBackend(CodeBackend):
@@ -73,7 +85,7 @@ class GoTypesBackend(CodeBackend):
             with self.block("if err := json.Unmarshal(data, &t); err != nil"):
                 self.emit("return nil, err")
             with self.block("switch t.Tag"):
-                fields = base.get_enumerated_subtypes()
+                fields = _public_fields(base.get_enumerated_subtypes())
                 for field in fields:
                     with self.block('case "%s":' % field.name, delim=(None, None)):
                         self.emit("return t.{0}, nil".format(fmt_var(field.name)))
@@ -81,10 +93,11 @@ class GoTypesBackend(CodeBackend):
             self.emit("return nil, nil")
 
     def _generate_struct(self, struct):
-        with self.block('type %s struct' % struct.name):
+        name = fmt_type_name(struct)
+        with self.block('type %s struct' % name):
             if struct.parent_type:
                 self.emit(fmt_type(struct.parent_type, struct.namespace).lstrip('*'))
-            for field in struct.fields:
+            for field in _public_fields(struct.fields):
                 self._generate_field(field, namespace=struct.namespace)
             if struct.name in ('DownloadArg',):
                 self.emit('// ExtraHeaders can be used to pass Range, If-None-Match headers')
@@ -92,16 +105,16 @@ class GoTypesBackend(CodeBackend):
         self._generate_struct_builder(struct)
         self.emit()
         if needs_base_type(struct):
-            self.emit('// UnmarshalJSON deserializes into a %s instance' % struct.name)
-            with self.block('func (u *%s) UnmarshalJSON(b []byte) error' % struct.name):
+            self.emit('// UnmarshalJSON deserializes into a %s instance' % name)
+            with self.block('func (u *%s) UnmarshalJSON(b []byte) error' % name):
                 with self.block('type wrap struct'):
-                    for field in struct.all_fields:
+                    for field in _public_fields(struct.all_fields):
                         self._generate_field(field, namespace=struct.namespace,
                                              raw=_needs_base_type(field.data_type))
                 self.emit('var w wrap')
                 with self.block('if err := json.Unmarshal(b, &w); err != nil'):
                     self.emit('return err')
-                for field in struct.all_fields:
+                for field in _public_fields(struct.all_fields):
                     dt = field.data_type
                     fn = fmt_var(field.name)
                     tn = fmt_type(dt, namespace=struct.namespace, use_interface=True)
@@ -125,19 +138,22 @@ class GoTypesBackend(CodeBackend):
                 self.emit('return nil')
 
     def _generate_struct_builder(self, struct):
+        name = fmt_type_name(struct)
+        required_fields = _public_fields(struct.all_required_fields)
+        optional_fields = _public_fields(struct.all_optional_fields)
         fields = ["%s %s" % (fmt_var(field.name),
                              fmt_type(field.data_type, struct.namespace,
                                       use_interface=True))
-                  for field in struct.all_required_fields]
-        self.emit('// New{0} returns a new {0} instance'.format(struct.name))
-        signature = "func New{0}({1}) *{0}".format(struct.name, ', '.join(fields))
+                  for field in required_fields]
+        self.emit('// New{0} returns a new {0} instance'.format(name))
+        signature = "func New{0}({1}) *{0}".format(name, ', '.join(fields))
         with self.block(signature):
-            self.emit('s := new({0})'.format(struct.name))
-            for field in struct.all_required_fields:
+            self.emit('s := new({0})'.format(name))
+            for field in required_fields:
                 field_name = fmt_var(field.name)
                 self.emit("s.{0} = {0}".format(field_name))
 
-            for field in struct.all_optional_fields:
+            for field in optional_fields:
                 if field.has_default:
                     if is_primitive_type(field.data_type):
                         default = field.default
@@ -167,14 +183,14 @@ class GoTypesBackend(CodeBackend):
         self._generate_union_helper(union)
 
     def _generate_union_helper(self, u):
-        name = u.name
+        name = fmt_type_name(u)
         namespace = u.namespace
         # Unions can be inherited, but don't need to be polymorphic.
         # So let's flatten out all the inherited fields.
-        fields = u.all_fields
+        fields = _public_fields(u.all_fields)
         if is_struct_type(u) and u.has_enumerated_subtypes():
-            name = fmt_var(name, export=False) + 'Union'
-            fields = u.get_enumerated_subtypes()
+            name = fmt_type_name(u, export=False) + 'Union'
+            fields = _public_fields(u.get_enumerated_subtypes())
 
         with self.block('type %s struct' % name):
             self.emit('dropbox.Tagged')
@@ -220,7 +236,7 @@ class GoTypesBackend(CodeBackend):
                     with self.block('case "%s":' % field.name, delim=(None, None)):
                         if _needs_base_type(field.data_type):
                             with self.block("if u.{0}, err = Is{1}FromJSON(w.{0}); err != nil"
-                                       .format(field_name, field.data_type.name)):
+                                       .format(field_name, fmt_type_name(field.data_type))):
                                 self.emit("return err")
                         elif is_struct_type(field.data_type):
                             with self.block('if err = json.Unmarshal(body, &u.{0}); err != nil'

--- a/v6/dropbox/account/client.go
+++ b/v6/dropbox/account/client.go
@@ -45,7 +45,8 @@ type ContextClient interface {
 	Client
 	// DeleteProfilePhotoContext : Deletes the current user's profile photo.
 	DeleteProfilePhotoContext(ctx context.Context, arg *DeleteProfilePhotoArg) (res *DeleteProfilePhotoResult, err error)
-	// GetPhotoContext : This lovely endpoint gets the account photo of a given user.
+	// GetPhotoContext : This lovely endpoint gets the account photo of a given
+	// user.
 	GetPhotoContext(ctx context.Context, arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error)
 	// SetProfilePhotoContext : Sets a user's profile photo.
 	SetProfilePhotoContext(ctx context.Context, arg *SetProfilePhotoArg) (res *SetProfilePhotoResult, err error)
@@ -102,7 +103,8 @@ type GetPhotoAPIError struct {
 	EndpointError *AccountPhotoGetError `json:"error"`
 }
 
-// GetPhotoContext : This lovely endpoint gets the account photo of a given user.
+// GetPhotoContext : This lovely endpoint gets the account photo of a given
+// user.
 func (dbx *apiImpl) GetPhotoContext(ctx context.Context, arg *AccountPhotoGetArg) (res *AccountPhotoGetResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",

--- a/v6/dropbox/auth/client.go
+++ b/v6/dropbox/auth/client.go
@@ -46,14 +46,14 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// TokenFromOauth1Context : Creates an OAuth 2.0 access token from the supplied
-	// OAuth 1.0 access token.
+	// TokenFromOauth1Context : Creates an OAuth 2.0 access token from the
+	// supplied OAuth 1.0 access token.
 	// Deprecated:
 	TokenFromOauth1Context(ctx context.Context, arg *TokenFromOAuth1Arg) (res *TokenFromOAuth1Result, err error)
-	// TokenRevokeContext : Disables the access token used to authenticate the call. If
-	// there is a corresponding refresh token for the access token, this
-	// disables that refresh token, as well as any other access tokens for that
-	// refresh token.
+	// TokenRevokeContext : Disables the access token used to authenticate the
+	// call. If there is a corresponding refresh token for the access token,
+	// this disables that refresh token, as well as any other access tokens for
+	// that refresh token.
 	TokenRevokeContext(ctx context.Context) (err error)
 }
 
@@ -112,10 +112,10 @@ type TokenRevokeAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// TokenRevokeContext : Disables the access token used to authenticate the call. If
-// there is a corresponding refresh token for the access token, this
-// disables that refresh token, as well as any other access tokens for that
-// refresh token.
+// TokenRevokeContext : Disables the access token used to authenticate the call.
+// If there is a corresponding refresh token for the access token, this disables
+// that refresh token, as well as any other access tokens for that refresh
+// token.
 func (dbx *apiImpl) TokenRevokeContext(ctx context.Context) (err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/check/client.go
+++ b/v6/dropbox/check/client.go
@@ -51,12 +51,12 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// AppContext : This endpoint performs App Authentication, validating the supplied
-	// app key and secret, and returns the supplied string, to allow you to test
-	// your code and connection to the Dropbox API. It has no other effect. If
-	// you receive an HTTP 200 response with the supplied query, it indicates at
-	// least part of the Dropbox API infrastructure is working and that the app
-	// key and secret valid.
+	// AppContext : This endpoint performs App Authentication, validating the
+	// supplied app key and secret, and returns the supplied string, to allow
+	// you to test your code and connection to the Dropbox API. It has no other
+	// effect. If you receive an HTTP 200 response with the supplied query, it
+	// indicates at least part of the Dropbox API infrastructure is working and
+	// that the app key and secret valid.
 	AppContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error)
 	// UserContext : This endpoint performs User Authentication, validating the
 	// supplied access token, and returns the supplied string, to allow you to
@@ -75,12 +75,12 @@ type AppAPIError struct {
 	EndpointError *EchoError `json:"error"`
 }
 
-// AppContext : This endpoint performs App Authentication, validating the supplied
-// app key and secret, and returns the supplied string, to allow you to test
-// your code and connection to the Dropbox API. It has no other effect. If
+// AppContext : This endpoint performs App Authentication, validating the
+// supplied app key and secret, and returns the supplied string, to allow you to
+// test your code and connection to the Dropbox API. It has no other effect. If
 // you receive an HTTP 200 response with the supplied query, it indicates at
-// least part of the Dropbox API infrastructure is working and that the app
-// key and secret valid.
+// least part of the Dropbox API infrastructure is working and that the app key
+// and secret valid.
 func (dbx *apiImpl) AppContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -124,11 +124,11 @@ type UserAPIError struct {
 }
 
 // UserContext : This endpoint performs User Authentication, validating the
-// supplied access token, and returns the supplied string, to allow you to
-// test your code and connection to the Dropbox API. It has no other effect.
-// If you receive an HTTP 200 response with the supplied query, it indicates
-// at least part of the Dropbox API infrastructure is working and that the
-// access token is valid.
+// supplied access token, and returns the supplied string, to allow you to test
+// your code and connection to the Dropbox API. It has no other effect. If you
+// receive an HTTP 200 response with the supplied query, it indicates at least
+// part of the Dropbox API infrastructure is working and that the access token
+// is valid.
 func (dbx *apiImpl) UserContext(ctx context.Context, arg *EchoArg) (res *EchoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/contacts/client.go
+++ b/v6/dropbox/contacts/client.go
@@ -43,12 +43,12 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// DeleteManualContactsContext : Removes all manually added contacts. You'll still
-	// keep contacts who are on your team or who you imported. New contacts will
-	// be added when you share.
+	// DeleteManualContactsContext : Removes all manually added contacts. You'll
+	// still keep contacts who are on your team or who you imported. New
+	// contacts will be added when you share.
 	DeleteManualContactsContext(ctx context.Context) (err error)
-	// DeleteManualContactsBatchContext : Removes manually added contacts from the
-	// given list.
+	// DeleteManualContactsBatchContext : Removes manually added contacts from
+	// the given list.
 	DeleteManualContactsBatchContext(ctx context.Context, arg *DeleteManualContactsArg) (err error)
 }
 
@@ -60,9 +60,9 @@ type DeleteManualContactsAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// DeleteManualContactsContext : Removes all manually added contacts. You'll still
-// keep contacts who are on your team or who you imported. New contacts will
-// be added when you share.
+// DeleteManualContactsContext : Removes all manually added contacts. You'll
+// still keep contacts who are on your team or who you imported. New contacts
+// will be added when you share.
 func (dbx *apiImpl) DeleteManualContactsContext(ctx context.Context) (err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/file_properties/client.go
+++ b/v6/dropbox/file_properties/client.go
@@ -107,18 +107,18 @@ type ContextClient interface {
 	// PropertiesAddContext : Add property groups to a Dropbox file. See
 	// `templatesAddForUser` or `templatesAddForTeam` to create new templates.
 	PropertiesAddContext(ctx context.Context, arg *AddPropertiesArg) (err error)
-	// PropertiesOverwriteContext : Overwrite property groups associated with a file.
-	// This endpoint should be used instead of `propertiesUpdate` when property
-	// groups are being updated via a "snapshot" instead of via a "delta". In
-	// other words, this endpoint will delete all omitted fields from a property
-	// group, whereas `propertiesUpdate` will only delete fields that are
-	// explicitly marked for deletion.
+	// PropertiesOverwriteContext : Overwrite property groups associated with a
+	// file. This endpoint should be used instead of `propertiesUpdate` when
+	// property groups are being updated via a "snapshot" instead of via a
+	// "delta". In other words, this endpoint will delete all omitted fields
+	// from a property group, whereas `propertiesUpdate` will only delete fields
+	// that are explicitly marked for deletion.
 	PropertiesOverwriteContext(ctx context.Context, arg *OverwritePropertyGroupArg) (err error)
-	// PropertiesRemoveContext : Permanently removes the specified property group from
-	// the file. To remove specific property field key value pairs, see
-	// `propertiesUpdate`. To update a template, see `templatesUpdateForUser` or
-	// `templatesUpdateForTeam`. To remove a template, see
-	// `templatesRemoveForUser` or `templatesRemoveForTeam`.
+	// PropertiesRemoveContext : Permanently removes the specified property
+	// group from the file. To remove specific property field key value pairs,
+	// see `propertiesUpdate`. To update a template, see
+	// `templatesUpdateForUser` or `templatesUpdateForTeam`. To remove a
+	// template, see `templatesRemoveForUser` or `templatesRemoveForTeam`.
 	PropertiesRemoveContext(ctx context.Context, arg *RemovePropertiesArg) (err error)
 	// PropertiesSearchContext : Search across property templates for particular
 	// property field values.
@@ -126,11 +126,11 @@ type ContextClient interface {
 	// PropertiesSearchContinueContext : Once a cursor has been retrieved from
 	// `propertiesSearch`, use this to paginate through all search results.
 	PropertiesSearchContinueContext(ctx context.Context, arg *PropertiesSearchContinueArg) (res *PropertiesSearchResult, err error)
-	// PropertiesUpdateContext : Add, update or remove properties associated with the
-	// supplied file and templates. This endpoint should be used instead of
-	// `propertiesOverwrite` when property groups are being updated via a
-	// "delta" instead of via a "snapshot" . In other words, this endpoint will
-	// not delete any omitted fields from a property group, whereas
+	// PropertiesUpdateContext : Add, update or remove properties associated
+	// with the supplied file and templates. This endpoint should be used
+	// instead of `propertiesOverwrite` when property groups are being updated
+	// via a "delta" instead of via a "snapshot" . In other words, this endpoint
+	// will not delete any omitted fields from a property group, whereas
 	// `propertiesOverwrite` will delete any fields that are omitted from a
 	// property group.
 	PropertiesUpdateContext(ctx context.Context, arg *UpdatePropertiesArg) (err error)
@@ -144,30 +144,30 @@ type ContextClient interface {
 	TemplatesAddForUserContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error)
 	// TemplatesGetForTeamContext : Get the schema for a specified template.
 	TemplatesGetForTeamContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error)
-	// TemplatesGetForUserContext : Get the schema for a specified template. This
-	// endpoint can't be called on a team member or admin's behalf.
+	// TemplatesGetForUserContext : Get the schema for a specified template.
+	// This endpoint can't be called on a team member or admin's behalf.
 	TemplatesGetForUserContext(ctx context.Context, arg *GetTemplateArg) (res *GetTemplateResult, err error)
-	// TemplatesListForTeamContext : Get the template identifiers for a team. To get
-	// the schema of each template use `templatesGetForTeam`.
+	// TemplatesListForTeamContext : Get the template identifiers for a team. To
+	// get the schema of each template use `templatesGetForTeam`.
 	TemplatesListForTeamContext(ctx context.Context) (res *ListTemplateResult, err error)
-	// TemplatesListForUserContext : Get the template identifiers for a team. To get
-	// the schema of each template use `templatesGetForUser`. This endpoint
+	// TemplatesListForUserContext : Get the template identifiers for a team. To
+	// get the schema of each template use `templatesGetForUser`. This endpoint
 	// can't be called on a team member or admin's behalf.
 	TemplatesListForUserContext(ctx context.Context) (res *ListTemplateResult, err error)
-	// TemplatesRemoveForTeamContext : Permanently removes the specified template
-	// created from `templatesAddForUser`. All properties associated with the
-	// template will also be removed. This action cannot be undone.
+	// TemplatesRemoveForTeamContext : Permanently removes the specified
+	// template created from `templatesAddForUser`. All properties associated
+	// with the template will also be removed. This action cannot be undone.
 	TemplatesRemoveForTeamContext(ctx context.Context, arg *RemoveTemplateArg) (err error)
-	// TemplatesRemoveForUserContext : Permanently removes the specified template
-	// created from `templatesAddForUser`. All properties associated with the
-	// template will also be removed. This action cannot be undone.
+	// TemplatesRemoveForUserContext : Permanently removes the specified
+	// template created from `templatesAddForUser`. All properties associated
+	// with the template will also be removed. This action cannot be undone.
 	TemplatesRemoveForUserContext(ctx context.Context, arg *RemoveTemplateArg) (err error)
-	// TemplatesUpdateForTeamContext : Update a template associated with a team. This
-	// route can update the template name, the template description and add
+	// TemplatesUpdateForTeamContext : Update a template associated with a team.
+	// This route can update the template name, the template description and add
 	// optional properties to templates.
 	TemplatesUpdateForTeamContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error)
-	// TemplatesUpdateForUserContext : Update a template associated with a user. This
-	// route can update the template name, the template description and add
+	// TemplatesUpdateForUserContext : Update a template associated with a user.
+	// This route can update the template name, the template description and add
 	// optional properties to templates. This endpoint can't be called on a team
 	// member or admin's behalf.
 	TemplatesUpdateForUserContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error)
@@ -221,12 +221,12 @@ type PropertiesOverwriteAPIError struct {
 	EndpointError *InvalidPropertyGroupError `json:"error"`
 }
 
-// PropertiesOverwriteContext : Overwrite property groups associated with a file.
-// This endpoint should be used instead of `propertiesUpdate` when property
-// groups are being updated via a "snapshot" instead of via a "delta". In
-// other words, this endpoint will delete all omitted fields from a property
-// group, whereas `propertiesUpdate` will only delete fields that are
-// explicitly marked for deletion.
+// PropertiesOverwriteContext : Overwrite property groups associated with a
+// file. This endpoint should be used instead of `propertiesUpdate` when
+// property groups are being updated via a "snapshot" instead of via a "delta".
+// In other words, this endpoint will delete all omitted fields from a property
+// group, whereas `propertiesUpdate` will only delete fields that are explicitly
+// marked for deletion.
 func (dbx *apiImpl) PropertiesOverwriteContext(ctx context.Context, arg *OverwritePropertyGroupArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -265,11 +265,11 @@ type PropertiesRemoveAPIError struct {
 	EndpointError *RemovePropertiesError `json:"error"`
 }
 
-// PropertiesRemoveContext : Permanently removes the specified property group from
-// the file. To remove specific property field key value pairs, see
+// PropertiesRemoveContext : Permanently removes the specified property group
+// from the file. To remove specific property field key value pairs, see
 // `propertiesUpdate`. To update a template, see `templatesUpdateForUser` or
-// `templatesUpdateForTeam`. To remove a template, see
-// `templatesRemoveForUser` or `templatesRemoveForTeam`.
+// `templatesUpdateForTeam`. To remove a template, see `templatesRemoveForUser`
+// or `templatesRemoveForTeam`.
 func (dbx *apiImpl) PropertiesRemoveContext(ctx context.Context, arg *RemovePropertiesArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -396,13 +396,12 @@ type PropertiesUpdateAPIError struct {
 	EndpointError *UpdatePropertiesError `json:"error"`
 }
 
-// PropertiesUpdateContext : Add, update or remove properties associated with the
-// supplied file and templates. This endpoint should be used instead of
-// `propertiesOverwrite` when property groups are being updated via a
-// "delta" instead of via a "snapshot" . In other words, this endpoint will
-// not delete any omitted fields from a property group, whereas
-// `propertiesOverwrite` will delete any fields that are omitted from a
-// property group.
+// PropertiesUpdateContext : Add, update or remove properties associated with
+// the supplied file and templates. This endpoint should be used instead of
+// `propertiesOverwrite` when property groups are being updated via a "delta"
+// instead of via a "snapshot" . In other words, this endpoint will not delete
+// any omitted fields from a property group, whereas `propertiesOverwrite` will
+// delete any fields that are omitted from a property group.
 func (dbx *apiImpl) PropertiesUpdateContext(ctx context.Context, arg *UpdatePropertiesArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -442,8 +441,8 @@ type TemplatesAddForTeamAPIError struct {
 }
 
 // TemplatesAddForTeamContext : Add a template associated with a team. See
-// `propertiesAdd` to add properties to a file or folder. Note: this
-// endpoint will create team-owned templates.
+// `propertiesAdd` to add properties to a file or folder. Note: this endpoint
+// will create team-owned templates.
 func (dbx *apiImpl) TemplatesAddForTeamContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -487,8 +486,8 @@ type TemplatesAddForUserAPIError struct {
 }
 
 // TemplatesAddForUserContext : Add a template associated with a user. See
-// `propertiesAdd` to add properties to a file. This endpoint can't be
-// called on a team member or admin's behalf.
+// `propertiesAdd` to add properties to a file. This endpoint can't be called on
+// a team member or admin's behalf.
 func (dbx *apiImpl) TemplatesAddForUserContext(ctx context.Context, arg *AddTemplateArg) (res *AddTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -663,8 +662,8 @@ type TemplatesListForUserAPIError struct {
 }
 
 // TemplatesListForUserContext : Get the template identifiers for a team. To get
-// the schema of each template use `templatesGetForUser`. This endpoint
-// can't be called on a team member or admin's behalf.
+// the schema of each template use `templatesGetForUser`. This endpoint can't be
+// called on a team member or admin's behalf.
 func (dbx *apiImpl) TemplatesListForUserContext(ctx context.Context) (res *ListTemplateResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -789,8 +788,8 @@ type TemplatesUpdateForTeamAPIError struct {
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-// TemplatesUpdateForTeamContext : Update a template associated with a team. This
-// route can update the template name, the template description and add
+// TemplatesUpdateForTeamContext : Update a template associated with a team.
+// This route can update the template name, the template description and add
 // optional properties to templates.
 func (dbx *apiImpl) TemplatesUpdateForTeamContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {
 	req := dropbox.Request{
@@ -834,8 +833,8 @@ type TemplatesUpdateForUserAPIError struct {
 	EndpointError *ModifyTemplateError `json:"error"`
 }
 
-// TemplatesUpdateForUserContext : Update a template associated with a user. This
-// route can update the template name, the template description and add
+// TemplatesUpdateForUserContext : Update a template associated with a user.
+// This route can update the template name, the template description and add
 // optional properties to templates. This endpoint can't be called on a team
 // member or admin's behalf.
 func (dbx *apiImpl) TemplatesUpdateForUserContext(ctx context.Context, arg *UpdateTemplateArg) (res *UpdateTemplateResult, err error) {

--- a/v6/dropbox/file_requests/client.go
+++ b/v6/dropbox/file_requests/client.go
@@ -62,28 +62,29 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// CountContext : Returns the total number of file requests owned by this user.
-	// Includes both open and closed file requests.
+	// CountContext : Returns the total number of file requests owned by this
+	// user. Includes both open and closed file requests.
 	CountContext(ctx context.Context) (res *CountFileRequestsResult, err error)
 	// CreateContext : Creates a file request for this user.
 	CreateContext(ctx context.Context, arg *CreateFileRequestArgs) (res *FileRequest, err error)
 	// DeleteContext : Delete a batch of closed file requests.
 	DeleteContext(ctx context.Context, arg *DeleteFileRequestArgs) (res *DeleteFileRequestsResult, err error)
-	// DeleteAllClosedContext : Delete all closed file requests owned by this user.
+	// DeleteAllClosedContext : Delete all closed file requests owned by this
+	// user.
 	DeleteAllClosedContext(ctx context.Context) (res *DeleteAllClosedFileRequestsResult, err error)
 	// GetContext : Returns the specified file request.
 	GetContext(ctx context.Context, arg *GetFileRequestArgs) (res *FileRequest, err error)
-	// ListContext : Returns a list of file requests owned by this user. For apps with
-	// the app folder permission, this will only return file requests with
-	// destinations in the app folder.
+	// ListContext : Returns a list of file requests owned by this user. For
+	// apps with the app folder permission, this will only return file requests
+	// with destinations in the app folder.
 	ListContext(ctx context.Context) (res *ListFileRequestsResult, err error)
-	// ListV2Context : Returns a list of file requests owned by this user. For apps with
-	// the app folder permission, this will only return file requests with
-	// destinations in the app folder.
+	// ListV2Context : Returns a list of file requests owned by this user. For
+	// apps with the app folder permission, this will only return file requests
+	// with destinations in the app folder.
 	ListV2Context(ctx context.Context, arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error)
-	// ListContinueContext : Once a cursor has been retrieved from `list`, use this to
-	// paginate through all file requests. The cursor must come from a previous
-	// call to `list` or `listContinue`.
+	// ListContinueContext : Once a cursor has been retrieved from `list`, use
+	// this to paginate through all file requests. The cursor must come from a
+	// previous call to `list` or `listContinue`.
 	ListContinueContext(ctx context.Context, arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error)
 	// UpdateContext : Update a file request.
 	UpdateContext(ctx context.Context, arg *UpdateFileRequestArgs) (res *FileRequest, err error)
@@ -313,8 +314,8 @@ type ListAPIError struct {
 	EndpointError *ListFileRequestsError `json:"error"`
 }
 
-// ListContext : Returns a list of file requests owned by this user. For apps with
-// the app folder permission, this will only return file requests with
+// ListContext : Returns a list of file requests owned by this user. For apps
+// with the app folder permission, this will only return file requests with
 // destinations in the app folder.
 func (dbx *apiImpl) ListContext(ctx context.Context) (res *ListFileRequestsResult, err error) {
 	req := dropbox.Request{
@@ -358,8 +359,8 @@ type ListV2APIError struct {
 	EndpointError *ListFileRequestsError `json:"error"`
 }
 
-// ListV2Context : Returns a list of file requests owned by this user. For apps with
-// the app folder permission, this will only return file requests with
+// ListV2Context : Returns a list of file requests owned by this user. For apps
+// with the app folder permission, this will only return file requests with
 // destinations in the app folder.
 func (dbx *apiImpl) ListV2Context(ctx context.Context, arg *ListFileRequestsArg) (res *ListFileRequestsV2Result, err error) {
 	req := dropbox.Request{
@@ -403,8 +404,8 @@ type ListContinueAPIError struct {
 	EndpointError *ListFileRequestsContinueError `json:"error"`
 }
 
-// ListContinueContext : Once a cursor has been retrieved from `list`, use this to
-// paginate through all file requests. The cursor must come from a previous
+// ListContinueContext : Once a cursor has been retrieved from `list`, use this
+// to paginate through all file requests. The cursor must come from a previous
 // call to `list` or `listContinue`.
 func (dbx *apiImpl) ListContinueContext(ctx context.Context, arg *ListFileRequestsContinueArg) (res *ListFileRequestsV2Result, err error) {
 	req := dropbox.Request{

--- a/v6/dropbox/files/client.go
+++ b/v6/dropbox/files/client.go
@@ -474,9 +474,9 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// AlphaGetMetadataContext : Returns the metadata for a file or folder. This is an
-	// alpha endpoint compatible with the properties API. Note: Metadata for the
-	// root folder is unsupported.
+	// AlphaGetMetadataContext : Returns the metadata for a file or folder. This
+	// is an alpha endpoint compatible with the properties API. Note: Metadata
+	// for the root folder is unsupported.
 	// Deprecated:
 	AlphaGetMetadataContext(ctx context.Context, arg *AlphaGetMetadataArg) (res IsMetadata, err error)
 	// AlphaUploadContext : Create a new file with the contents provided in the
@@ -489,21 +489,23 @@ type ContextClient interface {
 	// Dropbox. If the source path is a folder all its contents will be copied.
 	// Deprecated:
 	CopyContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error)
-	// CopyV2Context : Copy a file or folder to a different location in the user's
-	// Dropbox. If the source path is a folder all its contents will be copied.
+	// CopyV2Context : Copy a file or folder to a different location in the
+	// user's Dropbox. If the source path is a folder all its contents will be
+	// copied.
 	CopyV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error)
-	// CopyBatchContext : Copy multiple files or folders to different locations at once
-	// in the user's Dropbox. This route will return job ID immediately and do
-	// the async copy job in background. Please use `copyBatchCheck` to check
-	// the job status.
+	// CopyBatchContext : Copy multiple files or folders to different locations
+	// at once in the user's Dropbox. This route will return job ID immediately
+	// and do the async copy job in background. Please use `copyBatchCheck` to
+	// check the job status.
 	// Deprecated:
 	CopyBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error)
-	// CopyBatchV2Context : Copy multiple files or folders to different locations at once
-	// in the user's Dropbox. This route will replace `copyBatch`. The main
-	// difference is this route will return status for each entry, while
-	// `copyBatch` raises failure if any entry fails. This route will either
-	// finish synchronously, or return a job ID and do the async copy job in
-	// background. Please use `copyBatchCheck` to check the job status.
+	// CopyBatchV2Context : Copy multiple files or folders to different
+	// locations at once in the user's Dropbox. This route will replace
+	// `copyBatch`. The main difference is this route will return status for
+	// each entry, while `copyBatch` raises failure if any entry fails. This
+	// route will either finish synchronously, or return a job ID and do the
+	// async copy job in background. Please use `copyBatchCheck` to check the
+	// job status.
 	CopyBatchV2Context(ctx context.Context, arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error)
 	// CopyBatchCheckContext : Returns the status of an asynchronous job for
 	// `copyBatch`. If success, it returns list of results for each entry.
@@ -516,8 +518,8 @@ type ContextClient interface {
 	// reference string can be used to save that file or folder to another
 	// user's Dropbox by passing it to `copyReferenceSave`.
 	CopyReferenceGetContext(ctx context.Context, arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error)
-	// CopyReferenceSaveContext : Save a copy reference returned by `copyReferenceGet`
-	// to the user's Dropbox.
+	// CopyReferenceSaveContext : Save a copy reference returned by
+	// `copyReferenceGet` to the user's Dropbox.
 	CopyReferenceSaveContext(ctx context.Context, arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error)
 	// CreateFolderContext : Create a folder at a given path.
 	// Deprecated:
@@ -532,19 +534,19 @@ type ContextClient interface {
 	// CreateFolderBatchArg.force_async flag.  Use `createFolderBatchCheck` to
 	// check the job status.
 	CreateFolderBatchContext(ctx context.Context, arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error)
-	// CreateFolderBatchCheckContext : Returns the status of an asynchronous job for
-	// `createFolderBatch`. If success, it returns list of result for each
+	// CreateFolderBatchCheckContext : Returns the status of an asynchronous job
+	// for `createFolderBatch`. If success, it returns list of result for each
 	// entry.
 	CreateFolderBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error)
-	// DeleteContext : Delete the file or folder at a given path. If the path is a
-	// folder, all its contents will be deleted too. A successful response
+	// DeleteContext : Delete the file or folder at a given path. If the path is
+	// a folder, all its contents will be deleted too. A successful response
 	// indicates that the file or folder was deleted. The returned metadata will
 	// be the corresponding FileMetadata or FolderMetadata for the item at time
 	// of deletion, and not a DeletedMetadata object.
 	// Deprecated:
 	DeleteContext(ctx context.Context, arg *DeleteArg) (res IsMetadata, err error)
-	// DeleteV2Context : Delete the file or folder at a given path. If the path is a
-	// folder, all its contents will be deleted too. A successful response
+	// DeleteV2Context : Delete the file or folder at a given path. If the path
+	// is a folder, all its contents will be deleted too. A successful response
 	// indicates that the file or folder was deleted. The returned metadata will
 	// be the corresponding FileMetadata or FolderMetadata for the item at time
 	// of deletion, and not a DeletedMetadata object.
@@ -558,21 +560,22 @@ type ContextClient interface {
 	DeleteBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *DeleteBatchJobStatus, err error)
 	// DownloadContext : Download a file from a user's Dropbox.
 	DownloadContext(ctx context.Context, arg *DownloadArg) (res *FileMetadata, content io.ReadCloser, err error)
-	// DownloadZipContext : Download a folder from the user's Dropbox, as a zip file.
-	// The folder must be less than 20 GB in size and any single file within
-	// must be less than 4 GB in size. The resulting zip must have fewer than
-	// 10,000 total file and folder entries, including the top level folder. The
-	// input cannot be a single file. Note: this endpoint does not support HTTP
-	// range requests.
+	// DownloadZipContext : Download a folder from the user's Dropbox, as a zip
+	// file. The folder must be less than 20 GB in size and any single file
+	// within must be less than 4 GB in size. The resulting zip must have fewer
+	// than 10,000 total file and folder entries, including the top level
+	// folder. The input cannot be a single file. Note: this endpoint does not
+	// support HTTP range requests.
 	DownloadZipContext(ctx context.Context, arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error)
-	// ExportContext : Export a file from a user's Dropbox. This route only supports
-	// exporting files that cannot be downloaded directly and whose
+	// ExportContext : Export a file from a user's Dropbox. This route only
+	// supports exporting files that cannot be downloaded directly and whose
 	// ExportResult.file_metadata has ExportInfo.export_as populated.
 	ExportContext(ctx context.Context, arg *ExportArg) (res *ExportResult, content io.ReadCloser, err error)
-	// GetFileLockBatchContext : Return the lock metadata for the given list of paths.
+	// GetFileLockBatchContext : Return the lock metadata for the given list of
+	// paths.
 	GetFileLockBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error)
-	// GetMetadataContext : Returns the metadata for a file or folder. Note: Metadata
-	// for the root folder is unsupported.
+	// GetMetadataContext : Returns the metadata for a file or folder. Note:
+	// Metadata for the root folder is unsupported.
 	GetMetadataContext(ctx context.Context, arg *GetMetadataArg) (res IsMetadata, err error)
 	// GetPreviewContext : Get a preview for a file. Currently, PDF previews are
 	// generated for files with the following extensions: .ai, .doc, .docm,
@@ -581,14 +584,14 @@ type ContextClient interface {
 	// .xlsm, .gsheet, .xlsx. Other formats will return an unsupported extension
 	// error.
 	GetPreviewContext(ctx context.Context, arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error)
-	// GetTemporaryLinkContext : Get a temporary link to stream content of a file. This
-	// link will expire in four hours and afterwards you will get 410 Gone. This
-	// URL should not be used to display content directly in the browser. The
-	// Content-Type of the link is determined automatically by the file's mime
-	// type.
+	// GetTemporaryLinkContext : Get a temporary link to stream content of a
+	// file. This link will expire in four hours and afterwards you will get 410
+	// Gone. This URL should not be used to display content directly in the
+	// browser. The Content-Type of the link is determined automatically by the
+	// file's mime type.
 	GetTemporaryLinkContext(ctx context.Context, arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error)
-	// GetTemporaryUploadLinkContext : Get a one-time use temporary upload link to
-	// upload a file to a Dropbox location.  This endpoint acts as a delayed
+	// GetTemporaryUploadLinkContext : Get a one-time use temporary upload link
+	// to upload a file to a Dropbox location.  This endpoint acts as a delayed
 	// upload(). The returned temporary upload link may be used to make a POST
 	// request with the data to be uploaded. The upload will then be perfomed
 	// with the CommitInfo previously provided to getTemporaryUploadLink() but
@@ -622,42 +625,42 @@ type ContextClient interface {
 	// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
 	// won't be converted to a thumbnail.
 	GetThumbnailContext(ctx context.Context, arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error)
-	// GetThumbnailV2Context : Get a thumbnail for an image. This method currently
-	// supports files with the following file extensions: jpg, jpeg, png, tiff,
-	// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
-	// won't be converted to a thumbnail.
+	// GetThumbnailV2Context : Get a thumbnail for an image. This method
+	// currently supports files with the following file extensions: jpg, jpeg,
+	// png, tiff, tif, gif, webp, ppm and bmp. Photos that are larger than 20MB
+	// in size won't be converted to a thumbnail.
 	GetThumbnailV2Context(ctx context.Context, arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error)
-	// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow up to
-	// 25 thumbnails in a single batch. This method currently supports files
-	// with the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp,
-	// ppm and bmp. Photos that are larger than 20MB in size won't be converted
-	// to a thumbnail.
+	// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow
+	// up to 25 thumbnails in a single batch. This method currently supports
+	// files with the following file extensions: jpg, jpeg, png, tiff, tif, gif,
+	// webp, ppm and bmp. Photos that are larger than 20MB in size won't be
+	// converted to a thumbnail.
 	GetThumbnailBatchContext(ctx context.Context, arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error)
-	// ListFolderContext : Starts returning the contents of a folder. If the result's
-	// `ListFolderResult.has_more` field is true, call `listFolderContinue` with
-	// the returned ListFolderResult.cursor to retrieve more entries. If you're
-	// using ListFolderArg.recursive set to true to keep a local cache of the
-	// contents of a Dropbox account, iterate through each entry in order and
-	// process them as follows to keep your local state in sync: For each
-	// FileMetadata, store the new entry at the given path in your local state.
-	// If the required parent folders don't exist yet, create them. If there's
-	// already something else at the given path, replace it and remove all its
-	// children. For each FolderMetadata, store the new entry at the given path
-	// in your local state. If the required parent folders don't exist yet,
-	// create them. If there's already something else at the given path, replace
-	// it but leave the children as they are. Check the new entry's
-	// FolderSharingInfo.read_only and set all its children's read-only statuses
-	// to match. For each DeletedMetadata, if your local state has something at
-	// the given path, remove it and all its children. If there's nothing at the
-	// given path, ignore this entry. Note: auth.RateLimitError may be returned
-	// if multiple `listFolder` or `listFolderContinue` calls with same
-	// parameters are made simultaneously by same API app for same user. If your
-	// app implements retry logic, please hold off the retry until the previous
-	// request finishes.
+	// ListFolderContext : Starts returning the contents of a folder. If the
+	// result's `ListFolderResult.has_more` field is true, call
+	// `listFolderContinue` with the returned ListFolderResult.cursor to
+	// retrieve more entries. If you're using ListFolderArg.recursive set to
+	// true to keep a local cache of the contents of a Dropbox account, iterate
+	// through each entry in order and process them as follows to keep your
+	// local state in sync: For each FileMetadata, store the new entry at the
+	// given path in your local state. If the required parent folders don't
+	// exist yet, create them. If there's already something else at the given
+	// path, replace it and remove all its children. For each FolderMetadata,
+	// store the new entry at the given path in your local state. If the
+	// required parent folders don't exist yet, create them. If there's already
+	// something else at the given path, replace it but leave the children as
+	// they are. Check the new entry's FolderSharingInfo.read_only and set all
+	// its children's read-only statuses to match. For each DeletedMetadata, if
+	// your local state has something at the given path, remove it and all its
+	// children. If there's nothing at the given path, ignore this entry. Note:
+	// auth.RateLimitError may be returned if multiple `listFolder` or
+	// `listFolderContinue` calls with same parameters are made simultaneously
+	// by same API app for same user. If your app implements retry logic, please
+	// hold off the retry until the previous request finishes.
 	ListFolderContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderResult, err error)
-	// ListFolderContinueContext : Once a cursor has been retrieved from `listFolder`,
-	// use this to paginate through all files and retrieve updates to the
-	// folder, following the same rules as documented for `listFolder`.
+	// ListFolderContinueContext : Once a cursor has been retrieved from
+	// `listFolder`, use this to paginate through all files and retrieve updates
+	// to the folder, following the same rules as documented for `listFolder`.
 	ListFolderContinueContext(ctx context.Context, arg *ListFolderContinueArg) (res *ListFolderResult, err error)
 	// ListFolderGetLatestCursorContext : A way to quickly get a cursor for the
 	// folder's state. Unlike `listFolder`, `listFolderGetLatestCursor` doesn't
@@ -671,8 +674,8 @@ type ContextClient interface {
 	// will block until there are changes available or a timeout occurs. This
 	// endpoint is useful mostly for client-side apps.
 	ListFolderLongpollContext(ctx context.Context, arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error)
-	// ListRevisionsContext : Returns revisions for files based on a file path or a
-	// file id. The file path or file id is identified from the latest file
+	// ListRevisionsContext : Returns revisions for files based on a file path
+	// or a file id. The file path or file id is identified from the latest file
 	// entry at the given file path or id. This end point allows your app to
 	// query either by file path or file id by setting the mode parameter
 	// appropriately. In the ListRevisionsMode.path (default) mode, all
@@ -681,32 +684,32 @@ type ContextClient interface {
 	// ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
 	// revisions for a given file across moves or renames.
 	ListRevisionsContext(ctx context.Context, arg *ListRevisionsArg) (res *ListRevisionsResult, err error)
-	// LockFileBatchContext : Lock the files at the given paths. A locked file will be
-	// writable only by the lock holder. A successful response indicates that
-	// the file has been locked. Returns a list of the locked file paths and
-	// their metadata after this operation.
+	// LockFileBatchContext : Lock the files at the given paths. A locked file
+	// will be writable only by the lock holder. A successful response indicates
+	// that the file has been locked. Returns a list of the locked file paths
+	// and their metadata after this operation.
 	LockFileBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error)
 	// MoveContext : Move a file or folder to a different location in the user's
 	// Dropbox. If the source path is a folder all its contents will be moved.
 	// Deprecated:
 	MoveContext(ctx context.Context, arg *RelocationArg) (res IsMetadata, err error)
-	// MoveV2Context : Move a file or folder to a different location in the user's
-	// Dropbox. If the source path is a folder all its contents will be moved.
-	// Note that we do not currently support case-only renaming.
+	// MoveV2Context : Move a file or folder to a different location in the
+	// user's Dropbox. If the source path is a folder all its contents will be
+	// moved. Note that we do not currently support case-only renaming.
 	MoveV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error)
-	// MoveBatchContext : Move multiple files or folders to different locations at once
-	// in the user's Dropbox. This route will return job ID immediately and do
-	// the async moving job in background. Please use `moveBatchCheck` to check
-	// the job status.
+	// MoveBatchContext : Move multiple files or folders to different locations
+	// at once in the user's Dropbox. This route will return job ID immediately
+	// and do the async moving job in background. Please use `moveBatchCheck` to
+	// check the job status.
 	// Deprecated:
 	MoveBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error)
-	// MoveBatchV2Context : Move multiple files or folders to different locations at once
-	// in the user's Dropbox. Note that we do not currently support case-only
-	// renaming. This route will replace `moveBatch`. The main difference is
-	// this route will return status for each entry, while `moveBatch` raises
-	// failure if any entry fails. This route will either finish synchronously,
-	// or return a job ID and do the async move job in background. Please use
-	// `moveBatchCheck` to check the job status.
+	// MoveBatchV2Context : Move multiple files or folders to different
+	// locations at once in the user's Dropbox. Note that we do not currently
+	// support case-only renaming. This route will replace `moveBatch`. The main
+	// difference is this route will return status for each entry, while
+	// `moveBatch` raises failure if any entry fails. This route will either
+	// finish synchronously, or return a job ID and do the async move job in
+	// background. Please use `moveBatchCheck` to check the job status.
 	MoveBatchV2Context(ctx context.Context, arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error)
 	// MoveBatchCheckContext : Returns the status of an asynchronous job for
 	// `moveBatch`. If success, it returns list of results for each entry.
@@ -717,27 +720,28 @@ type ContextClient interface {
 	MoveBatchCheckV2Context(ctx context.Context, arg *async.PollArg) (res *RelocationBatchV2JobStatus, err error)
 	// PaperCreateContext : Creates a new Paper doc with the provided content.
 	PaperCreateContext(ctx context.Context, arg *PaperCreateArg, content io.Reader) (res *PaperCreateResult, err error)
-	// PaperUpdateContext : Updates an existing Paper doc with the provided content.
+	// PaperUpdateContext : Updates an existing Paper doc with the provided
+	// content.
 	PaperUpdateContext(ctx context.Context, arg *PaperUpdateArg, content io.Reader) (res *PaperUpdateResult, err error)
-	// PermanentlyDeleteContext : Permanently delete the file or folder at a given path
-	// (see https://www.dropbox.com/en/help/40). If the given file or folder is
-	// not yet deleted, this route will first delete it. It is possible for this
-	// route to successfully delete, then fail to permanently delete. Note: This
-	// endpoint is only available for Dropbox Business apps.
+	// PermanentlyDeleteContext : Permanently delete the file or folder at a
+	// given path (see https://www.dropbox.com/en/help/40). If the given file or
+	// folder is not yet deleted, this route will first delete it. It is
+	// possible for this route to successfully delete, then fail to permanently
+	// delete. Note: This endpoint is only available for Dropbox Business apps.
 	PermanentlyDeleteContext(ctx context.Context, arg *DeleteArg) (err error)
 	// PropertiesAddContext : Add property groups to a Dropbox file. See
 	// templates/add_for_user or templates/add_for_team to create new templates.
 	// Deprecated:
 	PropertiesAddContext(ctx context.Context, arg *file_properties.AddPropertiesArg) (err error)
-	// PropertiesOverwriteContext : Overwrite property groups associated with a file.
-	// This endpoint should be used instead of properties/update when property
-	// groups are being overwritten rather than updated via a "delta".
+	// PropertiesOverwriteContext : Overwrite property groups associated with a
+	// file. This endpoint should be used instead of properties/update when
+	// property groups are being overwritten rather than updated via a "delta".
 	// Deprecated:
 	PropertiesOverwriteContext(ctx context.Context, arg *file_properties.OverwritePropertyGroupArg) (err error)
-	// PropertiesUpdateContext : Add, update or remove properties associated with the
-	// supplied file and templates. This endpoint should be used instead of
-	// properties/overwrite when property groups are being updated via a "delta"
-	// instead of overwriting all properties of a file.
+	// PropertiesUpdateContext : Add, update or remove properties associated
+	// with the supplied file and templates. This endpoint should be used
+	// instead of properties/overwrite when property groups are being updated
+	// via a "delta" instead of overwriting all properties of a file.
 	// Deprecated:
 	PropertiesUpdateContext(ctx context.Context, arg *file_properties.UpdatePropertiesArg) (err error)
 	// RestoreContext : Restore a specific revision of a file to the given path.
@@ -748,23 +752,23 @@ type ContextClient interface {
 	SaveUrlContext(ctx context.Context, arg *SaveUrlArg) (res *SaveUrlResult, err error)
 	// SaveUrlCheckJobStatusContext : Check the status of a `saveUrl` job.
 	SaveUrlCheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *SaveUrlJobStatus, err error)
-	// SearchContext : Searches for files and folders. Note: Recent changes will be
-	// reflected in search results within a few seconds and older revisions of
-	// existing files may still match your query for up to a few days.
+	// SearchContext : Searches for files and folders. Note: Recent changes will
+	// be reflected in search results within a few seconds and older revisions
+	// of existing files may still match your query for up to a few days.
 	// Deprecated:
 	SearchContext(ctx context.Context, arg *SearchArg) (res *SearchResult, err error)
-	// SearchV2Context : Searches for files and folders. Note: `search` along with
-	// `searchContinue` can only be used to retrieve a maximum of 10,000
+	// SearchV2Context : Searches for files and folders. Note: `search` along
+	// with `searchContinue` can only be used to retrieve a maximum of 10,000
 	// matches. Recent changes may not immediately be reflected in search
 	// results due to a short delay in indexing. Duplicate results may be
 	// returned across pages. Some results may not be returned.
 	SearchV2Context(ctx context.Context, arg *SearchV2Arg) (res *SearchV2Result, err error)
-	// SearchContinueV2Context : Fetches the next page of search results returned from
-	// `search`. Note: `search` along with `searchContinue` can only be used to
-	// retrieve a maximum of 10,000 matches. Recent changes may not immediately
-	// be reflected in search results due to a short delay in indexing.
-	// Duplicate results may be returned across pages. Some results may not be
-	// returned.
+	// SearchContinueV2Context : Fetches the next page of search results
+	// returned from `search`. Note: `search` along with `searchContinue` can
+	// only be used to retrieve a maximum of 10,000 matches. Recent changes may
+	// not immediately be reflected in search results due to a short delay in
+	// indexing. Duplicate results may be returned across pages. Some results
+	// may not be returned.
 	SearchContinueV2Context(ctx context.Context, arg *SearchV2ContinueArg) (res *SearchV2Result, err error)
 	// TagsAddContext : Add a tag to an item. A tag is a string. The strings are
 	// automatically converted to lowercase letters. No more than 20 tags can be
@@ -774,41 +778,43 @@ type ContextClient interface {
 	TagsGetContext(ctx context.Context, arg *GetTagsArg) (res *GetTagsResult, err error)
 	// TagsRemoveContext : Remove a tag from an item.
 	TagsRemoveContext(ctx context.Context, arg *RemoveTagArg) (err error)
-	// UnlockFileBatchContext : Unlock the files at the given paths. A locked file can
-	// only be unlocked by the lock holder or, if a business account, a team
-	// admin. A successful response indicates that the file has been unlocked.
-	// Returns a list of the unlocked file paths and their metadata after this
-	// operation.
+	// UnlockFileBatchContext : Unlock the files at the given paths. A locked
+	// file can only be unlocked by the lock holder or, if a business account, a
+	// team admin. A successful response indicates that the file has been
+	// unlocked. Returns a list of the unlocked file paths and their metadata
+	// after this operation.
 	UnlockFileBatchContext(ctx context.Context, arg *UnlockFileBatchArg) (res *LockFileBatchResult, err error)
-	// UploadContext : Create a new file with the contents provided in the request. Do
-	// not use this to upload a file larger than 150 MiB. Instead, create an
-	// upload session with `uploadSessionStart`. Calls to this endpoint will
-	// count as data transport calls for any Dropbox Business teams with a limit
-	// on the number of data transport calls allowed per month. For more
-	// information, see the Data transport limit page
+	// UploadContext : Create a new file with the contents provided in the
+	// request. Do not use this to upload a file larger than 150 MiB. Instead,
+	// create an upload session with `uploadSessionStart`. Calls to this
+	// endpoint will count as data transport calls for any Dropbox Business
+	// teams with a limit on the number of data transport calls allowed per
+	// month. For more information, see the Data transport limit page
 	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error)
-	// UploadSessionAppendContext : Append more data to an upload session. A single
-	// request should not upload more than 150 MiB. The maximum size of a file
-	// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
-	// bytes. Calls to this endpoint will count as data transport calls for any
-	// Dropbox Business teams with a limit on the number of data transport calls
-	// allowed per month. For more information, see the Data transport limit
-	// page https://www.dropbox.com/developers/reference/data-transport-limit.
+	// UploadSessionAppendContext : Append more data to an upload session. A
+	// single request should not upload more than 150 MiB. The maximum size of a
+	// file one can upload to an upload session is 2^41 - 2^22
+	// (2,199,019,061,248) bytes. Calls to this endpoint will count as data
+	// transport calls for any Dropbox Business teams with a limit on the number
+	// of data transport calls allowed per month. For more information, see the
+	// Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	// Deprecated:
 	UploadSessionAppendContext(ctx context.Context, arg *UploadSessionCursor, content io.Reader) (err error)
-	// UploadSessionAppendV2Context : Append more data to an upload session. When the
-	// parameter close is set, this call will close the session. A single
-	// request should not upload more than 150 MiB. The maximum size of a file
-	// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
-	// bytes. Calls to this endpoint will count as data transport calls for any
-	// Dropbox Business teams with a limit on the number of data transport calls
-	// allowed per month. For more information, see the Data transport limit
-	// page https://www.dropbox.com/developers/reference/data-transport-limit.
+	// UploadSessionAppendV2Context : Append more data to an upload session.
+	// When the parameter close is set, this call will close the session. A
+	// single request should not upload more than 150 MiB. The maximum size of a
+	// file one can upload to an upload session is 2^41 - 2^22
+	// (2,199,019,061,248) bytes. Calls to this endpoint will count as data
+	// transport calls for any Dropbox Business teams with a limit on the number
+	// of data transport calls allowed per month. For more information, see the
+	// Data transport limit page
+	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	UploadSessionAppendV2Context(ctx context.Context, arg *UploadSessionAppendArg, content io.Reader) (err error)
-	// UploadSessionAppendBatchContext : Append more data to multiple upload sessions.
-	// Each piece of file content to append to each upload session should be
-	// concatenated in the request body, in the order delineated by
+	// UploadSessionAppendBatchContext : Append more data to multiple upload
+	// sessions. Each piece of file content to append to each upload session
+	// should be concatenated in the request body, in the order delineated by
 	// `UploadSessionAppendBatchArg.entries` and their individual lengths
 	// indicated by `UploadSessionAppendBatchArgEntry.length`. A single request
 	// should not upload more than 150 MiB. The maximum size of a file one can
@@ -818,26 +824,26 @@ type ContextClient interface {
 	// per month. For more information, see the Data transport limit page
 	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	UploadSessionAppendBatchContext(ctx context.Context, arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error)
-	// UploadSessionFinishContext : Finish an upload session and save the uploaded data
-	// to the given file path. A single request should not upload more than 150
-	// MiB. The maximum size of a file one can upload to an upload session is
-	// 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count
-	// as data transport calls for any Dropbox Business teams with a limit on
-	// the number of data transport calls allowed per month. For more
+	// UploadSessionFinishContext : Finish an upload session and save the
+	// uploaded data to the given file path. A single request should not upload
+	// more than 150 MiB. The maximum size of a file one can upload to an upload
+	// session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint
+	// will count as data transport calls for any Dropbox Business teams with a
+	// limit on the number of data transport calls allowed per month. For more
 	// information, see the Data transport limit page
 	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	UploadSessionFinishContext(ctx context.Context, arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error)
-	// UploadSessionFinishBatchContext : This route helps you commit many files at once
-	// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
-	// to upload file contents. We recommend uploading many files in parallel to
-	// increase throughput. Once the file contents have been uploaded, rather
-	// than calling `uploadSessionFinish`, use this route to finish all your
-	// upload sessions in a single request. `UploadSessionStartArg.close` or
-	// `UploadSessionAppendArg.close` needs to be true for the last
-	// `uploadSessionStart` or `uploadSessionAppend` call. The maximum size of a
-	// file one can upload to an upload session is 2^41 - 2^22
-	// (2,199,019,061,248) bytes. This route will return a job_id immediately
-	// and do the async commit job in background. Use
+	// UploadSessionFinishBatchContext : This route helps you commit many files
+	// at once into a user's Dropbox. Use `uploadSessionStart` and
+	// `uploadSessionAppend` to upload file contents. We recommend uploading
+	// many files in parallel to increase throughput. Once the file contents
+	// have been uploaded, rather than calling `uploadSessionFinish`, use this
+	// route to finish all your upload sessions in a single request.
+	// `UploadSessionStartArg.close` or `UploadSessionAppendArg.close` needs to
+	// be true for the last `uploadSessionStart` or `uploadSessionAppend` call.
+	// The maximum size of a file one can upload to an upload session is 2^41 -
+	// 2^22 (2,199,019,061,248) bytes. This route will return a job_id
+	// immediately and do the async commit job in background. Use
 	// `uploadSessionFinishBatchCheck` to check the job status. For the same
 	// account, this route should be executed serially. That means you should
 	// not start the next job before current job finishes. We allow up to 1000
@@ -848,41 +854,41 @@ type ContextClient interface {
 	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	// Deprecated:
 	UploadSessionFinishBatchContext(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error)
-	// UploadSessionFinishBatchV2Context : This route helps you commit many files at once
-	// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
-	// to upload file contents. We recommend uploading many files in parallel to
-	// increase throughput. Once the file contents have been uploaded, rather
-	// than calling `uploadSessionFinish`, use this route to finish all your
-	// upload sessions in a single request. `UploadSessionStartArg.close` or
-	// `UploadSessionAppendArg.close` needs to be true for the last
-	// `uploadSessionStart` or `uploadSessionAppend` call of each upload
-	// session. The maximum size of a file one can upload to an upload session
-	// is 2^41 - 2^22 (2,199,019,061,248) bytes. We allow up to 1000 entries in
-	// a single request. Calls to this endpoint will count as data transport
-	// calls for any Dropbox Business teams with a limit on the number of data
-	// transport calls allowed per month. For more information, see the Data
-	// transport limit page
+	// UploadSessionFinishBatchV2Context : This route helps you commit many
+	// files at once into a user's Dropbox. Use `uploadSessionStart` and
+	// `uploadSessionAppend` to upload file contents. We recommend uploading
+	// many files in parallel to increase throughput. Once the file contents
+	// have been uploaded, rather than calling `uploadSessionFinish`, use this
+	// route to finish all your upload sessions in a single request.
+	// `UploadSessionStartArg.close` or `UploadSessionAppendArg.close` needs to
+	// be true for the last `uploadSessionStart` or `uploadSessionAppend` call
+	// of each upload session. The maximum size of a file one can upload to an
+	// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. We allow up to
+	// 1000 entries in a single request. Calls to this endpoint will count as
+	// data transport calls for any Dropbox Business teams with a limit on the
+	// number of data transport calls allowed per month. For more information,
+	// see the Data transport limit page
 	// https://www.dropbox.com/developers/reference/data-transport-limit.
 	UploadSessionFinishBatchV2Context(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error)
-	// UploadSessionFinishBatchCheckContext : Returns the status of an asynchronous job
-	// for `uploadSessionFinishBatch`. If success, it returns list of result for
-	// each entry.
+	// UploadSessionFinishBatchCheckContext : Returns the status of an
+	// asynchronous job for `uploadSessionFinishBatch`. If success, it returns
+	// list of result for each entry.
 	UploadSessionFinishBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error)
-	// UploadSessionStartContext : Upload sessions allow you to upload a single file in
-	// one or more requests, for example where the size of the file is greater
-	// than 150 MiB. This call starts a new upload session with the given data.
-	// You can then use `uploadSessionAppend` or `uploadSessionAppendBatch` to
-	// add more data, then `uploadSessionFinish` or `uploadSessionFinishBatch`
-	// to save all the data to a file in Dropbox. A single request should not
-	// upload more than 150 MiB. The maximum size of a file one can upload to an
-	// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. An upload
-	// session can be used for a maximum of 7 days. Attempting to use a
-	// `UploadSessionStartResult.session_id` with `uploadSessionAppend` or other
-	// upload session routes more than 7 days after its creation will return
-	// `UploadSessionLookupError.not_found`. Calls to this endpoint will count
-	// as data transport calls for any Dropbox Business teams with a limit on
-	// the number of data transport calls allowed per month. For more
-	// information, see the Data transport limit page
+	// UploadSessionStartContext : Upload sessions allow you to upload a single
+	// file in one or more requests, for example where the size of the file is
+	// greater than 150 MiB. This call starts a new upload session with the
+	// given data. You can then use `uploadSessionAppend` or
+	// `uploadSessionAppendBatch` to add more data, then `uploadSessionFinish`
+	// or `uploadSessionFinishBatch` to save all the data to a file in Dropbox.
+	// A single request should not upload more than 150 MiB. The maximum size of
+	// a file one can upload to an upload session is 2^41 - 2^22
+	// (2,199,019,061,248) bytes. An upload session can be used for a maximum of
+	// 7 days. Attempting to use a `UploadSessionStartResult.session_id` with
+	// `uploadSessionAppend` or other upload session routes more than 7 days
+	// after its creation will return `UploadSessionLookupError.not_found`.
+	// Calls to this endpoint will count as data transport calls for any Dropbox
+	// Business teams with a limit on the number of data transport calls allowed
+	// per month. For more information, see the Data transport limit page
 	// https://www.dropbox.com/developers/reference/data-transport-limit. By
 	// default, upload sessions require you to send content of the file in
 	// sequential order via consecutive `uploadSessionStart`,
@@ -918,8 +924,8 @@ type AlphaGetMetadataAPIError struct {
 	EndpointError *AlphaGetMetadataError `json:"error"`
 }
 
-// AlphaGetMetadataContext : Returns the metadata for a file or folder. This is an
-// alpha endpoint compatible with the properties API. Note: Metadata for the
+// AlphaGetMetadataContext : Returns the metadata for a file or folder. This is
+// an alpha endpoint compatible with the properties API. Note: Metadata for the
 // root folder is unsupported.
 // Deprecated:
 func (dbx *apiImpl) AlphaGetMetadataContext(ctx context.Context, arg *AlphaGetMetadataArg) (res IsMetadata, err error) {
@@ -1133,10 +1139,10 @@ type CopyBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// CopyBatchContext : Copy multiple files or folders to different locations at once
-// in the user's Dropbox. This route will return job ID immediately and do
-// the async copy job in background. Please use `copyBatchCheck` to check
-// the job status.
+// CopyBatchContext : Copy multiple files or folders to different locations at
+// once in the user's Dropbox. This route will return job ID immediately and do
+// the async copy job in background. Please use `copyBatchCheck` to check the
+// job status.
 // Deprecated:
 func (dbx *apiImpl) CopyBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	log.Printf("WARNING: API `CopyBatch` is deprecated")
@@ -1182,12 +1188,12 @@ type CopyBatchV2APIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// CopyBatchV2Context : Copy multiple files or folders to different locations at once
-// in the user's Dropbox. This route will replace `copyBatch`. The main
-// difference is this route will return status for each entry, while
-// `copyBatch` raises failure if any entry fails. This route will either
-// finish synchronously, or return a job ID and do the async copy job in
-// background. Please use `copyBatchCheck` to check the job status.
+// CopyBatchV2Context : Copy multiple files or folders to different locations at
+// once in the user's Dropbox. This route will replace `copyBatch`. The main
+// difference is this route will return status for each entry, while `copyBatch`
+// raises failure if any entry fails. This route will either finish
+// synchronously, or return a job ID and do the async copy job in background.
+// Please use `copyBatchCheck` to check the job status.
 func (dbx *apiImpl) CopyBatchV2Context(ctx context.Context, arg *RelocationBatchArgBase) (res *RelocationBatchV2Launch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1322,8 +1328,8 @@ type CopyReferenceGetAPIError struct {
 }
 
 // CopyReferenceGetContext : Get a copy reference to a file or folder. This
-// reference string can be used to save that file or folder to another
-// user's Dropbox by passing it to `copyReferenceSave`.
+// reference string can be used to save that file or folder to another user's
+// Dropbox by passing it to `copyReferenceSave`.
 func (dbx *apiImpl) CopyReferenceGetContext(ctx context.Context, arg *GetCopyReferenceArg) (res *GetCopyReferenceResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1366,8 +1372,8 @@ type CopyReferenceSaveAPIError struct {
 	EndpointError *SaveCopyReferenceError `json:"error"`
 }
 
-// CopyReferenceSaveContext : Save a copy reference returned by `copyReferenceGet`
-// to the user's Dropbox.
+// CopyReferenceSaveContext : Save a copy reference returned by
+// `copyReferenceGet` to the user's Dropbox.
 func (dbx *apiImpl) CopyReferenceSaveContext(ctx context.Context, arg *SaveCopyReferenceArg) (res *SaveCopyReferenceResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1500,12 +1506,11 @@ type CreateFolderBatchAPIError struct {
 }
 
 // CreateFolderBatchContext : Create multiple folders at once. This route is
-// asynchronous for large batches, which returns a job ID immediately and
-// runs the create folder batch asynchronously. Otherwise, creates the
-// folders and returns the result synchronously for smaller inputs. You can
-// force asynchronous behaviour by using the
-// CreateFolderBatchArg.force_async flag.  Use `createFolderBatchCheck` to
-// check the job status.
+// asynchronous for large batches, which returns a job ID immediately and runs
+// the create folder batch asynchronously. Otherwise, creates the folders and
+// returns the result synchronously for smaller inputs. You can force
+// asynchronous behaviour by using the CreateFolderBatchArg.force_async flag.
+// Use `createFolderBatchCheck` to check the job status.
 func (dbx *apiImpl) CreateFolderBatchContext(ctx context.Context, arg *CreateFolderBatchArg) (res *CreateFolderBatchLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1549,8 +1554,7 @@ type CreateFolderBatchCheckAPIError struct {
 }
 
 // CreateFolderBatchCheckContext : Returns the status of an asynchronous job for
-// `createFolderBatch`. If success, it returns list of result for each
-// entry.
+// `createFolderBatch`. If success, it returns list of result for each entry.
 func (dbx *apiImpl) CreateFolderBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *CreateFolderBatchJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1594,10 +1598,10 @@ type DeleteAPIError struct {
 }
 
 // DeleteContext : Delete the file or folder at a given path. If the path is a
-// folder, all its contents will be deleted too. A successful response
-// indicates that the file or folder was deleted. The returned metadata will
-// be the corresponding FileMetadata or FolderMetadata for the item at time
-// of deletion, and not a DeletedMetadata object.
+// folder, all its contents will be deleted too. A successful response indicates
+// that the file or folder was deleted. The returned metadata will be the
+// corresponding FileMetadata or FolderMetadata for the item at time of
+// deletion, and not a DeletedMetadata object.
 // Deprecated:
 func (dbx *apiImpl) DeleteContext(ctx context.Context, arg *DeleteArg) (res IsMetadata, err error) {
 	log.Printf("WARNING: API `Delete` is deprecated")
@@ -1655,10 +1659,10 @@ type DeleteV2APIError struct {
 }
 
 // DeleteV2Context : Delete the file or folder at a given path. If the path is a
-// folder, all its contents will be deleted too. A successful response
-// indicates that the file or folder was deleted. The returned metadata will
-// be the corresponding FileMetadata or FolderMetadata for the item at time
-// of deletion, and not a DeletedMetadata object.
+// folder, all its contents will be deleted too. A successful response indicates
+// that the file or folder was deleted. The returned metadata will be the
+// corresponding FileMetadata or FolderMetadata for the item at time of
+// deletion, and not a DeletedMetadata object.
 func (dbx *apiImpl) DeleteV2Context(ctx context.Context, arg *DeleteArg) (res *DeleteResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1702,8 +1706,8 @@ type DeleteBatchAPIError struct {
 }
 
 // DeleteBatchContext : Delete multiple files/folders at once. This route is
-// asynchronous, which returns a job ID immediately and runs the delete
-// batch asynchronously. Use `deleteBatchCheck` to check the job status.
+// asynchronous, which returns a job ID immediately and runs the delete batch
+// asynchronously. Use `deleteBatchCheck` to check the job status.
 func (dbx *apiImpl) DeleteBatchContext(ctx context.Context, arg *DeleteBatchArg) (res *DeleteBatchLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1833,12 +1837,12 @@ type DownloadZipAPIError struct {
 	EndpointError *DownloadZipError `json:"error"`
 }
 
-// DownloadZipContext : Download a folder from the user's Dropbox, as a zip file.
-// The folder must be less than 20 GB in size and any single file within
-// must be less than 4 GB in size. The resulting zip must have fewer than
-// 10,000 total file and folder entries, including the top level folder. The
-// input cannot be a single file. Note: this endpoint does not support HTTP
-// range requests.
+// DownloadZipContext : Download a folder from the user's Dropbox, as a zip
+// file. The folder must be less than 20 GB in size and any single file within
+// must be less than 4 GB in size. The resulting zip must have fewer than 10,000
+// total file and folder entries, including the top level folder. The input
+// cannot be a single file. Note: this endpoint does not support HTTP range
+// requests.
 func (dbx *apiImpl) DownloadZipContext(ctx context.Context, arg *DownloadZipArg) (res *DownloadZipResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
@@ -1926,7 +1930,8 @@ type GetFileLockBatchAPIError struct {
 	EndpointError *LockFileError `json:"error"`
 }
 
-// GetFileLockBatchContext : Return the lock metadata for the given list of paths.
+// GetFileLockBatchContext : Return the lock metadata for the given list of
+// paths.
 func (dbx *apiImpl) GetFileLockBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1969,8 +1974,8 @@ type GetMetadataAPIError struct {
 	EndpointError *GetMetadataError `json:"error"`
 }
 
-// GetMetadataContext : Returns the metadata for a file or folder. Note: Metadata
-// for the root folder is unsupported.
+// GetMetadataContext : Returns the metadata for a file or folder. Note:
+// Metadata for the root folder is unsupported.
 func (dbx *apiImpl) GetMetadataContext(ctx context.Context, arg *GetMetadataArg) (res IsMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2025,11 +2030,10 @@ type GetPreviewAPIError struct {
 }
 
 // GetPreviewContext : Get a preview for a file. Currently, PDF previews are
-// generated for files with the following extensions: .ai, .doc, .docm,
-// .docx, .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx, .ppt,
-// .pptm, .pptx, .rtf. HTML previews are generated for .csv, .ods, .xls,
-// .xlsm, .gsheet, .xlsx. Other formats will return an unsupported extension
-// error.
+// generated for files with the following extensions: .ai, .doc, .docm, .docx,
+// .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx, .ppt, .pptm, .pptx,
+// .rtf. HTML previews are generated for .csv, .ods, .xls, .xlsm, .gsheet,
+// .xlsx. Other formats will return an unsupported extension error.
 func (dbx *apiImpl) GetPreviewContext(ctx context.Context, arg *PreviewArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
@@ -2072,11 +2076,10 @@ type GetTemporaryLinkAPIError struct {
 	EndpointError *GetTemporaryLinkError `json:"error"`
 }
 
-// GetTemporaryLinkContext : Get a temporary link to stream content of a file. This
-// link will expire in four hours and afterwards you will get 410 Gone. This
-// URL should not be used to display content directly in the browser. The
-// Content-Type of the link is determined automatically by the file's mime
-// type.
+// GetTemporaryLinkContext : Get a temporary link to stream content of a file.
+// This link will expire in four hours and afterwards you will get 410 Gone.
+// This URL should not be used to display content directly in the browser. The
+// Content-Type of the link is determined automatically by the file's mime type.
 func (dbx *apiImpl) GetTemporaryLinkContext(ctx context.Context, arg *GetTemporaryLinkArg) (res *GetTemporaryLinkResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2122,32 +2125,30 @@ type GetTemporaryUploadLinkAPIError struct {
 // GetTemporaryUploadLinkContext : Get a one-time use temporary upload link to
 // upload a file to a Dropbox location.  This endpoint acts as a delayed
 // upload(). The returned temporary upload link may be used to make a POST
-// request with the data to be uploaded. The upload will then be perfomed
-// with the CommitInfo previously provided to getTemporaryUploadLink() but
-// evaluated only upon consumption. Hence, errors stemming from invalid
-// CommitInfo with respect to the state of the user's Dropbox will only be
-// communicated at consumption time. Additionally, these errors are surfaced
-// as generic HTTP 409 Conflict responses, potentially hiding issue details.
-// The maximum temporary upload link duration is 4 hours. Upon consumption
-// or expiration, a new link will have to be generated. Multiple links may
-// exist for a specific upload path at any given time.  The POST request on
-// the temporary upload link must have its Content-Type set to
-// "application/octet-stream".  Example temporary upload link consumption
-// request:  curl -X POST
+// request with the data to be uploaded. The upload will then be perfomed with
+// the CommitInfo previously provided to getTemporaryUploadLink() but evaluated
+// only upon consumption. Hence, errors stemming from invalid CommitInfo with
+// respect to the state of the user's Dropbox will only be communicated at
+// consumption time. Additionally, these errors are surfaced as generic HTTP 409
+// Conflict responses, potentially hiding issue details. The maximum temporary
+// upload link duration is 4 hours. Upon consumption or expiration, a new link
+// will have to be generated. Multiple links may exist for a specific upload
+// path at any given time.  The POST request on the temporary upload link must
+// have its Content-Type set to "application/octet-stream".  Example temporary
+// upload link consumption request:  curl -X POST
 // https://content.dropboxapi.com/apitul/1/bNi2uIYF51cVBND --header
 // "Content-Type: application/octet-stream" --data-binary @local_file.txt  A
-// successful temporary upload link consumption request returns the content
-// hash of the uploaded data in JSON format. Example successful temporary
-// upload link consumption response: {"content-hash":
-// "599d71033d700ac892a0e48fa61b125d2f5994"}  An unsuccessful temporary
-// upload link consumption request returns any of the following status
-// codes:  HTTP 400 Bad Request: Content-Type is not one of
-// application/octet-stream and text/plain or request is invalid. HTTP 409
-// Conflict: The temporary upload link does not exist or is currently
-// unavailable, the upload failed, or another error happened. HTTP 410 Gone:
-// The temporary upload link is expired or consumed. Example unsuccessful
-// temporary upload link consumption response: Temporary upload link has
-// been recently consumed.
+// successful temporary upload link consumption request returns the content hash
+// of the uploaded data in JSON format. Example successful temporary upload link
+// consumption response: {"content-hash":
+// "599d71033d700ac892a0e48fa61b125d2f5994"}  An unsuccessful temporary upload
+// link consumption request returns any of the following status codes:  HTTP 400
+// Bad Request: Content-Type is not one of application/octet-stream and
+// text/plain or request is invalid. HTTP 409 Conflict: The temporary upload
+// link does not exist or is currently unavailable, the upload failed, or
+// another error happened. HTTP 410 Gone: The temporary upload link is expired
+// or consumed. Example unsuccessful temporary upload link consumption response:
+// Temporary upload link has been recently consumed.
 func (dbx *apiImpl) GetTemporaryUploadLinkContext(ctx context.Context, arg *GetTemporaryUploadLinkArg) (res *GetTemporaryUploadLinkResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2191,9 +2192,9 @@ type GetThumbnailAPIError struct {
 }
 
 // GetThumbnailContext : Get a thumbnail for an image. This method currently
-// supports files with the following file extensions: jpg, jpeg, png, tiff,
-// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
-// won't be converted to a thumbnail.
+// supports files with the following file extensions: jpg, jpeg, png, tiff, tif,
+// gif, webp, ppm and bmp. Photos that are larger than 20MB in size won't be
+// converted to a thumbnail.
 func (dbx *apiImpl) GetThumbnailContext(ctx context.Context, arg *ThumbnailArg) (res *FileMetadata, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
@@ -2237,9 +2238,9 @@ type GetThumbnailV2APIError struct {
 }
 
 // GetThumbnailV2Context : Get a thumbnail for an image. This method currently
-// supports files with the following file extensions: jpg, jpeg, png, tiff,
-// tif, gif, webp, ppm and bmp. Photos that are larger than 20MB in size
-// won't be converted to a thumbnail.
+// supports files with the following file extensions: jpg, jpeg, png, tiff, tif,
+// gif, webp, ppm and bmp. Photos that are larger than 20MB in size won't be
+// converted to a thumbnail.
 func (dbx *apiImpl) GetThumbnailV2Context(ctx context.Context, arg *ThumbnailV2Arg) (res *PreviewResult, content io.ReadCloser, err error) {
 	req := dropbox.Request{
 		Host:         "content",
@@ -2282,11 +2283,11 @@ type GetThumbnailBatchAPIError struct {
 	EndpointError *GetThumbnailBatchError `json:"error"`
 }
 
-// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow up to
-// 25 thumbnails in a single batch. This method currently supports files
-// with the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp,
-// ppm and bmp. Photos that are larger than 20MB in size won't be converted
-// to a thumbnail.
+// GetThumbnailBatchContext : Get thumbnails for a list of images. We allow up
+// to 25 thumbnails in a single batch. This method currently supports files with
+// the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and
+// bmp. Photos that are larger than 20MB in size won't be converted to a
+// thumbnail.
 func (dbx *apiImpl) GetThumbnailBatchContext(ctx context.Context, arg *GetThumbnailBatchArg) (res *GetThumbnailBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "content",
@@ -2329,27 +2330,26 @@ type ListFolderAPIError struct {
 	EndpointError *ListFolderError `json:"error"`
 }
 
-// ListFolderContext : Starts returning the contents of a folder. If the result's
-// `ListFolderResult.has_more` field is true, call `listFolderContinue` with
-// the returned ListFolderResult.cursor to retrieve more entries. If you're
+// ListFolderContext : Starts returning the contents of a folder. If the
+// result's `ListFolderResult.has_more` field is true, call `listFolderContinue`
+// with the returned ListFolderResult.cursor to retrieve more entries. If you're
 // using ListFolderArg.recursive set to true to keep a local cache of the
 // contents of a Dropbox account, iterate through each entry in order and
 // process them as follows to keep your local state in sync: For each
-// FileMetadata, store the new entry at the given path in your local state.
-// If the required parent folders don't exist yet, create them. If there's
-// already something else at the given path, replace it and remove all its
-// children. For each FolderMetadata, store the new entry at the given path
-// in your local state. If the required parent folders don't exist yet,
-// create them. If there's already something else at the given path, replace
-// it but leave the children as they are. Check the new entry's
-// FolderSharingInfo.read_only and set all its children's read-only statuses
-// to match. For each DeletedMetadata, if your local state has something at
-// the given path, remove it and all its children. If there's nothing at the
-// given path, ignore this entry. Note: auth.RateLimitError may be returned
-// if multiple `listFolder` or `listFolderContinue` calls with same
-// parameters are made simultaneously by same API app for same user. If your
-// app implements retry logic, please hold off the retry until the previous
-// request finishes.
+// FileMetadata, store the new entry at the given path in your local state. If
+// the required parent folders don't exist yet, create them. If there's already
+// something else at the given path, replace it and remove all its children. For
+// each FolderMetadata, store the new entry at the given path in your local
+// state. If the required parent folders don't exist yet, create them. If
+// there's already something else at the given path, replace it but leave the
+// children as they are. Check the new entry's FolderSharingInfo.read_only and
+// set all its children's read-only statuses to match. For each DeletedMetadata,
+// if your local state has something at the given path, remove it and all its
+// children. If there's nothing at the given path, ignore this entry. Note:
+// auth.RateLimitError may be returned if multiple `listFolder` or
+// `listFolderContinue` calls with same parameters are made simultaneously by
+// same API app for same user. If your app implements retry logic, please hold
+// off the retry until the previous request finishes.
 func (dbx *apiImpl) ListFolderContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2392,9 +2392,9 @@ type ListFolderContinueAPIError struct {
 	EndpointError *ListFolderContinueError `json:"error"`
 }
 
-// ListFolderContinueContext : Once a cursor has been retrieved from `listFolder`,
-// use this to paginate through all files and retrieve updates to the
-// folder, following the same rules as documented for `listFolder`.
+// ListFolderContinueContext : Once a cursor has been retrieved from
+// `listFolder`, use this to paginate through all files and retrieve updates to
+// the folder, following the same rules as documented for `listFolder`.
 func (dbx *apiImpl) ListFolderContinueContext(ctx context.Context, arg *ListFolderContinueArg) (res *ListFolderResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2439,9 +2439,9 @@ type ListFolderGetLatestCursorAPIError struct {
 
 // ListFolderGetLatestCursorContext : A way to quickly get a cursor for the
 // folder's state. Unlike `listFolder`, `listFolderGetLatestCursor` doesn't
-// return any entries. This endpoint is for app which only needs to know
-// about new files and modifications and doesn't need to know about files
-// that already exist in Dropbox.
+// return any entries. This endpoint is for app which only needs to know about
+// new files and modifications and doesn't need to know about files that already
+// exist in Dropbox.
 func (dbx *apiImpl) ListFolderGetLatestCursorContext(ctx context.Context, arg *ListFolderArg) (res *ListFolderGetLatestCursorResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2486,9 +2486,9 @@ type ListFolderLongpollAPIError struct {
 
 // ListFolderLongpollContext : A longpoll endpoint to wait for changes on an
 // account. In conjunction with `listFolderContinue`, this call gives you a
-// low-latency way to monitor an account for file changes. The connection
-// will block until there are changes available or a timeout occurs. This
-// endpoint is useful mostly for client-side apps.
+// low-latency way to monitor an account for file changes. The connection will
+// block until there are changes available or a timeout occurs. This endpoint is
+// useful mostly for client-side apps.
 func (dbx *apiImpl) ListFolderLongpollContext(ctx context.Context, arg *ListFolderLongpollArg) (res *ListFolderLongpollResult, err error) {
 	req := dropbox.Request{
 		Host:         "notify",
@@ -2532,14 +2532,14 @@ type ListRevisionsAPIError struct {
 }
 
 // ListRevisionsContext : Returns revisions for files based on a file path or a
-// file id. The file path or file id is identified from the latest file
-// entry at the given file path or id. This end point allows your app to
-// query either by file path or file id by setting the mode parameter
-// appropriately. In the ListRevisionsMode.path (default) mode, all
-// revisions at the same file path as the latest file entry are returned. If
-// revisions with the same file id are desired, then mode must be set to
-// ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
-// revisions for a given file across moves or renames.
+// file id. The file path or file id is identified from the latest file entry at
+// the given file path or id. This end point allows your app to query either by
+// file path or file id by setting the mode parameter appropriately. In the
+// ListRevisionsMode.path (default) mode, all revisions at the same file path as
+// the latest file entry are returned. If revisions with the same file id are
+// desired, then mode must be set to ListRevisionsMode.id. The
+// ListRevisionsMode.id mode is useful to retrieve revisions for a given file
+// across moves or renames.
 func (dbx *apiImpl) ListRevisionsContext(ctx context.Context, arg *ListRevisionsArg) (res *ListRevisionsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2582,10 +2582,10 @@ type LockFileBatchAPIError struct {
 	EndpointError *LockFileError `json:"error"`
 }
 
-// LockFileBatchContext : Lock the files at the given paths. A locked file will be
-// writable only by the lock holder. A successful response indicates that
-// the file has been locked. Returns a list of the locked file paths and
-// their metadata after this operation.
+// LockFileBatchContext : Lock the files at the given paths. A locked file will
+// be writable only by the lock holder. A successful response indicates that the
+// file has been locked. Returns a list of the locked file paths and their
+// metadata after this operation.
 func (dbx *apiImpl) LockFileBatchContext(ctx context.Context, arg *LockFileBatchArg) (res *LockFileBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2687,8 +2687,8 @@ type MoveV2APIError struct {
 }
 
 // MoveV2Context : Move a file or folder to a different location in the user's
-// Dropbox. If the source path is a folder all its contents will be moved.
-// Note that we do not currently support case-only renaming.
+// Dropbox. If the source path is a folder all its contents will be moved. Note
+// that we do not currently support case-only renaming.
 func (dbx *apiImpl) MoveV2Context(ctx context.Context, arg *RelocationArg) (res *RelocationResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2731,10 +2731,10 @@ type MoveBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// MoveBatchContext : Move multiple files or folders to different locations at once
-// in the user's Dropbox. This route will return job ID immediately and do
-// the async moving job in background. Please use `moveBatchCheck` to check
-// the job status.
+// MoveBatchContext : Move multiple files or folders to different locations at
+// once in the user's Dropbox. This route will return job ID immediately and do
+// the async moving job in background. Please use `moveBatchCheck` to check the
+// job status.
 // Deprecated:
 func (dbx *apiImpl) MoveBatchContext(ctx context.Context, arg *RelocationBatchArg) (res *RelocationBatchLaunch, err error) {
 	log.Printf("WARNING: API `MoveBatch` is deprecated")
@@ -2780,13 +2780,13 @@ type MoveBatchV2APIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// MoveBatchV2Context : Move multiple files or folders to different locations at once
-// in the user's Dropbox. Note that we do not currently support case-only
-// renaming. This route will replace `moveBatch`. The main difference is
-// this route will return status for each entry, while `moveBatch` raises
-// failure if any entry fails. This route will either finish synchronously,
-// or return a job ID and do the async move job in background. Please use
-// `moveBatchCheck` to check the job status.
+// MoveBatchV2Context : Move multiple files or folders to different locations at
+// once in the user's Dropbox. Note that we do not currently support case-only
+// renaming. This route will replace `moveBatch`. The main difference is this
+// route will return status for each entry, while `moveBatch` raises failure if
+// any entry fails. This route will either finish synchronously, or return a job
+// ID and do the async move job in background. Please use `moveBatchCheck` to
+// check the job status.
 func (dbx *apiImpl) MoveBatchV2Context(ctx context.Context, arg *MoveBatchArg) (res *RelocationBatchV2Launch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3006,8 +3006,8 @@ type PermanentlyDeleteAPIError struct {
 	EndpointError *DeleteError `json:"error"`
 }
 
-// PermanentlyDeleteContext : Permanently delete the file or folder at a given path
-// (see https://www.dropbox.com/en/help/40). If the given file or folder is
+// PermanentlyDeleteContext : Permanently delete the file or folder at a given
+// path (see https://www.dropbox.com/en/help/40). If the given file or folder is
 // not yet deleted, this route will first delete it. It is possible for this
 // route to successfully delete, then fail to permanently delete. Note: This
 // endpoint is only available for Dropbox Business apps.
@@ -3092,8 +3092,8 @@ type PropertiesOverwriteAPIError struct {
 	EndpointError *file_properties.InvalidPropertyGroupError `json:"error"`
 }
 
-// PropertiesOverwriteContext : Overwrite property groups associated with a file.
-// This endpoint should be used instead of properties/update when property
+// PropertiesOverwriteContext : Overwrite property groups associated with a
+// file. This endpoint should be used instead of properties/update when property
 // groups are being overwritten rather than updated via a "delta".
 // Deprecated:
 func (dbx *apiImpl) PropertiesOverwriteContext(ctx context.Context, arg *file_properties.OverwritePropertyGroupArg) (err error) {
@@ -3136,8 +3136,8 @@ type PropertiesUpdateAPIError struct {
 	EndpointError *file_properties.UpdatePropertiesError `json:"error"`
 }
 
-// PropertiesUpdateContext : Add, update or remove properties associated with the
-// supplied file and templates. This endpoint should be used instead of
+// PropertiesUpdateContext : Add, update or remove properties associated with
+// the supplied file and templates. This endpoint should be used instead of
 // properties/overwrite when property groups are being updated via a "delta"
 // instead of overwriting all properties of a file.
 // Deprecated:
@@ -3225,8 +3225,8 @@ type SaveUrlAPIError struct {
 }
 
 // SaveUrlContext : Save the data from a specified URL into a file in user's
-// Dropbox. Note that the transfer from the URL must complete within 15
-// minutes, or the operation will time out and the job will fail.
+// Dropbox. Note that the transfer from the URL must complete within 15 minutes,
+// or the operation will time out and the job will fail.
 func (dbx *apiImpl) SaveUrlContext(ctx context.Context, arg *SaveUrlArg) (res *SaveUrlResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3361,10 +3361,10 @@ type SearchV2APIError struct {
 }
 
 // SearchV2Context : Searches for files and folders. Note: `search` along with
-// `searchContinue` can only be used to retrieve a maximum of 10,000
-// matches. Recent changes may not immediately be reflected in search
-// results due to a short delay in indexing. Duplicate results may be
-// returned across pages. Some results may not be returned.
+// `searchContinue` can only be used to retrieve a maximum of 10,000 matches.
+// Recent changes may not immediately be reflected in search results due to a
+// short delay in indexing. Duplicate results may be returned across pages. Some
+// results may not be returned.
 func (dbx *apiImpl) SearchV2Context(ctx context.Context, arg *SearchV2Arg) (res *SearchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3407,12 +3407,11 @@ type SearchContinueV2APIError struct {
 	EndpointError *SearchError `json:"error"`
 }
 
-// SearchContinueV2Context : Fetches the next page of search results returned from
-// `search`. Note: `search` along with `searchContinue` can only be used to
-// retrieve a maximum of 10,000 matches. Recent changes may not immediately
-// be reflected in search results due to a short delay in indexing.
-// Duplicate results may be returned across pages. Some results may not be
-// returned.
+// SearchContinueV2Context : Fetches the next page of search results returned
+// from `search`. Note: `search` along with `searchContinue` can only be used to
+// retrieve a maximum of 10,000 matches. Recent changes may not immediately be
+// reflected in search results due to a short delay in indexing. Duplicate
+// results may be returned across pages. Some results may not be returned.
 func (dbx *apiImpl) SearchContinueV2Context(ctx context.Context, arg *SearchV2ContinueArg) (res *SearchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3578,8 +3577,8 @@ type UnlockFileBatchAPIError struct {
 	EndpointError *LockFileError `json:"error"`
 }
 
-// UnlockFileBatchContext : Unlock the files at the given paths. A locked file can
-// only be unlocked by the lock holder or, if a business account, a team
+// UnlockFileBatchContext : Unlock the files at the given paths. A locked file
+// can only be unlocked by the lock holder or, if a business account, a team
 // admin. A successful response indicates that the file has been unlocked.
 // Returns a list of the unlocked file paths and their metadata after this
 // operation.
@@ -3625,12 +3624,12 @@ type UploadAPIError struct {
 	EndpointError *UploadError `json:"error"`
 }
 
-// UploadContext : Create a new file with the contents provided in the request. Do
-// not use this to upload a file larger than 150 MiB. Instead, create an
-// upload session with `uploadSessionStart`. Calls to this endpoint will
-// count as data transport calls for any Dropbox Business teams with a limit
-// on the number of data transport calls allowed per month. For more
-// information, see the Data transport limit page
+// UploadContext : Create a new file with the contents provided in the request.
+// Do not use this to upload a file larger than 150 MiB. Instead, create an
+// upload session with `uploadSessionStart`. Calls to this endpoint will count
+// as data transport calls for any Dropbox Business teams with a limit on the
+// number of data transport calls allowed per month. For more information, see
+// the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadContext(ctx context.Context, arg *UploadArg, content io.Reader) (res *FileMetadata, err error) {
 	arg, content, err = addAutoContentHashToUploadArg(arg, content)
@@ -3680,12 +3679,12 @@ type UploadSessionAppendAPIError struct {
 }
 
 // UploadSessionAppendContext : Append more data to an upload session. A single
-// request should not upload more than 150 MiB. The maximum size of a file
-// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
-// bytes. Calls to this endpoint will count as data transport calls for any
-// Dropbox Business teams with a limit on the number of data transport calls
-// allowed per month. For more information, see the Data transport limit
-// page https://www.dropbox.com/developers/reference/data-transport-limit.
+// request should not upload more than 150 MiB. The maximum size of a file one
+// can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+// Calls to this endpoint will count as data transport calls for any Dropbox
+// Business teams with a limit on the number of data transport calls allowed per
+// month. For more information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
 // Deprecated:
 func (dbx *apiImpl) UploadSessionAppendContext(ctx context.Context, arg *UploadSessionCursor, content io.Reader) (err error) {
 	log.Printf("WARNING: API `UploadSessionAppend` is deprecated")
@@ -3727,14 +3726,14 @@ type UploadSessionAppendV2APIError struct {
 	EndpointError *UploadSessionAppendError `json:"error"`
 }
 
-// UploadSessionAppendV2Context : Append more data to an upload session. When the
-// parameter close is set, this call will close the session. A single
-// request should not upload more than 150 MiB. The maximum size of a file
-// one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
-// bytes. Calls to this endpoint will count as data transport calls for any
-// Dropbox Business teams with a limit on the number of data transport calls
-// allowed per month. For more information, see the Data transport limit
-// page https://www.dropbox.com/developers/reference/data-transport-limit.
+// UploadSessionAppendV2Context : Append more data to an upload session. When
+// the parameter close is set, this call will close the session. A single
+// request should not upload more than 150 MiB. The maximum size of a file one
+// can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+// Calls to this endpoint will count as data transport calls for any Dropbox
+// Business teams with a limit on the number of data transport calls allowed per
+// month. For more information, see the Data transport limit page
+// https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionAppendV2Context(ctx context.Context, arg *UploadSessionAppendArg, content io.Reader) (err error) {
 	arg, content, err = addAutoContentHashToUploadSessionAppendArg(arg, content)
 	if err != nil {
@@ -3778,16 +3777,16 @@ type UploadSessionAppendBatchAPIError struct {
 	EndpointError *UploadSessionAppendBatchError `json:"error"`
 }
 
-// UploadSessionAppendBatchContext : Append more data to multiple upload sessions.
-// Each piece of file content to append to each upload session should be
-// concatenated in the request body, in the order delineated by
-// `UploadSessionAppendBatchArg.entries` and their individual lengths
-// indicated by `UploadSessionAppendBatchArgEntry.length`. A single request
-// should not upload more than 150 MiB. The maximum size of a file one can
-// upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
-// Calls to this endpoint will count as data transport calls for any Dropbox
-// Business teams with a limit on the number of data transport calls allowed
-// per month. For more information, see the Data transport limit page
+// UploadSessionAppendBatchContext : Append more data to multiple upload
+// sessions. Each piece of file content to append to each upload session should
+// be concatenated in the request body, in the order delineated by
+// `UploadSessionAppendBatchArg.entries` and their individual lengths indicated
+// by `UploadSessionAppendBatchArgEntry.length`. A single request should not
+// upload more than 150 MiB. The maximum size of a file one can upload to an
+// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this
+// endpoint will count as data transport calls for any Dropbox Business teams
+// with a limit on the number of data transport calls allowed per month. For
+// more information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionAppendBatchContext(ctx context.Context, arg *UploadSessionAppendBatchArg, content io.Reader) (res *UploadSessionAppendBatchResult, err error) {
 	arg, content, err = addAutoContentHashToUploadSessionAppendBatchArg(arg, content)
@@ -3836,13 +3835,13 @@ type UploadSessionFinishAPIError struct {
 	EndpointError *UploadSessionFinishError `json:"error"`
 }
 
-// UploadSessionFinishContext : Finish an upload session and save the uploaded data
-// to the given file path. A single request should not upload more than 150
-// MiB. The maximum size of a file one can upload to an upload session is
-// 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count
-// as data transport calls for any Dropbox Business teams with a limit on
-// the number of data transport calls allowed per month. For more
-// information, see the Data transport limit page
+// UploadSessionFinishContext : Finish an upload session and save the uploaded
+// data to the given file path. A single request should not upload more than 150
+// MiB. The maximum size of a file one can upload to an upload session is 2^41 -
+// 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count as data
+// transport calls for any Dropbox Business teams with a limit on the number of
+// data transport calls allowed per month. For more information, see the Data
+// transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionFinishContext(ctx context.Context, arg *UploadSessionFinishArg, content io.Reader) (res *FileMetadata, err error) {
 	arg, content, err = addAutoContentHashToUploadSessionFinishArg(arg, content)
@@ -3891,24 +3890,23 @@ type UploadSessionFinishBatchAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// UploadSessionFinishBatchContext : This route helps you commit many files at once
-// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
-// to upload file contents. We recommend uploading many files in parallel to
-// increase throughput. Once the file contents have been uploaded, rather
-// than calling `uploadSessionFinish`, use this route to finish all your
-// upload sessions in a single request. `UploadSessionStartArg.close` or
-// `UploadSessionAppendArg.close` needs to be true for the last
+// UploadSessionFinishBatchContext : This route helps you commit many files at
+// once into a user's Dropbox. Use `uploadSessionStart` and
+// `uploadSessionAppend` to upload file contents. We recommend uploading many
+// files in parallel to increase throughput. Once the file contents have been
+// uploaded, rather than calling `uploadSessionFinish`, use this route to finish
+// all your upload sessions in a single request. `UploadSessionStartArg.close`
+// or `UploadSessionAppendArg.close` needs to be true for the last
 // `uploadSessionStart` or `uploadSessionAppend` call. The maximum size of a
-// file one can upload to an upload session is 2^41 - 2^22
-// (2,199,019,061,248) bytes. This route will return a job_id immediately
-// and do the async commit job in background. Use
-// `uploadSessionFinishBatchCheck` to check the job status. For the same
-// account, this route should be executed serially. That means you should
-// not start the next job before current job finishes. We allow up to 1000
-// entries in a single request. Calls to this endpoint will count as data
-// transport calls for any Dropbox Business teams with a limit on the number
-// of data transport calls allowed per month. For more information, see the
-// Data transport limit page
+// file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+// bytes. This route will return a job_id immediately and do the async commit
+// job in background. Use `uploadSessionFinishBatchCheck` to check the job
+// status. For the same account, this route should be executed serially. That
+// means you should not start the next job before current job finishes. We allow
+// up to 1000 entries in a single request. Calls to this endpoint will count as
+// data transport calls for any Dropbox Business teams with a limit on the
+// number of data transport calls allowed per month. For more information, see
+// the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 // Deprecated:
 func (dbx *apiImpl) UploadSessionFinishBatchContext(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchLaunch, err error) {
@@ -3955,20 +3953,19 @@ type UploadSessionFinishBatchV2APIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// UploadSessionFinishBatchV2Context : This route helps you commit many files at once
-// into a user's Dropbox. Use `uploadSessionStart` and `uploadSessionAppend`
-// to upload file contents. We recommend uploading many files in parallel to
-// increase throughput. Once the file contents have been uploaded, rather
-// than calling `uploadSessionFinish`, use this route to finish all your
-// upload sessions in a single request. `UploadSessionStartArg.close` or
-// `UploadSessionAppendArg.close` needs to be true for the last
-// `uploadSessionStart` or `uploadSessionAppend` call of each upload
-// session. The maximum size of a file one can upload to an upload session
-// is 2^41 - 2^22 (2,199,019,061,248) bytes. We allow up to 1000 entries in
-// a single request. Calls to this endpoint will count as data transport
-// calls for any Dropbox Business teams with a limit on the number of data
-// transport calls allowed per month. For more information, see the Data
-// transport limit page
+// UploadSessionFinishBatchV2Context : This route helps you commit many files at
+// once into a user's Dropbox. Use `uploadSessionStart` and
+// `uploadSessionAppend` to upload file contents. We recommend uploading many
+// files in parallel to increase throughput. Once the file contents have been
+// uploaded, rather than calling `uploadSessionFinish`, use this route to finish
+// all your upload sessions in a single request. `UploadSessionStartArg.close`
+// or `UploadSessionAppendArg.close` needs to be true for the last
+// `uploadSessionStart` or `uploadSessionAppend` call of each upload session.
+// The maximum size of a file one can upload to an upload session is 2^41 - 2^22
+// (2,199,019,061,248) bytes. We allow up to 1000 entries in a single request.
+// Calls to this endpoint will count as data transport calls for any Dropbox
+// Business teams with a limit on the number of data transport calls allowed per
+// month. For more information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit.
 func (dbx *apiImpl) UploadSessionFinishBatchV2Context(ctx context.Context, arg *UploadSessionFinishBatchArg) (res *UploadSessionFinishBatchResult, err error) {
 	req := dropbox.Request{
@@ -4012,8 +4009,8 @@ type UploadSessionFinishBatchCheckAPIError struct {
 	EndpointError *async.PollError `json:"error"`
 }
 
-// UploadSessionFinishBatchCheckContext : Returns the status of an asynchronous job
-// for `uploadSessionFinishBatch`. If success, it returns list of result for
+// UploadSessionFinishBatchCheckContext : Returns the status of an asynchronous
+// job for `uploadSessionFinishBatch`. If success, it returns list of result for
 // each entry.
 func (dbx *apiImpl) UploadSessionFinishBatchCheckContext(ctx context.Context, arg *async.PollArg) (res *UploadSessionFinishBatchJobStatus, err error) {
 	req := dropbox.Request{
@@ -4057,38 +4054,36 @@ type UploadSessionStartAPIError struct {
 	EndpointError *UploadSessionStartError `json:"error"`
 }
 
-// UploadSessionStartContext : Upload sessions allow you to upload a single file in
-// one or more requests, for example where the size of the file is greater
-// than 150 MiB. This call starts a new upload session with the given data.
-// You can then use `uploadSessionAppend` or `uploadSessionAppendBatch` to
-// add more data, then `uploadSessionFinish` or `uploadSessionFinishBatch`
-// to save all the data to a file in Dropbox. A single request should not
-// upload more than 150 MiB. The maximum size of a file one can upload to an
-// upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. An upload
-// session can be used for a maximum of 7 days. Attempting to use a
-// `UploadSessionStartResult.session_id` with `uploadSessionAppend` or other
-// upload session routes more than 7 days after its creation will return
-// `UploadSessionLookupError.not_found`. Calls to this endpoint will count
-// as data transport calls for any Dropbox Business teams with a limit on
-// the number of data transport calls allowed per month. For more
-// information, see the Data transport limit page
+// UploadSessionStartContext : Upload sessions allow you to upload a single file
+// in one or more requests, for example where the size of the file is greater
+// than 150 MiB. This call starts a new upload session with the given data. You
+// can then use `uploadSessionAppend` or `uploadSessionAppendBatch` to add more
+// data, then `uploadSessionFinish` or `uploadSessionFinishBatch` to save all
+// the data to a file in Dropbox. A single request should not upload more than
+// 150 MiB. The maximum size of a file one can upload to an upload session is
+// 2^41 - 2^22 (2,199,019,061,248) bytes. An upload session can be used for a
+// maximum of 7 days. Attempting to use a `UploadSessionStartResult.session_id`
+// with `uploadSessionAppend` or other upload session routes more than 7 days
+// after its creation will return `UploadSessionLookupError.not_found`. Calls to
+// this endpoint will count as data transport calls for any Dropbox Business
+// teams with a limit on the number of data transport calls allowed per month.
+// For more information, see the Data transport limit page
 // https://www.dropbox.com/developers/reference/data-transport-limit. By
 // default, upload sessions require you to send content of the file in
-// sequential order via consecutive `uploadSessionStart`,
-// `uploadSessionAppend`, and `uploadSessionFinish` calls (or their batch
-// variants). For better performance, you can optionally set
-// `UploadSessionStartArg.session_type` to `UploadSessionType.concurrent` to
-// start a concurrent upload session. Concurrent upload sessions may upload
-// file data in concurrent `uploadSessionAppend` requests, with a few
-// caveats. After all of the requests are complete, finish the session with
-// `uploadSessionFinish` as normal. You can not send data in a
-// `uploadSessionStart` or `uploadSessionFinish` call, only with
-// `uploadSessionAppend` or `uploadSessionAppendBatch`. Also, the length of
-// the uploaded data in a call to `uploadSessionAppend` or
+// sequential order via consecutive `uploadSessionStart`, `uploadSessionAppend`,
+// and `uploadSessionFinish` calls (or their batch variants). For better
+// performance, you can optionally set `UploadSessionStartArg.session_type` to
+// `UploadSessionType.concurrent` to start a concurrent upload session.
+// Concurrent upload sessions may upload file data in concurrent
+// `uploadSessionAppend` requests, with a few caveats. After all of the requests
+// are complete, finish the session with `uploadSessionFinish` as normal. You
+// can not send data in a `uploadSessionStart` or `uploadSessionFinish` call,
+// only with `uploadSessionAppend` or `uploadSessionAppendBatch`. Also, the
+// length of the uploaded data in a call to `uploadSessionAppend` or
 // `uploadSessionAppendBatch` must be a multiple of 2^22 (4,194,304) bytes,
-// except for the final append request with `UploadSessionAppendArg.close`
-// or `UploadSessionAppendBatchArgEntry.close` set to true that may contain
-// any remaining data.
+// except for the final append request with `UploadSessionAppendArg.close` or
+// `UploadSessionAppendBatchArgEntry.close` set to true that may contain any
+// remaining data.
 func (dbx *apiImpl) UploadSessionStartContext(ctx context.Context, arg *UploadSessionStartArg, content io.Reader) (res *UploadSessionStartResult, err error) {
 	arg, content, err = addAutoContentHashToUploadSessionStartArg(arg, content)
 	if err != nil {

--- a/v6/dropbox/files/types.go
+++ b/v6/dropbox/files/types.go
@@ -4402,8 +4402,6 @@ type ThumbnailArg struct {
 	Size *ThumbnailSize `json:"size"`
 	// Mode : How to resize and crop the image to achieve the desired size.
 	Mode *ThumbnailMode `json:"mode"`
-	// Quality : Quality of the thumbnail image.
-	Quality *ThumbnailQuality `json:"quality"`
 	// ExcludeMediaInfo : Normally, `FileMetadata.media_info` is set for photo
 	// and video. When this flag is true, `FileMetadata.media_info` is not
 	// populated. This improves latency for use cases where `media_info` is not
@@ -4418,7 +4416,6 @@ func NewThumbnailArg(Path string) *ThumbnailArg {
 	s.Format = &ThumbnailFormat{Tagged: dropbox.Tagged{Tag: "jpeg"}}
 	s.Size = &ThumbnailSize{Tagged: dropbox.Tagged{Tag: "w64h64"}}
 	s.Mode = &ThumbnailMode{Tagged: dropbox.Tagged{Tag: "strict"}}
-	s.Quality = &ThumbnailQuality{Tagged: dropbox.Tagged{Tag: "quality_80"}}
 	return s
 }
 
@@ -4511,7 +4508,6 @@ const (
 	ThumbnailSizeW960h640   = "w960h640"
 	ThumbnailSizeW1024h768  = "w1024h768"
 	ThumbnailSizeW2048h1536 = "w2048h1536"
-	ThumbnailSizeW3200h2400 = "w3200h2400"
 )
 
 // ThumbnailV2Arg : has no documentation (yet)
@@ -4528,8 +4524,6 @@ type ThumbnailV2Arg struct {
 	Size *ThumbnailSize `json:"size"`
 	// Mode : How to resize and crop the image to achieve the desired size.
 	Mode *ThumbnailMode `json:"mode"`
-	// Quality : Quality of the thumbnail image.
-	Quality *ThumbnailQuality `json:"quality"`
 	// ExcludeMediaInfo : Normally, `FileMetadata.media_info` is set for photo
 	// and video. When this flag is true, `FileMetadata.media_info` is not
 	// populated. This improves latency for use cases where `media_info` is not
@@ -4544,7 +4538,6 @@ func NewThumbnailV2Arg(Resource *PathOrLink) *ThumbnailV2Arg {
 	s.Format = &ThumbnailFormat{Tagged: dropbox.Tagged{Tag: "jpeg"}}
 	s.Size = &ThumbnailSize{Tagged: dropbox.Tagged{Tag: "w64h64"}}
 	s.Mode = &ThumbnailMode{Tagged: dropbox.Tagged{Tag: "strict"}}
-	s.Quality = &ThumbnailQuality{Tagged: dropbox.Tagged{Tag: "quality_80"}}
 	return s
 }
 

--- a/v6/dropbox/integration/helpers_test.go
+++ b/v6/dropbox/integration/helpers_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build integration
+
+// Package integration contains tests that talk to the live Dropbox API using
+// real credentials. They are excluded from the default build and only compile
+// under the "integration" build tag:
+//
+//	go test -tags integration ./dropbox/integration/...
+//
+// Credentials are read from the environment, mirroring the CI setup used by the
+// Python SDK (SCOPED_USER_* and SCOPED_TEAM_* refresh-token credentials). For
+// local runs they can instead be loaded from a dropbox-sdk-python-secrets.json
+// file pointed to by DROPBOX_SDK_SECRETS_FILE.
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth"
+	"golang.org/x/oauth2"
+)
+
+// Credential environment variable names. These match the names used by the
+// dropbox-sdk-python integration tests and CI.
+const (
+	envUserClientID     = "SCOPED_USER_CLIENT_ID"
+	envUserClientSecret = "SCOPED_USER_CLIENT_SECRET"
+	envUserRefreshToken = "SCOPED_USER_REFRESH_TOKEN"
+
+	envTeamClientID     = "SCOPED_TEAM_CLIENT_ID"
+	envTeamClientSecret = "SCOPED_TEAM_CLIENT_SECRET"
+	envTeamRefreshToken = "SCOPED_TEAM_REFRESH_TOKEN"
+
+	// envSecretsFile optionally points to a JSON file holding the credentials
+	// above (the dropbox-sdk-python-secrets.json format). Values already set in
+	// the environment take precedence.
+	envSecretsFile = "DROPBOX_SDK_SECRETS_FILE"
+)
+
+// loadSecretsFile loads any credentials from the JSON file referenced by
+// DROPBOX_SDK_SECRETS_FILE into the environment, without overwriting values
+// that are already set. It is a no-op when the variable is unset.
+func loadSecretsFile(t *testing.T) {
+	t.Helper()
+	path := os.Getenv(envSecretsFile)
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s=%q: %v", envSecretsFile, path, err)
+	}
+	var secrets map[string]string
+	if err := json.Unmarshal(data, &secrets); err != nil {
+		t.Fatalf("parsing secrets file %q: %v", path, err)
+	}
+	for k, v := range secrets {
+		if _, ok := os.LookupEnv(k); !ok {
+			t.Setenv(k, v)
+		}
+	}
+}
+
+// requireEnv returns the value of the named environment variable, skipping the
+// test if it is not set. Integration credentials are not always available (for
+// example on fork PRs), so a missing credential skips rather than fails.
+func requireEnv(t *testing.T, name string) string {
+	t.Helper()
+	v := os.Getenv(name)
+	if v == "" {
+		t.Skipf("%s is not set; skipping integration test", name)
+	}
+	return v
+}
+
+// refreshTokenSource builds an OAuth token source that mints short-lived access
+// tokens from a long-lived refresh token, matching how the Python SDK
+// authenticates its integration fixtures.
+func refreshTokenSource(t *testing.T, appKey, appSecret, refreshToken string) oauth2.TokenSource {
+	t.Helper()
+	return oauth.TokenSource(
+		context.Background(),
+		appKey,
+		&oauth2.Token{RefreshToken: refreshToken},
+		oauth.WithAppSecret(appSecret),
+	)
+}
+
+// userConfig returns a dropbox.Config authenticated as the scoped user via a
+// refresh token, skipping the test if the credentials are unavailable.
+func userConfig(t *testing.T) dropbox.Config {
+	t.Helper()
+	loadSecretsFile(t)
+	appKey := requireEnv(t, envUserClientID)
+	appSecret := requireEnv(t, envUserClientSecret)
+	refreshToken := requireEnv(t, envUserRefreshToken)
+	return dropbox.Config{
+		TokenSource: refreshTokenSource(t, appKey, appSecret, refreshToken),
+	}
+}
+
+// teamConfig returns a dropbox.Config authenticated as the scoped team via a
+// refresh token, skipping the test if the credentials are unavailable.
+func teamConfig(t *testing.T) dropbox.Config {
+	t.Helper()
+	loadSecretsFile(t)
+	appKey := requireEnv(t, envTeamClientID)
+	appSecret := requireEnv(t, envTeamClientSecret)
+	refreshToken := requireEnv(t, envTeamRefreshToken)
+	return dropbox.Config{
+		TokenSource: refreshTokenSource(t, appKey, appSecret, refreshToken),
+	}
+}

--- a/v6/dropbox/integration/team_test.go
+++ b/v6/dropbox/integration/team_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/team"
+)
+
+// TestTeamMembersList exercises a team-scoped endpoint with team credentials.
+func TestTeamMembersList(t *testing.T) {
+	client := team.New(teamConfig(t))
+
+	if _, err := client.MembersList(team.NewMembersListArg()); err != nil {
+		t.Fatalf("MembersList: %v", err)
+	}
+}
+
+// TestTeamMemberCreateAndDeleteFolder acts as a team member (the team analogue
+// of the user create/delete round-trip) to create a uniquely named folder in
+// that member's Dropbox and then delete it. It requires team credentials and a
+// team with at least one member.
+func TestTeamMemberCreateAndDeleteFolder(t *testing.T) {
+	cfg := teamConfig(t)
+
+	members, err := team.New(cfg).MembersList(team.NewMembersListArg())
+	if err != nil {
+		t.Fatalf("MembersList: %v", err)
+	}
+	if len(members.Members) == 0 {
+		t.Skip("team has no members; skipping member file operations")
+	}
+	memberID := members.Members[0].Profile.TeamMemberId
+
+	// Perform file operations as the selected member (equivalent to the Python
+	// SDK's DropboxTeam.as_user).
+	cfg.AsMemberID = memberID
+	client := files.New(cfg)
+
+	path := fmt.Sprintf("/sdk-integration-team-%d", time.Now().UnixNano())
+
+	created, err := client.CreateFolderV2(files.NewCreateFolderArg(path))
+	if err != nil {
+		t.Fatalf("CreateFolderV2(%q) as member %q: %v", path, memberID, err)
+	}
+	if created.Metadata.PathDisplay != path {
+		t.Fatalf("created folder path = %q, want %q", created.Metadata.PathDisplay, path)
+	}
+
+	deleted := false
+	defer func() {
+		if deleted {
+			return
+		}
+		if _, err := client.DeleteV2(files.NewDeleteArg(path)); err != nil {
+			t.Errorf("cleanup DeleteV2(%q): %v", path, err)
+		}
+	}()
+
+	result, err := client.DeleteV2(files.NewDeleteArg(path))
+	if err != nil {
+		t.Fatalf("DeleteV2(%q) as member %q: %v", path, memberID, err)
+	}
+	deleted = true
+	folder, ok := result.Metadata.(*files.FolderMetadata)
+	if !ok {
+		t.Fatalf("deleted metadata type = %T, want *files.FolderMetadata", result.Metadata)
+	}
+	if folder.PathDisplay != path {
+		t.Fatalf("deleted folder path = %q, want %q", folder.PathDisplay, path)
+	}
+}

--- a/v6/dropbox/integration/user_test.go
+++ b/v6/dropbox/integration/user_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+// TestUserCreateAndDeleteFolder exercises a round-trip against the live user
+// API: create a uniquely named folder, then delete it. It authenticates with a
+// refresh token, so it also proves the SDK can mint an access token on demand.
+func TestUserCreateAndDeleteFolder(t *testing.T) {
+	client := files.New(userConfig(t))
+
+	path := fmt.Sprintf("/sdk-integration-%d", time.Now().UnixNano())
+
+	created, err := client.CreateFolderV2(files.NewCreateFolderArg(path))
+	if err != nil {
+		t.Fatalf("CreateFolderV2(%q): %v", path, err)
+	}
+	if created.Metadata.PathDisplay != path {
+		t.Fatalf("created folder path = %q, want %q", created.Metadata.PathDisplay, path)
+	}
+
+	// Best-effort cleanup so an early failure below does not leak the folder.
+	// Once the folder is deleted successfully this becomes a no-op.
+	deleted := false
+	defer func() {
+		if deleted {
+			return
+		}
+		if _, err := client.DeleteV2(files.NewDeleteArg(path)); err != nil {
+			t.Errorf("cleanup DeleteV2(%q): %v", path, err)
+		}
+	}()
+
+	result, err := client.DeleteV2(files.NewDeleteArg(path))
+	if err != nil {
+		t.Fatalf("DeleteV2(%q): %v", path, err)
+	}
+	deleted = true
+	// DeleteResult.Metadata is the IsMetadata interface; a deleted folder comes
+	// back as *FolderMetadata.
+	folder, ok := result.Metadata.(*files.FolderMetadata)
+	if !ok {
+		t.Fatalf("deleted metadata type = %T, want *files.FolderMetadata", result.Metadata)
+	}
+	if folder.PathDisplay != path {
+		t.Fatalf("deleted folder path = %q, want %q", folder.PathDisplay, path)
+	}
+}

--- a/v6/dropbox/openid/client.go
+++ b/v6/dropbox/openid/client.go
@@ -41,9 +41,10 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// UserinfoContext : This route is used for refreshing the info that is found in
-	// the id_token during the OIDC flow. This route doesn't require any
-	// arguments and will use the scopes approved for the given access token.
+	// UserinfoContext : This route is used for refreshing the info that is
+	// found in the id_token during the OIDC flow. This route doesn't require
+	// any arguments and will use the scopes approved for the given access
+	// token.
 	UserinfoContext(ctx context.Context, arg *UserInfoArgs) (res *UserInfoResult, err error)
 }
 
@@ -56,8 +57,8 @@ type UserinfoAPIError struct {
 }
 
 // UserinfoContext : This route is used for refreshing the info that is found in
-// the id_token during the OIDC flow. This route doesn't require any
-// arguments and will use the scopes approved for the given access token.
+// the id_token during the OIDC flow. This route doesn't require any arguments
+// and will use the scopes approved for the given access token.
 func (dbx *apiImpl) UserinfoContext(ctx context.Context, arg *UserInfoArgs) (res *UserInfoResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/paper/client.go
+++ b/v6/dropbox/paper/client.go
@@ -235,23 +235,25 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// DocsArchiveContext : Marks the given Paper doc as archived. This action can be
-	// performed or undone by anyone with edit permissions to the doc. Note that
-	// this endpoint will continue to work for content created by users on the
-	// older version of Paper. To check which version of Paper a user is on, use
-	// /users/features/get_values. If the paper_as_files feature is enabled,
-	// then the user is running the new version of Paper. This endpoint will be
-	// retired in September 2020. Refer to the `Paper Migration Guide`
+	// DocsArchiveContext : Marks the given Paper doc as archived. This action
+	// can be performed or undone by anyone with edit permissions to the doc.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. This
+	// endpoint will be retired in September 2020. Refer to the `Paper Migration
+	// Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for more information.
 	// Deprecated:
 	DocsArchiveContext(ctx context.Context, arg *RefPaperDoc) (err error)
-	// DocsCreateContext : Creates a new Paper doc with the provided content. Note that
-	// this endpoint will continue to work for content created by users on the
-	// older version of Paper. To check which version of Paper a user is on, use
-	// /users/features/get_values. If the paper_as_files feature is enabled,
-	// then the user is running the new version of Paper. This endpoint will be
-	// retired in September 2020. Refer to the `Paper Migration Guide`
+	// DocsCreateContext : Creates a new Paper doc with the provided content.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. This
+	// endpoint will be retired in September 2020. Refer to the `Paper Migration
+	// Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for more information.
 	// Deprecated:
@@ -266,21 +268,21 @@ type ContextClient interface {
 	// for migration information.
 	// Deprecated:
 	DocsDownloadContext(ctx context.Context, arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error)
-	// DocsFolderUsersListContext : Lists the users who are explicitly invited to the
-	// Paper folder in which the Paper doc is contained. For private folders all
-	// users (including owner) shared on the folder are listed and for team
-	// folders all non-team users shared on the folder are returned. Note that
-	// this endpoint will continue to work for content created by users on the
-	// older version of Paper. To check which version of Paper a user is on, use
-	// /users/features/get_values. If the paper_as_files feature is enabled,
-	// then the user is running the new version of Paper. Refer to the `Paper
-	// Migration Guide`
+	// DocsFolderUsersListContext : Lists the users who are explicitly invited
+	// to the Paper folder in which the Paper doc is contained. For private
+	// folders all users (including owner) shared on the folder are listed and
+	// for team folders all non-team users shared on the folder are returned.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. Refer to
+	// the `Paper Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
 	DocsFolderUsersListContext(ctx context.Context, arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error)
-	// DocsFolderUsersListContinueContext : Once a cursor has been retrieved from
-	// `docsFolderUsersList`, use this to paginate through all users on the
+	// DocsFolderUsersListContinueContext : Once a cursor has been retrieved
+	// from `docsFolderUsersList`, use this to paginate through all users on the
 	// Paper folder. Note that this endpoint will continue to work for content
 	// created by users on the older version of Paper. To check which version of
 	// Paper a user is on, use /users/features/get_values. If the paper_as_files
@@ -290,14 +292,14 @@ type ContextClient interface {
 	// for migration information.
 	// Deprecated:
 	DocsFolderUsersListContinueContext(ctx context.Context, arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error)
-	// DocsGetFolderInfoContext : Retrieves folder information for the given Paper doc.
-	// This includes: - folder sharing policy; permissions for subfolders are
-	// set by the top-level folder. - full 'filepath', i.e. the list of folders
-	// (both folderId and folderName) from the root folder to the folder
-	// directly containing the Paper doc. If the Paper doc is not in any folder
-	// (aka unfiled) the response will be empty. Note that this endpoint will
-	// continue to work for content created by users on the older version of
-	// Paper. To check which version of Paper a user is on, use
+	// DocsGetFolderInfoContext : Retrieves folder information for the given
+	// Paper doc. This includes: - folder sharing policy; permissions for
+	// subfolders are set by the top-level folder. - full 'filepath', i.e. the
+	// list of folders (both folderId and folderName) from the root folder to
+	// the folder directly containing the Paper doc. If the Paper doc is not in
+	// any folder (aka unfiled) the response will be empty. Note that this
+	// endpoint will continue to work for content created by users on the older
+	// version of Paper. To check which version of Paper a user is on, use
 	// /users/features/get_values. If the paper_as_files feature is enabled,
 	// then the user is running the new version of Paper. Refer to the `Paper
 	// Migration Guide`
@@ -307,19 +309,9 @@ type ContextClient interface {
 	DocsGetFolderInfoContext(ctx context.Context, arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error)
 	// DocsGetMetadataContext : Returns metadata for a Paper doc or Cloud Doc.
 	DocsGetMetadataContext(ctx context.Context, arg *GetDocMetadataArg) (res *PaperDocGetMetadataResult, err error)
-	// DocsListContext : Return the list of all Paper docs according to the argument
-	// specifications. To iterate over through the full pagination, pass the
-	// cursor to `docsListContinue`. Note that this endpoint will continue to
-	// work for content created by users on the older version of Paper. To check
-	// which version of Paper a user is on, use /users/features/get_values. If
-	// the paper_as_files feature is enabled, then the user is running the new
-	// version of Paper. Refer to the `Paper Migration Guide`
-	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-	// for migration information.
-	// Deprecated:
-	DocsListContext(ctx context.Context, arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error)
-	// DocsListContinueContext : Once a cursor has been retrieved from `docsList`, use
-	// this to paginate through all Paper doc. Note that this endpoint will
+	// DocsListContext : Return the list of all Paper docs according to the
+	// argument specifications. To iterate over through the full pagination,
+	// pass the cursor to `docsListContinue`. Note that this endpoint will
 	// continue to work for content created by users on the older version of
 	// Paper. To check which version of Paper a user is on, use
 	// /users/features/get_values. If the paper_as_files feature is enabled,
@@ -328,30 +320,42 @@ type ContextClient interface {
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
+	DocsListContext(ctx context.Context, arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error)
+	// DocsListContinueContext : Once a cursor has been retrieved from
+	// `docsList`, use this to paginate through all Paper doc. Note that this
+	// endpoint will continue to work for content created by users on the older
+	// version of Paper. To check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
+	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
+	// for migration information.
+	// Deprecated:
 	DocsListContinueContext(ctx context.Context, arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error)
-	// DocsPermanentlyDeleteContext : Permanently deletes the given Paper doc. This
-	// operation is final as the doc cannot be recovered. This action can be
-	// performed only by the doc owner. Note that this endpoint will continue to
-	// work for content created by users on the older version of Paper. To check
-	// which version of Paper a user is on, use /users/features/get_values. If
-	// the paper_as_files feature is enabled, then the user is running the new
-	// version of Paper. Refer to the `Paper Migration Guide`
+	// DocsPermanentlyDeleteContext : Permanently deletes the given Paper doc.
+	// This operation is final as the doc cannot be recovered. This action can
+	// be performed only by the doc owner. Note that this endpoint will continue
+	// to work for content created by users on the older version of Paper. To
+	// check which version of Paper a user is on, use
+	// /users/features/get_values. If the paper_as_files feature is enabled,
+	// then the user is running the new version of Paper. Refer to the `Paper
+	// Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
 	DocsPermanentlyDeleteContext(ctx context.Context, arg *RefPaperDoc) (err error)
-	// DocsSharingPolicyGetContext : Gets the default sharing policy for the given
-	// Paper doc. Note that this endpoint will continue to work for content
-	// created by users on the older version of Paper. To check which version of
-	// Paper a user is on, use /users/features/get_values. If the paper_as_files
-	// feature is enabled, then the user is running the new version of Paper.
-	// Refer to the `Paper Migration Guide`
+	// DocsSharingPolicyGetContext : Gets the default sharing policy for the
+	// given Paper doc. Note that this endpoint will continue to work for
+	// content created by users on the older version of Paper. To check which
+	// version of Paper a user is on, use /users/features/get_values. If the
+	// paper_as_files feature is enabled, then the user is running the new
+	// version of Paper. Refer to the `Paper Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
 	DocsSharingPolicyGetContext(ctx context.Context, arg *RefPaperDoc) (res *SharingPolicy, err error)
-	// DocsSharingPolicySetContext : Sets the default sharing policy for the given
-	// Paper doc. The default 'team_sharing_policy' can be changed only by
+	// DocsSharingPolicySetContext : Sets the default sharing policy for the
+	// given Paper doc. The default 'team_sharing_policy' can be changed only by
 	// teams, omit this field for personal accounts. The 'public_sharing_policy'
 	// policy can't be set to the value 'disabled' because this setting can be
 	// changed only via the team admin console. Note that this endpoint will
@@ -364,22 +368,22 @@ type ContextClient interface {
 	// for migration information.
 	// Deprecated:
 	DocsSharingPolicySetContext(ctx context.Context, arg *PaperDocSharingPolicy) (err error)
-	// DocsUpdateContext : Updates an existing Paper doc with the provided content.
-	// Note that this endpoint will continue to work for content created by
-	// users on the older version of Paper. To check which version of Paper a
-	// user is on, use /users/features/get_values. If the paper_as_files feature
-	// is enabled, then the user is running the new version of Paper. This
-	// endpoint will be retired in September 2020. Refer to the `Paper Migration
-	// Guide`
+	// DocsUpdateContext : Updates an existing Paper doc with the provided
+	// content. Note that this endpoint will continue to work for content
+	// created by users on the older version of Paper. To check which version of
+	// Paper a user is on, use /users/features/get_values. If the paper_as_files
+	// feature is enabled, then the user is running the new version of Paper.
+	// This endpoint will be retired in September 2020. Refer to the `Paper
+	// Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for more information.
 	// Deprecated:
 	DocsUpdateContext(ctx context.Context, arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error)
-	// DocsUsersAddContext : Allows an owner or editor to add users to a Paper doc or
-	// change their permissions using their email address or Dropbox account ID.
-	// The doc owner's permissions cannot be changed. Note that this endpoint
-	// will continue to work for content created by users on the older version
-	// of Paper. To check which version of Paper a user is on, use
+	// DocsUsersAddContext : Allows an owner or editor to add users to a Paper
+	// doc or change their permissions using their email address or Dropbox
+	// account ID. The doc owner's permissions cannot be changed. Note that this
+	// endpoint will continue to work for content created by users on the older
+	// version of Paper. To check which version of Paper a user is on, use
 	// /users/features/get_values. If the paper_as_files feature is enabled,
 	// then the user is running the new version of Paper. Refer to the `Paper
 	// Migration Guide`
@@ -387,9 +391,9 @@ type ContextClient interface {
 	// for migration information.
 	// Deprecated:
 	DocsUsersAddContext(ctx context.Context, arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error)
-	// DocsUsersListContext : Lists all users who visited the Paper doc or users with
-	// explicit access. This call excludes users who have been removed. The list
-	// is sorted by the date of the visit or the share date. The list will
+	// DocsUsersListContext : Lists all users who visited the Paper doc or users
+	// with explicit access. This call excludes users who have been removed. The
+	// list is sorted by the date of the visit or the share date. The list will
 	// include both users, the explicitly shared ones as well as those who came
 	// in using the Paper url link. Note that this endpoint will continue to
 	// work for content created by users on the older version of Paper. To check
@@ -411,23 +415,23 @@ type ContextClient interface {
 	// for migration information.
 	// Deprecated:
 	DocsUsersListContinueContext(ctx context.Context, arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error)
-	// DocsUsersRemoveContext : Allows an owner or editor to remove users from a Paper
-	// doc using their email address or Dropbox account ID. The doc owner cannot
-	// be removed. Note that this endpoint will continue to work for content
-	// created by users on the older version of Paper. To check which version of
-	// Paper a user is on, use /users/features/get_values. If the paper_as_files
-	// feature is enabled, then the user is running the new version of Paper.
-	// Refer to the `Paper Migration Guide`
+	// DocsUsersRemoveContext : Allows an owner or editor to remove users from a
+	// Paper doc using their email address or Dropbox account ID. The doc owner
+	// cannot be removed. Note that this endpoint will continue to work for
+	// content created by users on the older version of Paper. To check which
+	// version of Paper a user is on, use /users/features/get_values. If the
+	// paper_as_files feature is enabled, then the user is running the new
+	// version of Paper. Refer to the `Paper Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
 	DocsUsersRemoveContext(ctx context.Context, arg *RemovePaperDocUser) (err error)
-	// FoldersCreateContext : Create a new Paper folder with the provided info. Note
-	// that this endpoint will continue to work for content created by users on
-	// the older version of Paper. To check which version of Paper a user is on,
-	// use /users/features/get_values. If the paper_as_files feature is enabled,
-	// then the user is running the new version of Paper. Refer to the `Paper
-	// Migration Guide`
+	// FoldersCreateContext : Create a new Paper folder with the provided info.
+	// Note that this endpoint will continue to work for content created by
+	// users on the older version of Paper. To check which version of Paper a
+	// user is on, use /users/features/get_values. If the paper_as_files feature
+	// is enabled, then the user is running the new version of Paper. Refer to
+	// the `Paper Migration Guide`
 	// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
 	// for migration information.
 	// Deprecated:
@@ -442,15 +446,15 @@ type DocsArchiveAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsArchiveContext : Marks the given Paper doc as archived. This action can be
-// performed or undone by anyone with edit permissions to the doc. Note that
-// this endpoint will continue to work for content created by users on the
-// older version of Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. This endpoint will be
-// retired in September 2020. Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for more information.
+// DocsArchiveContext : Marks the given Paper doc as archived. This action can
+// be performed or undone by anyone with edit permissions to the doc. Note that
+// this endpoint will continue to work for content created by users on the older
+// version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. This endpoint will be retired
+// in September 2020. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// more information.
 // Deprecated:
 func (dbx *apiImpl) DocsArchiveContext(ctx context.Context, arg *RefPaperDoc) (err error) {
 	log.Printf("WARNING: API `DocsArchive` is deprecated")
@@ -492,14 +496,14 @@ type DocsCreateAPIError struct {
 	EndpointError *PaperDocCreateError `json:"error"`
 }
 
-// DocsCreateContext : Creates a new Paper doc with the provided content. Note that
-// this endpoint will continue to work for content created by users on the
+// DocsCreateContext : Creates a new Paper doc with the provided content. Note
+// that this endpoint will continue to work for content created by users on the
 // older version of Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. This endpoint will be
-// retired in September 2020. Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for more information.
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. This endpoint will be retired
+// in September 2020. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// more information.
 // Deprecated:
 func (dbx *apiImpl) DocsCreateContext(ctx context.Context, arg *PaperDocCreateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
 	log.Printf("WARNING: API `DocsCreate` is deprecated")
@@ -546,13 +550,13 @@ type DocsDownloadAPIError struct {
 }
 
 // DocsDownloadContext : Exports and downloads Paper doc either as HTML or
-// markdown. Note that this endpoint will continue to work for content
-// created by users on the older version of Paper. To check which version of
-// Paper a user is on, use /users/features/get_values. If the paper_as_files
-// feature is enabled, then the user is running the new version of Paper.
-// Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// markdown. Note that this endpoint will continue to work for content created
+// by users on the older version of Paper. To check which version of Paper a
+// user is on, use /users/features/get_values. If the paper_as_files feature is
+// enabled, then the user is running the new version of Paper. Refer to the
+// `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsDownloadContext(ctx context.Context, arg *PaperDocExport) (res *PaperDocExportResult, content io.ReadCloser, err error) {
 	log.Printf("WARNING: API `DocsDownload` is deprecated")
@@ -598,17 +602,17 @@ type DocsFolderUsersListAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsFolderUsersListContext : Lists the users who are explicitly invited to the
-// Paper folder in which the Paper doc is contained. For private folders all
-// users (including owner) shared on the folder are listed and for team
-// folders all non-team users shared on the folder are returned. Note that
-// this endpoint will continue to work for content created by users on the
-// older version of Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// DocsFolderUsersListContext : Lists the users who are explicitly invited to
+// the Paper folder in which the Paper doc is contained. For private folders all
+// users (including owner) shared on the folder are listed and for team folders
+// all non-team users shared on the folder are returned. Note that this endpoint
+// will continue to work for content created by users on the older version of
+// Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. Refer to the `Paper Migration
+// Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsFolderUsersListContext(ctx context.Context, arg *ListUsersOnFolderArgs) (res *ListUsersOnFolderResponse, err error) {
 	log.Printf("WARNING: API `DocsFolderUsersList` is deprecated")
@@ -655,14 +659,14 @@ type DocsFolderUsersListContinueAPIError struct {
 }
 
 // DocsFolderUsersListContinueContext : Once a cursor has been retrieved from
-// `docsFolderUsersList`, use this to paginate through all users on the
-// Paper folder. Note that this endpoint will continue to work for content
-// created by users on the older version of Paper. To check which version of
-// Paper a user is on, use /users/features/get_values. If the paper_as_files
-// feature is enabled, then the user is running the new version of Paper.
-// Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// `docsFolderUsersList`, use this to paginate through all users on the Paper
+// folder. Note that this endpoint will continue to work for content created by
+// users on the older version of Paper. To check which version of Paper a user
+// is on, use /users/features/get_values. If the paper_as_files feature is
+// enabled, then the user is running the new version of Paper. Refer to the
+// `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsFolderUsersListContinueContext(ctx context.Context, arg *ListUsersOnFolderContinueArgs) (res *ListUsersOnFolderResponse, err error) {
 	log.Printf("WARNING: API `DocsFolderUsersListContinue` is deprecated")
@@ -708,19 +712,18 @@ type DocsGetFolderInfoAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsGetFolderInfoContext : Retrieves folder information for the given Paper doc.
-// This includes: - folder sharing policy; permissions for subfolders are
+// DocsGetFolderInfoContext : Retrieves folder information for the given Paper
+// doc. This includes: - folder sharing policy; permissions for subfolders are
 // set by the top-level folder. - full 'filepath', i.e. the list of folders
-// (both folderId and folderName) from the root folder to the folder
-// directly containing the Paper doc. If the Paper doc is not in any folder
-// (aka unfiled) the response will be empty. Note that this endpoint will
-// continue to work for content created by users on the older version of
-// Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// (both folderId and folderName) from the root folder to the folder directly
+// containing the Paper doc. If the Paper doc is not in any folder (aka unfiled)
+// the response will be empty. Note that this endpoint will continue to work for
+// content created by users on the older version of Paper. To check which
+// version of Paper a user is on, use /users/features/get_values. If the
+// paper_as_files feature is enabled, then the user is running the new version
+// of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsGetFolderInfoContext(ctx context.Context, arg *RefPaperDoc) (res *FoldersContainingPaperDoc, err error) {
 	log.Printf("WARNING: API `DocsGetFolderInfo` is deprecated")
@@ -810,14 +813,14 @@ type DocsListAPIError struct {
 }
 
 // DocsListContext : Return the list of all Paper docs according to the argument
-// specifications. To iterate over through the full pagination, pass the
-// cursor to `docsListContinue`. Note that this endpoint will continue to
-// work for content created by users on the older version of Paper. To check
-// which version of Paper a user is on, use /users/features/get_values. If
-// the paper_as_files feature is enabled, then the user is running the new
-// version of Paper. Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// specifications. To iterate over through the full pagination, pass the cursor
+// to `docsListContinue`. Note that this endpoint will continue to work for
+// content created by users on the older version of Paper. To check which
+// version of Paper a user is on, use /users/features/get_values. If the
+// paper_as_files feature is enabled, then the user is running the new version
+// of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsListContext(ctx context.Context, arg *ListPaperDocsArgs) (res *ListPaperDocsResponse, err error) {
 	log.Printf("WARNING: API `DocsList` is deprecated")
@@ -863,15 +866,14 @@ type DocsListContinueAPIError struct {
 	EndpointError *ListDocsCursorError `json:"error"`
 }
 
-// DocsListContinueContext : Once a cursor has been retrieved from `docsList`, use
-// this to paginate through all Paper doc. Note that this endpoint will
-// continue to work for content created by users on the older version of
-// Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// DocsListContinueContext : Once a cursor has been retrieved from `docsList`,
+// use this to paginate through all Paper doc. Note that this endpoint will
+// continue to work for content created by users on the older version of Paper.
+// To check which version of Paper a user is on, use /users/features/get_values.
+// If the paper_as_files feature is enabled, then the user is running the new
+// version of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsListContinueContext(ctx context.Context, arg *ListPaperDocsContinueArgs) (res *ListPaperDocsResponse, err error) {
 	log.Printf("WARNING: API `DocsListContinue` is deprecated")
@@ -921,11 +923,11 @@ type DocsPermanentlyDeleteAPIError struct {
 // operation is final as the doc cannot be recovered. This action can be
 // performed only by the doc owner. Note that this endpoint will continue to
 // work for content created by users on the older version of Paper. To check
-// which version of Paper a user is on, use /users/features/get_values. If
-// the paper_as_files feature is enabled, then the user is running the new
-// version of Paper. Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// which version of Paper a user is on, use /users/features/get_values. If the
+// paper_as_files feature is enabled, then the user is running the new version
+// of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsPermanentlyDeleteContext(ctx context.Context, arg *RefPaperDoc) (err error) {
 	log.Printf("WARNING: API `DocsPermanentlyDelete` is deprecated")
@@ -968,13 +970,13 @@ type DocsSharingPolicyGetAPIError struct {
 }
 
 // DocsSharingPolicyGetContext : Gets the default sharing policy for the given
-// Paper doc. Note that this endpoint will continue to work for content
-// created by users on the older version of Paper. To check which version of
-// Paper a user is on, use /users/features/get_values. If the paper_as_files
-// feature is enabled, then the user is running the new version of Paper.
-// Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// Paper doc. Note that this endpoint will continue to work for content created
+// by users on the older version of Paper. To check which version of Paper a
+// user is on, use /users/features/get_values. If the paper_as_files feature is
+// enabled, then the user is running the new version of Paper. Refer to the
+// `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsSharingPolicyGetContext(ctx context.Context, arg *RefPaperDoc) (res *SharingPolicy, err error) {
 	log.Printf("WARNING: API `DocsSharingPolicyGet` is deprecated")
@@ -1021,17 +1023,16 @@ type DocsSharingPolicySetAPIError struct {
 }
 
 // DocsSharingPolicySetContext : Sets the default sharing policy for the given
-// Paper doc. The default 'team_sharing_policy' can be changed only by
-// teams, omit this field for personal accounts. The 'public_sharing_policy'
-// policy can't be set to the value 'disabled' because this setting can be
-// changed only via the team admin console. Note that this endpoint will
-// continue to work for content created by users on the older version of
-// Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// Paper doc. The default 'team_sharing_policy' can be changed only by teams,
+// omit this field for personal accounts. The 'public_sharing_policy' policy
+// can't be set to the value 'disabled' because this setting can be changed only
+// via the team admin console. Note that this endpoint will continue to work for
+// content created by users on the older version of Paper. To check which
+// version of Paper a user is on, use /users/features/get_values. If the
+// paper_as_files feature is enabled, then the user is running the new version
+// of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsSharingPolicySetContext(ctx context.Context, arg *PaperDocSharingPolicy) (err error) {
 	log.Printf("WARNING: API `DocsSharingPolicySet` is deprecated")
@@ -1074,14 +1075,13 @@ type DocsUpdateAPIError struct {
 }
 
 // DocsUpdateContext : Updates an existing Paper doc with the provided content.
-// Note that this endpoint will continue to work for content created by
-// users on the older version of Paper. To check which version of Paper a
-// user is on, use /users/features/get_values. If the paper_as_files feature
-// is enabled, then the user is running the new version of Paper. This
-// endpoint will be retired in September 2020. Refer to the `Paper Migration
-// Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for more information.
+// Note that this endpoint will continue to work for content created by users on
+// the older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. This endpoint will be retired
+// in September 2020. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// more information.
 // Deprecated:
 func (dbx *apiImpl) DocsUpdateContext(ctx context.Context, arg *PaperDocUpdateArgs, content io.Reader) (res *PaperDocCreateUpdateResult, err error) {
 	log.Printf("WARNING: API `DocsUpdate` is deprecated")
@@ -1127,16 +1127,15 @@ type DocsUsersAddAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsUsersAddContext : Allows an owner or editor to add users to a Paper doc or
-// change their permissions using their email address or Dropbox account ID.
-// The doc owner's permissions cannot be changed. Note that this endpoint
-// will continue to work for content created by users on the older version
-// of Paper. To check which version of Paper a user is on, use
-// /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// DocsUsersAddContext : Allows an owner or editor to add users to a Paper doc
+// or change their permissions using their email address or Dropbox account ID.
+// The doc owner's permissions cannot be changed. Note that this endpoint will
+// continue to work for content created by users on the older version of Paper.
+// To check which version of Paper a user is on, use /users/features/get_values.
+// If the paper_as_files feature is enabled, then the user is running the new
+// version of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsUsersAddContext(ctx context.Context, arg *AddPaperDocUser) (res []*AddPaperDocUserMemberResult, err error) {
 	log.Printf("WARNING: API `DocsUsersAdd` is deprecated")
@@ -1182,17 +1181,17 @@ type DocsUsersListAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsUsersListContext : Lists all users who visited the Paper doc or users with
-// explicit access. This call excludes users who have been removed. The list
-// is sorted by the date of the visit or the share date. The list will
-// include both users, the explicitly shared ones as well as those who came
-// in using the Paper url link. Note that this endpoint will continue to
-// work for content created by users on the older version of Paper. To check
-// which version of Paper a user is on, use /users/features/get_values. If
-// the paper_as_files feature is enabled, then the user is running the new
-// version of Paper. Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// DocsUsersListContext : Lists all users who visited the Paper doc or users
+// with explicit access. This call excludes users who have been removed. The
+// list is sorted by the date of the visit or the share date. The list will
+// include both users, the explicitly shared ones as well as those who came in
+// using the Paper url link. Note that this endpoint will continue to work for
+// content created by users on the older version of Paper. To check which
+// version of Paper a user is on, use /users/features/get_values. If the
+// paper_as_files feature is enabled, then the user is running the new version
+// of Paper. Refer to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsUsersListContext(ctx context.Context, arg *ListUsersOnPaperDocArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	log.Printf("WARNING: API `DocsUsersList` is deprecated")
@@ -1240,13 +1239,13 @@ type DocsUsersListContinueAPIError struct {
 
 // DocsUsersListContinueContext : Once a cursor has been retrieved from
 // `docsUsersList`, use this to paginate through all users on the Paper doc.
-// Note that this endpoint will continue to work for content created by
-// users on the older version of Paper. To check which version of Paper a
-// user is on, use /users/features/get_values. If the paper_as_files feature
-// is enabled, then the user is running the new version of Paper. Refer to
-// the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// Note that this endpoint will continue to work for content created by users on
+// the older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. Refer to the `Paper Migration
+// Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsUsersListContinueContext(ctx context.Context, arg *ListUsersOnPaperDocContinueArgs) (res *ListUsersOnPaperDocResponse, err error) {
 	log.Printf("WARNING: API `DocsUsersListContinue` is deprecated")
@@ -1292,15 +1291,15 @@ type DocsUsersRemoveAPIError struct {
 	EndpointError *DocLookupError `json:"error"`
 }
 
-// DocsUsersRemoveContext : Allows an owner or editor to remove users from a Paper
-// doc using their email address or Dropbox account ID. The doc owner cannot
-// be removed. Note that this endpoint will continue to work for content
+// DocsUsersRemoveContext : Allows an owner or editor to remove users from a
+// Paper doc using their email address or Dropbox account ID. The doc owner
+// cannot be removed. Note that this endpoint will continue to work for content
 // created by users on the older version of Paper. To check which version of
 // Paper a user is on, use /users/features/get_values. If the paper_as_files
-// feature is enabled, then the user is running the new version of Paper.
-// Refer to the `Paper Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// feature is enabled, then the user is running the new version of Paper. Refer
+// to the `Paper Migration Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) DocsUsersRemoveContext(ctx context.Context, arg *RemovePaperDocUser) (err error) {
 	log.Printf("WARNING: API `DocsUsersRemove` is deprecated")
@@ -1343,13 +1342,13 @@ type FoldersCreateAPIError struct {
 }
 
 // FoldersCreateContext : Create a new Paper folder with the provided info. Note
-// that this endpoint will continue to work for content created by users on
-// the older version of Paper. To check which version of Paper a user is on,
-// use /users/features/get_values. If the paper_as_files feature is enabled,
-// then the user is running the new version of Paper. Refer to the `Paper
-// Migration Guide`
-// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>
-// for migration information.
+// that this endpoint will continue to work for content created by users on the
+// older version of Paper. To check which version of Paper a user is on, use
+// /users/features/get_values. If the paper_as_files feature is enabled, then
+// the user is running the new version of Paper. Refer to the `Paper Migration
+// Guide`
+// <https://www.dropbox.com/lp/developers/reference/paper-migration-guide> for
+// migration information.
 // Deprecated:
 func (dbx *apiImpl) FoldersCreateContext(ctx context.Context, arg *PaperFolderCreateArg) (res *PaperFolderCreateResult, err error) {
 	log.Printf("WARNING: API `FoldersCreate` is deprecated")

--- a/v6/dropbox/riviera/client.go
+++ b/v6/dropbox/riviera/client.go
@@ -39,6 +39,12 @@ type Client interface {
 	// GetMarkdownAsyncCheck : Returns the status or result of specified
 	// get_markdown_async task.
 	GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error)
+	// GetMetadataAsync : Asynchronous file metadata extraction for supported
+	// file formats.
+	GetMetadataAsync(arg *GetMetadataArgs) (res *async.LaunchResultBase, err error)
+	// GetMetadataAsyncCheck : Returns the status or result of specified
+	// get_metadata_async task.
+	GetMetadataAsyncCheck(arg *async.PollArg) (res *GetMetadataAsyncCheckResult, err error)
 	// GetTranscriptAsync : Asynchronous transcript generation for audio and
 	// video files.
 	GetTranscriptAsync(arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error)
@@ -50,17 +56,23 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// GetMarkdownAsyncContext : Asynchronous document-to-markdown conversion for
-	// supported file formats.
+	// GetMarkdownAsyncContext : Asynchronous document-to-markdown conversion
+	// for supported file formats.
 	GetMarkdownAsyncContext(ctx context.Context, arg *GetMarkdownArgs) (res *async.LaunchResultBase, err error)
 	// GetMarkdownAsyncCheckContext : Returns the status or result of specified
 	// get_markdown_async task.
 	GetMarkdownAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error)
-	// GetTranscriptAsyncContext : Asynchronous transcript generation for audio and
-	// video files.
+	// GetMetadataAsyncContext : Asynchronous file metadata extraction for
+	// supported file formats.
+	GetMetadataAsyncContext(ctx context.Context, arg *GetMetadataArgs) (res *async.LaunchResultBase, err error)
+	// GetMetadataAsyncCheckContext : Returns the status or result of specified
+	// get_metadata_async task.
+	GetMetadataAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetMetadataAsyncCheckResult, err error)
+	// GetTranscriptAsyncContext : Asynchronous transcript generation for audio
+	// and video files.
 	GetTranscriptAsyncContext(ctx context.Context, arg *GetTranscriptArgs) (res *async.LaunchResultBase, err error)
-	// GetTranscriptAsyncCheckContext : Returns the status or result of specified
-	// get_transcript_async task.
+	// GetTranscriptAsyncCheckContext : Returns the status or result of
+	// specified get_transcript_async task.
 	GetTranscriptAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetTranscriptAsyncCheckResult, err error)
 }
 
@@ -152,6 +164,94 @@ func (dbx *apiImpl) GetMarkdownAsyncCheckContext(ctx context.Context, arg *async
 
 func (dbx *apiImpl) GetMarkdownAsyncCheck(arg *async.PollArg) (res *GetMarkdownAsyncCheckResult, err error) {
 	return dbx.GetMarkdownAsyncCheckContext(context.Background(), arg)
+}
+
+// GetMetadataAsyncAPIError is an error-wrapper for the get_metadata_async route
+type GetMetadataAsyncAPIError struct {
+	dropbox.APIError
+	EndpointError struct{} `json:"error"`
+}
+
+// GetMetadataAsyncContext : Asynchronous file metadata extraction for supported
+// file formats.
+func (dbx *apiImpl) GetMetadataAsyncContext(ctx context.Context, arg *GetMetadataArgs) (res *async.LaunchResultBase, err error) {
+	req := dropbox.Request{
+		Host:         "api",
+		Namespace:    "riviera",
+		Route:        "get_metadata_async",
+		Auth:         "app, user",
+		Style:        "rpc",
+		Arg:          arg,
+		ExtraHeaders: nil,
+	}
+
+	var resp []byte
+	var respBody io.ReadCloser
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
+	if err != nil {
+		var appErr GetMetadataAsyncAPIError
+		err = auth.ParseError(err, &appErr)
+		if errors.Is(err, &appErr) {
+			err = appErr
+		}
+		return
+	}
+
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return
+	}
+
+	_ = respBody
+	return
+}
+
+func (dbx *apiImpl) GetMetadataAsync(arg *GetMetadataArgs) (res *async.LaunchResultBase, err error) {
+	return dbx.GetMetadataAsyncContext(context.Background(), arg)
+}
+
+// GetMetadataAsyncCheckAPIError is an error-wrapper for the get_metadata_async/check route
+type GetMetadataAsyncCheckAPIError struct {
+	dropbox.APIError
+	EndpointError *async.PollError `json:"error"`
+}
+
+// GetMetadataAsyncCheckContext : Returns the status or result of specified
+// get_metadata_async task.
+func (dbx *apiImpl) GetMetadataAsyncCheckContext(ctx context.Context, arg *async.PollArg) (res *GetMetadataAsyncCheckResult, err error) {
+	req := dropbox.Request{
+		Host:         "api",
+		Namespace:    "riviera",
+		Route:        "get_metadata_async/check",
+		Auth:         "app, user",
+		Style:        "rpc",
+		Arg:          arg,
+		ExtraHeaders: nil,
+	}
+
+	var resp []byte
+	var respBody io.ReadCloser
+	resp, respBody, err = (*dropbox.Context)(dbx).ExecuteContext(ctx, req, nil)
+	if err != nil {
+		var appErr GetMetadataAsyncCheckAPIError
+		err = auth.ParseError(err, &appErr)
+		if errors.Is(err, &appErr) {
+			err = appErr
+		}
+		return
+	}
+
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return
+	}
+
+	_ = respBody
+	return
+}
+
+func (dbx *apiImpl) GetMetadataAsyncCheck(arg *async.PollArg) (res *GetMetadataAsyncCheckResult, err error) {
+	return dbx.GetMetadataAsyncCheckContext(context.Background(), arg)
 }
 
 // GetTranscriptAsyncAPIError is an error-wrapper for the get_transcript_async route

--- a/v6/dropbox/riviera/types.go
+++ b/v6/dropbox/riviera/types.go
@@ -27,6 +27,240 @@ import (
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 )
 
+// ApiExifGpsMetadata : GPS coordinates and related tags extracted from image
+// EXIF data. Fields are populated on a best-effort basis and may be empty when
+// absent from the source file.
+type ApiExifGpsMetadata struct {
+	// Latitude : Latitude / longitude in decimal degrees (positive = N/E,
+	// negative = S/W).
+	Latitude float32 `json:"latitude"`
+	// Longitude : has no documentation (yet)
+	Longitude float32 `json:"longitude"`
+	// Altitude : Altitude in meters, as reported by the source (string to
+	// preserve the original representation, which may include a reference
+	// direction).
+	Altitude string `json:"altitude"`
+	// Timestamp : Timestamp / datestamp of the GPS fix, in the EXIF-provided
+	// format.
+	Timestamp string `json:"timestamp"`
+	// Datestamp : has no documentation (yet)
+	Datestamp string `json:"datestamp"`
+}
+
+// NewApiExifGpsMetadata returns a new ApiExifGpsMetadata instance
+func NewApiExifGpsMetadata() *ApiExifGpsMetadata {
+	s := new(ApiExifGpsMetadata)
+	s.Latitude = 0.0
+	s.Longitude = 0.0
+	s.Altitude = ""
+	s.Timestamp = ""
+	s.Datestamp = ""
+	return s
+}
+
+// ApiExifMetadata : Image EXIF metadata. Mirrors the useful subset of the
+// internal `riviera.ExifMetadata` message. Fields are best-effort and may be
+// empty.
+type ApiExifMetadata struct {
+	// ImageWidth : has no documentation (yet)
+	ImageWidth uint32 `json:"image_width"`
+	// ImageHeight : has no documentation (yet)
+	ImageHeight uint32 `json:"image_height"`
+	// CameraMake : has no documentation (yet)
+	CameraMake string `json:"camera_make"`
+	// CameraModel : has no documentation (yet)
+	CameraModel string `json:"camera_model"`
+	// LensModel : has no documentation (yet)
+	LensModel string `json:"lens_model"`
+	// DateTimeOriginal : Capture time in the EXIF-provided format (local time
+	// of the camera).
+	DateTimeOriginal string `json:"date_time_original"`
+	// OffsetTimeOriginal : Timezone offset for `date_time_original`, e.g.
+	// "+09:00".
+	OffsetTimeOriginal string `json:"offset_time_original"`
+	// Orientation : EXIF orientation value (1-8). See the EXIF spec; 1 is the
+	// normal upright orientation.
+	Orientation uint32 `json:"orientation"`
+	// ExposureTime : fraction in string form, e.g. "1/250"
+	ExposureTime string `json:"exposure_time"`
+	// ApertureValue : has no documentation (yet)
+	ApertureValue float64 `json:"aperture_value"`
+	// IsoSpeed : has no documentation (yet)
+	IsoSpeed uint32 `json:"iso_speed"`
+	// FocalLength : e.g. "26.0 mm"
+	FocalLength string `json:"focal_length"`
+	// Megapixels : has no documentation (yet)
+	Megapixels float64 `json:"megapixels"`
+	// Artist : has no documentation (yet)
+	Artist string `json:"artist"`
+	// Copyright : has no documentation (yet)
+	Copyright string `json:"copyright"`
+	// GpsMetadata : has no documentation (yet)
+	GpsMetadata *ApiExifGpsMetadata `json:"gps_metadata,omitempty"`
+}
+
+// NewApiExifMetadata returns a new ApiExifMetadata instance
+func NewApiExifMetadata() *ApiExifMetadata {
+	s := new(ApiExifMetadata)
+	s.ImageWidth = 0
+	s.ImageHeight = 0
+	s.CameraMake = ""
+	s.CameraModel = ""
+	s.LensModel = ""
+	s.DateTimeOriginal = ""
+	s.OffsetTimeOriginal = ""
+	s.Orientation = 0
+	s.ExposureTime = ""
+	s.ApertureValue = 0.0
+	s.IsoSpeed = 0
+	s.FocalLength = ""
+	s.Megapixels = 0.0
+	s.Artist = ""
+	s.Copyright = ""
+	return s
+}
+
+// ApiMediaMetadata : Audio/video container and per-stream metadata. Mirrors the
+// useful subset of the internal `riviera.MediaMetadata` message.
+type ApiMediaMetadata struct {
+	// BitrateBps : has no documentation (yet)
+	BitrateBps uint64 `json:"bitrate_bps"`
+	// DurationS : has no documentation (yet)
+	DurationS float64 `json:"duration_s"`
+	// CreationTime : Container-level creation time, when present.
+	CreationTime string `json:"creation_time"`
+	// Streams : has no documentation (yet)
+	Streams []*ApiMediaStream `json:"streams,omitempty"`
+}
+
+// NewApiMediaMetadata returns a new ApiMediaMetadata instance
+func NewApiMediaMetadata() *ApiMediaMetadata {
+	s := new(ApiMediaMetadata)
+	s.BitrateBps = 0
+	s.DurationS = 0.0
+	s.CreationTime = ""
+	return s
+}
+
+// ApiMediaStream : A single audio or video stream within a media file.
+type ApiMediaStream struct {
+	// Index : has no documentation (yet)
+	Index uint32 `json:"index"`
+	// CodecType : "audio", "video", etc.
+	CodecType string `json:"codec_type"`
+	// CodecName : has no documentation (yet)
+	CodecName string `json:"codec_name"`
+	// BitrateBps : has no documentation (yet)
+	BitrateBps uint64 `json:"bitrate_bps"`
+	// DurationS : has no documentation (yet)
+	DurationS float64 `json:"duration_s"`
+	// Width : Video-specific fields (zero / empty for audio streams).
+	Width uint32 `json:"width"`
+	// Height : has no documentation (yet)
+	Height uint32 `json:"height"`
+	// FramesPerSecond : has no documentation (yet)
+	FramesPerSecond float64 `json:"frames_per_second"`
+	// Rotation : has no documentation (yet)
+	Rotation int32 `json:"rotation"`
+	// DisplayAspectRatio : e.g. "16:9"
+	DisplayAspectRatio string `json:"display_aspect_ratio"`
+	// Channels : Audio-specific fields (zero / empty for video streams).
+	Channels uint32 `json:"channels"`
+	// ChannelLayout : has no documentation (yet)
+	ChannelLayout string `json:"channel_layout"`
+	// SampleRateS : has no documentation (yet)
+	SampleRateS uint64 `json:"sample_rate_s"`
+	// LanguageIso639 : ISO 639 language code for the stream, when present.
+	LanguageIso639 string `json:"language_iso_639"`
+}
+
+// NewApiMediaStream returns a new ApiMediaStream instance
+func NewApiMediaStream() *ApiMediaStream {
+	s := new(ApiMediaStream)
+	s.Index = 0
+	s.CodecType = ""
+	s.CodecName = ""
+	s.BitrateBps = 0
+	s.DurationS = 0.0
+	s.Width = 0
+	s.Height = 0
+	s.FramesPerSecond = 0.0
+	s.Rotation = 0
+	s.DisplayAspectRatio = ""
+	s.Channels = 0
+	s.ChannelLayout = ""
+	s.SampleRateS = 0
+	s.LanguageIso639 = ""
+	return s
+}
+
+// ApiOfficeMetadata : MS Office document metadata. Mirrors the internal
+// `riviera.OfficeMetadata` message. Some fields apply only to specific document
+// types (e.g. `slides` for PowerPoint, `words`/`pages` for Word).
+type ApiOfficeMetadata struct {
+	// FileType : has no documentation (yet)
+	FileType *OfficeFileType `json:"file_type"`
+	// Creator : has no documentation (yet)
+	Creator string `json:"creator"`
+	// Company : has no documentation (yet)
+	Company string `json:"company"`
+	// Title : has no documentation (yet)
+	Title string `json:"title"`
+	// Subject : has no documentation (yet)
+	Subject string `json:"subject"`
+	// Keywords : has no documentation (yet)
+	Keywords string `json:"keywords"`
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+	// TotalEditTimeMinutes : has no documentation (yet)
+	TotalEditTimeMinutes uint32 `json:"total_edit_time_minutes"`
+	// Pages : Word only.
+	Pages uint32 `json:"pages"`
+	// Words : has no documentation (yet)
+	Words uint32 `json:"words"`
+	// Slides : PowerPoint only.
+	Slides uint32 `json:"slides"`
+	// RevisionNumber : has no documentation (yet)
+	RevisionNumber string `json:"revision_number"`
+}
+
+// NewApiOfficeMetadata returns a new ApiOfficeMetadata instance
+func NewApiOfficeMetadata() *ApiOfficeMetadata {
+	s := new(ApiOfficeMetadata)
+	s.FileType = &OfficeFileType{Tagged: dropbox.Tagged{Tag: "office_filetype_unknown"}}
+	s.Creator = ""
+	s.Company = ""
+	s.Title = ""
+	s.Subject = ""
+	s.Keywords = ""
+	s.Description = ""
+	s.TotalEditTimeMinutes = 0
+	s.Pages = 0
+	s.Words = 0
+	s.Slides = 0
+	s.RevisionNumber = ""
+	return s
+}
+
+// ApiPdfMetadata : PDF document metadata.
+type ApiPdfMetadata struct {
+	// Pages : has no documentation (yet)
+	Pages uint32 `json:"pages"`
+	// Width : Width / height of the first page, in PDF points.
+	Width uint32 `json:"width"`
+	// Height : has no documentation (yet)
+	Height uint32 `json:"height"`
+}
+
+// NewApiPdfMetadata returns a new ApiPdfMetadata instance
+func NewApiPdfMetadata() *ApiPdfMetadata {
+	s := new(ApiPdfMetadata)
+	s.Pages = 0
+	s.Width = 0
+	s.Height = 0
+	return s
+}
+
 // ApiStructuredTranscript : Structured transcript for APIv2
 type ApiStructuredTranscript struct {
 	// Segments : has no documentation (yet)
@@ -81,6 +315,8 @@ const (
 	ContentApiV2ErrorLinkDownloadDisabledError   = "link_download_disabled_error"
 	ContentApiV2ErrorSharedLinkPasswordProtected = "shared_link_password_protected"
 	ContentApiV2ErrorLimitExceededError          = "limit_exceeded_error"
+	ContentApiV2ErrorNotFoundError               = "not_found_error"
+	ContentApiV2ErrorIsAFolderError              = "is_a_folder_error"
 	ContentApiV2ErrorOther                       = "other"
 )
 
@@ -289,6 +525,112 @@ func NewGetMarkdownResult() *GetMarkdownResult {
 	return s
 }
 
+// GetMetadataArgs : Arguments for the asynchronous `get_metadata_async` route.
+// Exactly one of `file_id`, `path`, or `url` must be supplied via
+// `file_id_or_url` to identify the file whose metadata should be extracted.
+type GetMetadataArgs struct {
+	// FileIdOrUrl : Identifier of the file to extract metadata from. Callers
+	// must set exactly one of the oneof variants: - file_id: a Dropbox-issued
+	// file id (format: "id:<id>") for a file the authenticated user has access
+	// to. - path: an absolute Dropbox path, e.g. "/folder/photo.jpg". - url:
+	// either a Dropbox shared link (www.dropbox.com) or an external HTTPS URL
+	// pointing to a supported file. - Dropbox shared links are resolved
+	// internally using the caller's authenticated identity and the link's
+	// visibility / download settings. They therefore require an authenticated
+	// user context (anonymous `url` requests against Dropbox links are rejected
+	// with an `ACCESS_ERROR`). Links protected by a password are rejected with
+	// `shared_link_password_protected`; links with downloads disabled are
+	// rejected with `link_download_disabled_error`. - External URLs are fetched
+	// over HTTPS through the backend's egress proxy and must point at a
+	// supported file extension. The kind of metadata returned is determined by
+	// the file type: image files return EXIF metadata, audio/video files return
+	// media metadata, PDFs return PDF metadata, and MS Office documents (docx,
+	// pptx, xlsx) return Office metadata. Requests against unsupported formats
+	// return `unsupported_format_error`.
+	FileIdOrUrl *FileIdOrUrl `json:"file_id_or_url,omitempty"`
+}
+
+// NewGetMetadataArgs returns a new GetMetadataArgs instance
+func NewGetMetadataArgs() *GetMetadataArgs {
+	s := new(GetMetadataArgs)
+	return s
+}
+
+// GetMetadataAsyncCheckResult : Result type for EventBus async check - must end
+// in "CheckResult"
+type GetMetadataAsyncCheckResult struct {
+	dropbox.Tagged
+	// Complete : has no documentation (yet)
+	Complete *GetMetadataResult `json:"complete,omitempty"`
+	// Failed : has no documentation (yet)
+	Failed *GetMetadataAsyncError `json:"failed,omitempty"`
+}
+
+// Valid tag values for GetMetadataAsyncCheckResult
+const (
+	GetMetadataAsyncCheckResultInProgress = "in_progress"
+	GetMetadataAsyncCheckResultComplete   = "complete"
+	GetMetadataAsyncCheckResultFailed     = "failed"
+	GetMetadataAsyncCheckResultOther      = "other"
+)
+
+// UnmarshalJSON deserializes into a GetMetadataAsyncCheckResult instance
+func (u *GetMetadataAsyncCheckResult) UnmarshalJSON(body []byte) error {
+	type wrap struct {
+		dropbox.Tagged
+	}
+	var w wrap
+	var err error
+	if err = json.Unmarshal(body, &w); err != nil {
+		return err
+	}
+	u.Tag = w.Tag
+	switch u.Tag {
+	case "complete":
+		if err = json.Unmarshal(body, &u.Complete); err != nil {
+			return err
+		}
+
+	case "failed":
+		if err = json.Unmarshal(body, &u.Failed); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+// GetMetadataAsyncError : has no documentation (yet)
+type GetMetadataAsyncError struct {
+	// ErrorCode : has no documentation (yet)
+	ErrorCode *ErrorCode `json:"error_code"`
+	// ErrorDetails : has no documentation (yet)
+	ErrorDetails *MetadataExtractionApiV2Error `json:"error_details,omitempty"`
+}
+
+// NewGetMetadataAsyncError returns a new GetMetadataAsyncError instance
+func NewGetMetadataAsyncError() *GetMetadataAsyncError {
+	s := new(GetMetadataAsyncError)
+	s.ErrorCode = &ErrorCode{Tagged: dropbox.Tagged{Tag: "unknown_error"}}
+	return s
+}
+
+// GetMetadataResult : has no documentation (yet)
+type GetMetadataResult struct {
+	// MetadataType : The kind of metadata that was extracted for the requested
+	// file. Callers should read the matching field of the `metadata` oneof.
+	MetadataType *MetadataType `json:"metadata_type"`
+	// Metadata : has no documentation (yet)
+	Metadata *MetadataUnion `json:"metadata,omitempty"`
+}
+
+// NewGetMetadataResult returns a new GetMetadataResult instance
+func NewGetMetadataResult() *GetMetadataResult {
+	s := new(GetMetadataResult)
+	s.MetadataType = &MetadataType{Tagged: dropbox.Tagged{Tag: "metadata_type_unknown"}}
+	return s
+}
+
 // GetTranscriptArgs : Arguments for the asynchronous `get_transcript_async`
 // route. Exactly one of `file_id`, `path`, or `url` must be supplied via
 // `file_id_or_url` to identify the audio or video asset to transcribe.
@@ -321,10 +663,10 @@ type GetTranscriptArgs struct {
 	// these fillers are stripped. Unrecognized tokens are ignored. Leave empty
 	// to use the default filtering behavior.
 	IncludedSpecialWords string `json:"included_special_words"`
-	// AudioLanguage : Optional BCP-47 language tag hinting the spoken language
-	// of the source audio (e.g. "en-US", "ja-JP"). When empty, the service
-	// auto-detects the language; supplying a hint improves accuracy and latency
-	// for short or ambiguous clips. Unsupported languages fall back to
+	// AudioLanguage : Optional ISO 639-1 two-letter language code hinting the
+	// spoken language of the source audio (e.g. "en", "ja"). When empty, the
+	// service auto-detects the language; supplying a hint improves accuracy and
+	// latency for short or ambiguous clips. Unsupported languages fall back to
 	// auto-detection.
 	AudioLanguage string `json:"audio_language"`
 }
@@ -430,6 +772,8 @@ const (
 	MarkdownConversionApiV2ErrorSharedLinkPasswordProtected = "shared_link_password_protected"
 	MarkdownConversionApiV2ErrorLimitExceededError          = "limit_exceeded_error"
 	MarkdownConversionApiV2ErrorConversionFailureError      = "conversion_failure_error"
+	MarkdownConversionApiV2ErrorNotFoundError               = "not_found_error"
+	MarkdownConversionApiV2ErrorIsAFolderError              = "is_a_folder_error"
 	MarkdownConversionApiV2ErrorOther                       = "other"
 )
 
@@ -472,6 +816,86 @@ func NewMediaDurationError() *MediaDurationError {
 	return s
 }
 
+// MetadataExtractionApiV2Error : has no documentation (yet)
+type MetadataExtractionApiV2Error struct {
+	dropbox.Tagged
+	// ServerError : has no documentation (yet)
+	ServerError string `json:"server_error,omitempty"`
+	// UserError : has no documentation (yet)
+	UserError string `json:"user_error,omitempty"`
+}
+
+// Valid tag values for MetadataExtractionApiV2Error
+const (
+	MetadataExtractionApiV2ErrorServerError                 = "server_error"
+	MetadataExtractionApiV2ErrorUserError                   = "user_error"
+	MetadataExtractionApiV2ErrorUnsupportedFormatError      = "unsupported_format_error"
+	MetadataExtractionApiV2ErrorLinkDownloadDisabledError   = "link_download_disabled_error"
+	MetadataExtractionApiV2ErrorSharedLinkPasswordProtected = "shared_link_password_protected"
+	MetadataExtractionApiV2ErrorLimitExceededError          = "limit_exceeded_error"
+	MetadataExtractionApiV2ErrorConversionFailureError      = "conversion_failure_error"
+	MetadataExtractionApiV2ErrorNotFoundError               = "not_found_error"
+	MetadataExtractionApiV2ErrorIsAFolderError              = "is_a_folder_error"
+	MetadataExtractionApiV2ErrorOther                       = "other"
+)
+
+// UnmarshalJSON deserializes into a MetadataExtractionApiV2Error instance
+func (u *MetadataExtractionApiV2Error) UnmarshalJSON(body []byte) error {
+	type wrap struct {
+		dropbox.Tagged
+		// ServerError : has no documentation (yet)
+		ServerError string `json:"server_error,omitempty"`
+		// UserError : has no documentation (yet)
+		UserError string `json:"user_error,omitempty"`
+	}
+	var w wrap
+	var err error
+	if err = json.Unmarshal(body, &w); err != nil {
+		return err
+	}
+	u.Tag = w.Tag
+	switch u.Tag {
+	case "server_error":
+		u.ServerError = w.ServerError
+
+	case "user_error":
+		u.UserError = w.UserError
+
+	}
+	return nil
+}
+
+// MetadataType : Which metadata variant is populated in a `GetMetadataResult`,
+// derived from the file type.
+type MetadataType struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MetadataType
+const (
+	MetadataTypeMetadataTypeUnknown = "metadata_type_unknown"
+	MetadataTypeMetadataTypeExif    = "metadata_type_exif"
+	MetadataTypeMetadataTypeMedia   = "metadata_type_media"
+	MetadataTypeMetadataTypePdf     = "metadata_type_pdf"
+	MetadataTypeMetadataTypeOffice  = "metadata_type_office"
+	MetadataTypeOther               = "other"
+)
+
+// OfficeFileType : The kind of MS Office document that produced an
+// `ApiOfficeMetadata` result.
+type OfficeFileType struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for OfficeFileType
+const (
+	OfficeFileTypeOfficeFiletypeUnknown    = "office_filetype_unknown"
+	OfficeFileTypeOfficeFiletypeWord       = "office_filetype_word"
+	OfficeFileTypeOfficeFiletypePowerpoint = "office_filetype_powerpoint"
+	OfficeFileTypeOfficeFiletypeExcel      = "office_filetype_excel"
+	OfficeFileTypeOther                    = "other"
+)
+
 // TimestampLevel : has no documentation (yet)
 type TimestampLevel struct {
 	dropbox.Tagged
@@ -484,3 +908,62 @@ const (
 	TimestampLevelWord     = "word"
 	TimestampLevelOther    = "other"
 )
+
+// MetadataUnion : Exactly one variant is populated, corresponding to
+// `metadata_type`.
+type MetadataUnion struct {
+	dropbox.Tagged
+	// Exif : has no documentation (yet)
+	Exif *ApiExifMetadata `json:"exif,omitempty"`
+	// Media : has no documentation (yet)
+	Media *ApiMediaMetadata `json:"media,omitempty"`
+	// Pdf : has no documentation (yet)
+	Pdf *ApiPdfMetadata `json:"pdf,omitempty"`
+	// Office : has no documentation (yet)
+	Office *ApiOfficeMetadata `json:"office,omitempty"`
+}
+
+// Valid tag values for MetadataUnion
+const (
+	MetadataUnionExif   = "exif"
+	MetadataUnionMedia  = "media"
+	MetadataUnionPdf    = "pdf"
+	MetadataUnionOffice = "office"
+	MetadataUnionOther  = "other"
+)
+
+// UnmarshalJSON deserializes into a MetadataUnion instance
+func (u *MetadataUnion) UnmarshalJSON(body []byte) error {
+	type wrap struct {
+		dropbox.Tagged
+	}
+	var w wrap
+	var err error
+	if err = json.Unmarshal(body, &w); err != nil {
+		return err
+	}
+	u.Tag = w.Tag
+	switch u.Tag {
+	case "exif":
+		if err = json.Unmarshal(body, &u.Exif); err != nil {
+			return err
+		}
+
+	case "media":
+		if err = json.Unmarshal(body, &u.Media); err != nil {
+			return err
+		}
+
+	case "pdf":
+		if err = json.Unmarshal(body, &u.Pdf); err != nil {
+			return err
+		}
+
+	case "office":
+		if err = json.Unmarshal(body, &u.Office); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/v6/dropbox/riviera/types_test.go
+++ b/v6/dropbox/riviera/types_test.go
@@ -1,0 +1,42 @@
+package riviera_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/riviera"
+)
+
+func TestMetadataUnionIsExported(t *testing.T) {
+	metadata := &riviera.MetadataUnion{
+		Tagged: dropbox.Tagged{Tag: riviera.MetadataUnionExif},
+		Exif:   riviera.NewApiExifMetadata(),
+	}
+	result := &riviera.GetMetadataResult{Metadata: metadata}
+	if result.Metadata.Exif == nil {
+		t.Fatal("expected EXIF metadata")
+	}
+}
+
+func TestMetadataUnionUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"metadata_type": {".tag": "metadata_type_exif"},
+		"metadata": {".tag": "exif", "image_width": 640, "image_height": 480}
+	}`)
+
+	var result riviera.GetMetadataResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Metadata == nil || result.Metadata.Tag != riviera.MetadataUnionExif {
+		t.Fatalf("unexpected metadata union: %#v", result.Metadata)
+	}
+	if result.Metadata.Exif == nil {
+		t.Fatal("expected EXIF metadata")
+	}
+	if result.Metadata.Exif.ImageWidth != 640 || result.Metadata.Exif.ImageHeight != 480 {
+		t.Fatalf("unexpected EXIF dimensions: %dx%d",
+			result.Metadata.Exif.ImageWidth, result.Metadata.Exif.ImageHeight)
+	}
+}

--- a/v6/dropbox/sdk.go
+++ b/v6/dropbox/sdk.go
@@ -42,7 +42,7 @@ const (
 	hostContent   = "content"
 	hostNotify    = "notify"
 	sdkVersion    = "6.4.0"
-	specVersion   = "b5f7ddd"
+	specVersion   = "7e5f668"
 )
 
 // Version returns the current SDK version and API Spec version

--- a/v6/dropbox/sharing/client.go
+++ b/v6/dropbox/sharing/client.go
@@ -219,30 +219,30 @@ type ContextClient interface {
 	Client
 	// AddFileMemberContext : Adds specified members to a file.
 	AddFileMemberContext(ctx context.Context, arg *AddFileMemberArgs) (res []*FileMemberActionResult, err error)
-	// AddFolderMemberContext : Allows an owner or editor (if the ACL update policy
-	// allows) of a shared folder to add another member. For the new member to
-	// get access to all the functionality for this folder, you will need to
-	// call `mountFolder` on their behalf.
+	// AddFolderMemberContext : Allows an owner or editor (if the ACL update
+	// policy allows) of a shared folder to add another member. For the new
+	// member to get access to all the functionality for this folder, you will
+	// need to call `mountFolder` on their behalf.
 	AddFolderMemberContext(ctx context.Context, arg *AddFolderMemberArg) (err error)
 	// CheckJobStatusContext : Returns the status of an asynchronous job.
 	CheckJobStatusContext(ctx context.Context, arg *async.PollArg) (res *JobStatus, err error)
-	// CheckRemoveMemberJobStatusContext : Returns the status of an asynchronous job
-	// for sharing a folder.
+	// CheckRemoveMemberJobStatusContext : Returns the status of an asynchronous
+	// job for sharing a folder.
 	CheckRemoveMemberJobStatusContext(ctx context.Context, arg *async.PollArg) (res *RemoveMemberJobStatus, err error)
-	// CheckShareJobStatusContext : Returns the status of an asynchronous job for
-	// sharing a folder.
+	// CheckShareJobStatusContext : Returns the status of an asynchronous job
+	// for sharing a folder.
 	CheckShareJobStatusContext(ctx context.Context, arg *async.PollArg) (res *ShareFolderJobStatus, err error)
-	// CreateSharedLinkContext : Create a shared link. If a shared link already exists
-	// for the given path, that link is returned. Previously, it was technically
-	// possible to break a shared link by moving or renaming the corresponding
-	// file or folder. In the future, this will no longer be the case, so your
-	// app shouldn't rely on this behavior. Instead, if your app needs to revoke
-	// a shared link, use revoke_shared_link. DEPRECATED: Use
+	// CreateSharedLinkContext : Create a shared link. If a shared link already
+	// exists for the given path, that link is returned. Previously, it was
+	// technically possible to break a shared link by moving or renaming the
+	// corresponding file or folder. In the future, this will no longer be the
+	// case, so your app shouldn't rely on this behavior. Instead, if your app
+	// needs to revoke a shared link, use revoke_shared_link. DEPRECATED: Use
 	// create_shared_link_with_settings instead.
 	// Deprecated:
 	CreateSharedLinkContext(ctx context.Context, arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error)
-	// CreateSharedLinkWithSettingsContext : Create a shared link with custom settings.
-	// If no settings are given then the default visibility is
+	// CreateSharedLinkWithSettingsContext : Create a shared link with custom
+	// settings. If no settings are given then the default visibility is
 	// RequestedVisibility.public (The resolved visibility, though, may depend
 	// on other aspects such as team and shared folder settings).
 	CreateSharedLinkWithSettingsContext(ctx context.Context, arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error)
@@ -250,24 +250,25 @@ type ContextClient interface {
 	GetFileMetadataContext(ctx context.Context, arg *GetFileMetadataArg) (res *SharedFileMetadata, err error)
 	// GetFileMetadataBatchContext : Returns shared file metadata.
 	GetFileMetadataBatchContext(ctx context.Context, arg *GetFileMetadataBatchArg) (res []*GetFileMetadataBatchResult, err error)
-	// GetFolderMetadataContext : Returns shared folder metadata by its folder ID.
+	// GetFolderMetadataContext : Returns shared folder metadata by its folder
+	// ID.
 	GetFolderMetadataContext(ctx context.Context, arg *GetMetadataArgs) (res *SharedFolderMetadata, err error)
 	// GetSharedLinkFileContext : Download the shared link's file from a user's
 	// Dropbox. This is a download-style endpoint that returns the file content.
 	GetSharedLinkFileContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, content io.ReadCloser, err error)
 	// GetSharedLinkMetadataContext : Get the shared link's metadata.
 	GetSharedLinkMetadataContext(ctx context.Context, arg *GetSharedLinkMetadataArg) (res IsSharedLinkMetadata, err error)
-	// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This endpoint
-	// will be retired in October 2026. Returns a list of `LinkMetadata` objects
-	// for this user, including collection links. If no path is given, returns a
-	// list of all shared links for the current user, including collection
-	// links, up to a maximum of 1000 links. If a non-empty path is given,
-	// returns a list of all shared links that allow access to the given path.
-	// Collection links are never returned in this case.
+	// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This
+	// endpoint will be retired in October 2026. Returns a list of
+	// `LinkMetadata` objects for this user, including collection links. If no
+	// path is given, returns a list of all shared links for the current user,
+	// including collection links, up to a maximum of 1000 links. If a non-empty
+	// path is given, returns a list of all shared links that allow access to
+	// the given path. Collection links are never returned in this case.
 	// Deprecated:
 	GetSharedLinksContext(ctx context.Context, arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error)
-	// ListFileMembersContext : Use to obtain the members who have been invited to a
-	// file, both inherited and uninherited members.
+	// ListFileMembersContext : Use to obtain the members who have been invited
+	// to a file, both inherited and uninherited members.
 	ListFileMembersContext(ctx context.Context, arg *ListFileMembersArg) (res *SharedFileMembers, err error)
 	// ListFileMembersBatchContext : Get members of multiple files at once. The
 	// arguments to this route are more limited, and the limit on query result
@@ -279,60 +280,63 @@ type ContextClient interface {
 	// `listFileMembers` or `listFileMembersBatch`, use this to paginate through
 	// all shared file members.
 	ListFileMembersContinueContext(ctx context.Context, arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error)
-	// ListFolderMembersContext : Returns shared folder membership by its folder ID.
+	// ListFolderMembersContext : Returns shared folder membership by its folder
+	// ID.
 	ListFolderMembersContext(ctx context.Context, arg *ListFolderMembersArgs) (res *SharedFolderMembers, err error)
 	// ListFolderMembersContinueContext : Once a cursor has been retrieved from
 	// `listFolderMembers`, use this to paginate through all shared folder
 	// members.
 	ListFolderMembersContinueContext(ctx context.Context, arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error)
-	// ListFoldersContext : Return the list of all shared folders the current user has
-	// access to.
+	// ListFoldersContext : Return the list of all shared folders the current
+	// user has access to.
 	ListFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error)
 	// ListFoldersContinueContext : Once a cursor has been retrieved from
 	// `listFolders`, use this to paginate through all shared folders. The
 	// cursor must come from a previous call to `listFolders` or
 	// `listFoldersContinue`.
 	ListFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error)
-	// ListMountableFoldersContext : Return the list of all shared folders the current
-	// user can mount or unmount.
+	// ListMountableFoldersContext : Return the list of all shared folders the
+	// current user can mount or unmount.
 	ListMountableFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error)
-	// ListMountableFoldersContinueContext : Once a cursor has been retrieved from
-	// `listMountableFolders`, use this to paginate through all mountable shared
-	// folders. The cursor must come from a previous call to
+	// ListMountableFoldersContinueContext : Once a cursor has been retrieved
+	// from `listMountableFolders`, use this to paginate through all mountable
+	// shared folders. The cursor must come from a previous call to
 	// `listMountableFolders` or `listMountableFoldersContinue`.
 	ListMountableFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error)
-	// ListReceivedFilesContext : Returns a list of all files shared with current user.
+	// ListReceivedFilesContext : Returns a list of all files shared with
+	// current user.
 	ListReceivedFilesContext(ctx context.Context, arg *ListFilesArg) (res *ListFilesResult, err error)
 	// ListReceivedFilesContinueContext : Get more results with a cursor from
 	// `listReceivedFiles`.
 	ListReceivedFilesContinueContext(ctx context.Context, arg *ListFilesContinueArg) (res *ListFilesResult, err error)
-	// ListSharedLinksContext : List shared links of this user. If no path is given,
-	// returns a list of all shared links for the current user. For members of
-	// business teams using team space and member folders, returns all shared
-	// links in the team member's home folder unless the team space ID is
-	// specified in the request header. If a non-empty path is given, returns a
-	// list of all shared links that allow access to the given path - direct
-	// links to the given path and links to parent folders of the given path.
-	// Links to parent folders can be suppressed by setting direct_only to true.
+	// ListSharedLinksContext : List shared links of this user. If no path is
+	// given, returns a list of all shared links for the current user. For
+	// members of business teams using team space and member folders, returns
+	// all shared links in the team member's home folder unless the team space
+	// ID is specified in the request header. If a non-empty path is given,
+	// returns a list of all shared links that allow access to the given path -
+	// direct links to the given path and links to parent folders of the given
+	// path. Links to parent folders can be suppressed by setting direct_only to
+	// true.
 	ListSharedLinksContext(ctx context.Context, arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error)
-	// ModifySharedLinkSettingsContext : Modify the shared link's settings. If the
-	// requested visibility conflict with the shared links policy of the team or
-	// the shared folder (in case the linked file is part of a shared folder)
-	// then the LinkPermissions.resolved_visibility of the returned
+	// ModifySharedLinkSettingsContext : Modify the shared link's settings. If
+	// the requested visibility conflict with the shared links policy of the
+	// team or the shared folder (in case the linked file is part of a shared
+	// folder) then the LinkPermissions.resolved_visibility of the returned
 	// SharedLinkMetadata will reflect the actual visibility of the shared link
 	// and the LinkPermissions.requested_visibility will reflect the requested
 	// visibility.
 	ModifySharedLinkSettingsContext(ctx context.Context, arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error)
-	// MountFolderContext : The current user mounts the designated folder. Mount a
-	// shared folder for a user after they have been added as a member. Once
+	// MountFolderContext : The current user mounts the designated folder. Mount
+	// a shared folder for a user after they have been added as a member. Once
 	// mounted, the shared folder will appear in their Dropbox.
 	MountFolderContext(ctx context.Context, arg *MountFolderArg) (res *SharedFolderMetadata, err error)
-	// RelinquishAccessContext : Removes all self-removable access from a file or
-	// folder for the current user. Best-effort and idempotent: attempts to drop
-	// link-visitor associations and explicit ACL membership.
+	// RelinquishAccessContext : Removes all self-removable access from a file
+	// or folder for the current user. Best-effort and idempotent: attempts to
+	// drop link-visitor associations and explicit ACL membership.
 	RelinquishAccessContext(ctx context.Context, arg *RelinquishAccessArg) (res *RelinquishAccessResult, err error)
-	// RelinquishFileMembershipContext : The current user relinquishes their membership
-	// in the designated file.
+	// RelinquishFileMembershipContext : The current user relinquishes their
+	// membership in the designated file.
 	RelinquishFileMembershipContext(ctx context.Context, arg *RelinquishFileMembershipArg) (err error)
 	// RelinquishFolderMembershipContext : The current user relinquishes their
 	// membership in the designated shared folder and will no longer have access
@@ -346,54 +350,54 @@ type ContextClient interface {
 	RemoveFileMemberContext(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberActionIndividualResult, err error)
 	// RemoveFileMember2Context : Removes a specified member from the file.
 	RemoveFileMember2Context(ctx context.Context, arg *RemoveFileMemberArg) (res *FileMemberRemoveActionResult, err error)
-	// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update policy
-	// allows) of a shared folder to remove another member.
+	// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update
+	// policy allows) of a shared folder to remove another member.
 	RemoveFolderMemberContext(ctx context.Context, arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error)
-	// RevokeSharedLinkContext : Revoke a shared link. Note that even after revoking a
-	// shared link to a file, the file may be accessible if there are shared
-	// links leading to any of the file parent folders. To list all shared links
-	// that enable access to a specific file, you can use the list_shared_links
-	// with the file as the ListSharedLinksArg.path argument.
+	// RevokeSharedLinkContext : Revoke a shared link. Note that even after
+	// revoking a shared link to a file, the file may be accessible if there are
+	// shared links leading to any of the file parent folders. To list all
+	// shared links that enable access to a specific file, you can use the
+	// list_shared_links with the file as the ListSharedLinksArg.path argument.
 	RevokeSharedLinkContext(ctx context.Context, arg *RevokeSharedLinkArg) (err error)
-	// SetAccessInheritanceContext : Change the inheritance policy of an existing
-	// Shared Folder. Only permitted for shared folders in a shared team root.
-	// If a `ShareFolderLaunch.async_job_id` is returned, you'll need to call
-	// `checkShareJobStatus` until the action completes to get the metadata for
-	// the folder.
+	// SetAccessInheritanceContext : Change the inheritance policy of an
+	// existing Shared Folder. Only permitted for shared folders in a shared
+	// team root. If a `ShareFolderLaunch.async_job_id` is returned, you'll need
+	// to call `checkShareJobStatus` until the action completes to get the
+	// metadata for the folder.
 	SetAccessInheritanceContext(ctx context.Context, arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error)
-	// ShareFolderContext : Share a folder with collaborators. Most sharing will be
-	// completed synchronously. Large folders will be completed asynchronously.
-	// To make testing the async case repeatable, set
+	// ShareFolderContext : Share a folder with collaborators. Most sharing will
+	// be completed synchronously. Large folders will be completed
+	// asynchronously. To make testing the async case repeatable, set
 	// `ShareFolderArg.force_async`. If a `ShareFolderLaunch.async_job_id` is
 	// returned, you'll need to call `checkShareJobStatus` until the action
 	// completes to get the metadata for the folder.
 	ShareFolderContext(ctx context.Context, arg *ShareFolderArg) (res *ShareFolderLaunch, err error)
-	// TransferFolderContext : Transfer ownership of a shared folder to a member of the
-	// shared folder. User must have `AccessLevel.owner` access to the shared
-	// folder to perform a transfer.
+	// TransferFolderContext : Transfer ownership of a shared folder to a member
+	// of the shared folder. User must have `AccessLevel.owner` access to the
+	// shared folder to perform a transfer.
 	TransferFolderContext(ctx context.Context, arg *TransferFolderArg) (err error)
-	// UnmountFolderContext : The current user unmounts the designated folder. They can
-	// re-mount the folder at a later time using `mountFolder`.
+	// UnmountFolderContext : The current user unmounts the designated folder.
+	// They can re-mount the folder at a later time using `mountFolder`.
 	UnmountFolderContext(ctx context.Context, arg *UnmountFolderArg) (err error)
 	// UnshareFileContext : Remove all members from this file. Does not remove
 	// inherited members.
 	UnshareFileContext(ctx context.Context, arg *UnshareFileArg) (err error)
-	// UnshareFolderContext : Allows a shared folder owner to unshare the folder.
-	// Unshare will not work in following cases: The shared folder contains
-	// shared folders OR the shared folder is inside another shared folder.
-	// You'll need to call `checkJobStatus` to determine if the action has
-	// completed successfully.
+	// UnshareFolderContext : Allows a shared folder owner to unshare the
+	// folder. Unshare will not work in following cases: The shared folder
+	// contains shared folders OR the shared folder is inside another shared
+	// folder. You'll need to call `checkJobStatus` to determine if the action
+	// has completed successfully.
 	UnshareFolderContext(ctx context.Context, arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error)
 	// UpdateFileMemberContext : Changes a member's access on a shared file.
 	UpdateFileMemberContext(ctx context.Context, arg *UpdateFileMemberArgs) (res *MemberAccessLevelResult, err error)
 	// UpdateFilePolicyContext : Update the viewer info policy of a file.
 	UpdateFilePolicyContext(ctx context.Context, arg *UpdateFilePolicyArg) (res *SharedFileMetadata, err error)
-	// UpdateFolderMemberContext : Allows an owner or editor of a shared folder to
-	// update another member's permissions.
+	// UpdateFolderMemberContext : Allows an owner or editor of a shared folder
+	// to update another member's permissions.
 	UpdateFolderMemberContext(ctx context.Context, arg *UpdateFolderMemberArg) (res *MemberAccessLevelResult, err error)
-	// UpdateFolderPolicyContext : Update the sharing policies for a shared folder.
-	// User must have `AccessLevel.owner` access to the shared folder to update
-	// its policies.
+	// UpdateFolderPolicyContext : Update the sharing policies for a shared
+	// folder. User must have `AccessLevel.owner` access to the shared folder to
+	// update its policies.
 	UpdateFolderPolicyContext(ctx context.Context, arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error)
 }
 
@@ -449,9 +453,9 @@ type AddFolderMemberAPIError struct {
 }
 
 // AddFolderMemberContext : Allows an owner or editor (if the ACL update policy
-// allows) of a shared folder to add another member. For the new member to
-// get access to all the functionality for this folder, you will need to
-// call `mountFolder` on their behalf.
+// allows) of a shared folder to add another member. For the new member to get
+// access to all the functionality for this folder, you will need to call
+// `mountFolder` on their behalf.
 func (dbx *apiImpl) AddFolderMemberContext(ctx context.Context, arg *AddFolderMemberArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -621,12 +625,12 @@ type CreateSharedLinkAPIError struct {
 	EndpointError *CreateSharedLinkError `json:"error"`
 }
 
-// CreateSharedLinkContext : Create a shared link. If a shared link already exists
-// for the given path, that link is returned. Previously, it was technically
-// possible to break a shared link by moving or renaming the corresponding
-// file or folder. In the future, this will no longer be the case, so your
-// app shouldn't rely on this behavior. Instead, if your app needs to revoke
-// a shared link, use revoke_shared_link. DEPRECATED: Use
+// CreateSharedLinkContext : Create a shared link. If a shared link already
+// exists for the given path, that link is returned. Previously, it was
+// technically possible to break a shared link by moving or renaming the
+// corresponding file or folder. In the future, this will no longer be the case,
+// so your app shouldn't rely on this behavior. Instead, if your app needs to
+// revoke a shared link, use revoke_shared_link. DEPRECATED: Use
 // create_shared_link_with_settings instead.
 // Deprecated:
 func (dbx *apiImpl) CreateSharedLinkContext(ctx context.Context, arg *CreateSharedLinkArg) (res *PathLinkMetadata, err error) {
@@ -673,10 +677,10 @@ type CreateSharedLinkWithSettingsAPIError struct {
 	EndpointError *CreateSharedLinkWithSettingsError `json:"error"`
 }
 
-// CreateSharedLinkWithSettingsContext : Create a shared link with custom settings.
-// If no settings are given then the default visibility is
-// RequestedVisibility.public (The resolved visibility, though, may depend
-// on other aspects such as team and shared folder settings).
+// CreateSharedLinkWithSettingsContext : Create a shared link with custom
+// settings. If no settings are given then the default visibility is
+// RequestedVisibility.public (The resolved visibility, though, may depend on
+// other aspects such as team and shared folder settings).
 func (dbx *apiImpl) CreateSharedLinkWithSettingsContext(ctx context.Context, arg *CreateSharedLinkWithSettingsArg) (res IsSharedLinkMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -959,13 +963,13 @@ type GetSharedLinksAPIError struct {
 	EndpointError *GetSharedLinksError `json:"error"`
 }
 
-// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This endpoint
-// will be retired in October 2026. Returns a list of `LinkMetadata` objects
-// for this user, including collection links. If no path is given, returns a
-// list of all shared links for the current user, including collection
-// links, up to a maximum of 1000 links. If a non-empty path is given,
-// returns a list of all shared links that allow access to the given path.
-// Collection links are never returned in this case.
+// GetSharedLinksContext : DEPRECATED: Use list_shared_links instead. This
+// endpoint will be retired in October 2026. Returns a list of `LinkMetadata`
+// objects for this user, including collection links. If no path is given,
+// returns a list of all shared links for the current user, including collection
+// links, up to a maximum of 1000 links. If a non-empty path is given, returns a
+// list of all shared links that allow access to the given path. Collection
+// links are never returned in this case.
 // Deprecated:
 func (dbx *apiImpl) GetSharedLinksContext(ctx context.Context, arg *GetSharedLinksArg) (res *GetSharedLinksResult, err error) {
 	log.Printf("WARNING: API `GetSharedLinks` is deprecated")
@@ -1056,10 +1060,10 @@ type ListFileMembersBatchAPIError struct {
 }
 
 // ListFileMembersBatchContext : Get members of multiple files at once. The
-// arguments to this route are more limited, and the limit on query result
-// size per file is more strict. To customize the results more, use the
-// individual file endpoint. Inherited users and groups are not included in
-// the result, and permissions are not returned for this endpoint.
+// arguments to this route are more limited, and the limit on query result size
+// per file is more strict. To customize the results more, use the individual
+// file endpoint. Inherited users and groups are not included in the result, and
+// permissions are not returned for this endpoint.
 func (dbx *apiImpl) ListFileMembersBatchContext(ctx context.Context, arg *ListFileMembersBatchArg) (res []*ListFileMembersBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1103,8 +1107,8 @@ type ListFileMembersContinueAPIError struct {
 }
 
 // ListFileMembersContinueContext : Once a cursor has been retrieved from
-// `listFileMembers` or `listFileMembersBatch`, use this to paginate through
-// all shared file members.
+// `listFileMembers` or `listFileMembersBatch`, use this to paginate through all
+// shared file members.
 func (dbx *apiImpl) ListFileMembersContinueContext(ctx context.Context, arg *ListFileMembersContinueArg) (res *SharedFileMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1191,8 +1195,7 @@ type ListFolderMembersContinueAPIError struct {
 }
 
 // ListFolderMembersContinueContext : Once a cursor has been retrieved from
-// `listFolderMembers`, use this to paginate through all shared folder
-// members.
+// `listFolderMembers`, use this to paginate through all shared folder members.
 func (dbx *apiImpl) ListFolderMembersContinueContext(ctx context.Context, arg *ListFolderMembersContinueArg) (res *SharedFolderMembers, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1235,8 +1238,8 @@ type ListFoldersAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// ListFoldersContext : Return the list of all shared folders the current user has
-// access to.
+// ListFoldersContext : Return the list of all shared folders the current user
+// has access to.
 func (dbx *apiImpl) ListFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1280,9 +1283,8 @@ type ListFoldersContinueAPIError struct {
 }
 
 // ListFoldersContinueContext : Once a cursor has been retrieved from
-// `listFolders`, use this to paginate through all shared folders. The
-// cursor must come from a previous call to `listFolders` or
-// `listFoldersContinue`.
+// `listFolders`, use this to paginate through all shared folders. The cursor
+// must come from a previous call to `listFolders` or `listFoldersContinue`.
 func (dbx *apiImpl) ListFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1325,8 +1327,8 @@ type ListMountableFoldersAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// ListMountableFoldersContext : Return the list of all shared folders the current
-// user can mount or unmount.
+// ListMountableFoldersContext : Return the list of all shared folders the
+// current user can mount or unmount.
 func (dbx *apiImpl) ListMountableFoldersContext(ctx context.Context, arg *ListFoldersArgs) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1371,8 +1373,8 @@ type ListMountableFoldersContinueAPIError struct {
 
 // ListMountableFoldersContinueContext : Once a cursor has been retrieved from
 // `listMountableFolders`, use this to paginate through all mountable shared
-// folders. The cursor must come from a previous call to
-// `listMountableFolders` or `listMountableFoldersContinue`.
+// folders. The cursor must come from a previous call to `listMountableFolders`
+// or `listMountableFoldersContinue`.
 func (dbx *apiImpl) ListMountableFoldersContinueContext(ctx context.Context, arg *ListFoldersContinueArg) (res *ListFoldersResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1415,7 +1417,8 @@ type ListReceivedFilesAPIError struct {
 	EndpointError *SharingUserError `json:"error"`
 }
 
-// ListReceivedFilesContext : Returns a list of all files shared with current user.
+// ListReceivedFilesContext : Returns a list of all files shared with current
+// user.
 func (dbx *apiImpl) ListReceivedFilesContext(ctx context.Context, arg *ListFilesArg) (res *ListFilesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1504,12 +1507,12 @@ type ListSharedLinksAPIError struct {
 
 // ListSharedLinksContext : List shared links of this user. If no path is given,
 // returns a list of all shared links for the current user. For members of
-// business teams using team space and member folders, returns all shared
-// links in the team member's home folder unless the team space ID is
-// specified in the request header. If a non-empty path is given, returns a
-// list of all shared links that allow access to the given path - direct
-// links to the given path and links to parent folders of the given path.
-// Links to parent folders can be suppressed by setting direct_only to true.
+// business teams using team space and member folders, returns all shared links
+// in the team member's home folder unless the team space ID is specified in the
+// request header. If a non-empty path is given, returns a list of all shared
+// links that allow access to the given path - direct links to the given path
+// and links to parent folders of the given path. Links to parent folders can be
+// suppressed by setting direct_only to true.
 func (dbx *apiImpl) ListSharedLinksContext(ctx context.Context, arg *ListSharedLinksArg) (res *ListSharedLinksResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1553,12 +1556,11 @@ type ModifySharedLinkSettingsAPIError struct {
 }
 
 // ModifySharedLinkSettingsContext : Modify the shared link's settings. If the
-// requested visibility conflict with the shared links policy of the team or
-// the shared folder (in case the linked file is part of a shared folder)
-// then the LinkPermissions.resolved_visibility of the returned
-// SharedLinkMetadata will reflect the actual visibility of the shared link
-// and the LinkPermissions.requested_visibility will reflect the requested
-// visibility.
+// requested visibility conflict with the shared links policy of the team or the
+// shared folder (in case the linked file is part of a shared folder) then the
+// LinkPermissions.resolved_visibility of the returned SharedLinkMetadata will
+// reflect the actual visibility of the shared link and the
+// LinkPermissions.requested_visibility will reflect the requested visibility.
 func (dbx *apiImpl) ModifySharedLinkSettingsContext(ctx context.Context, arg *ModifySharedLinkSettingsArgs) (res IsSharedLinkMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1699,8 +1701,8 @@ type RelinquishFileMembershipAPIError struct {
 	EndpointError *RelinquishFileMembershipError `json:"error"`
 }
 
-// RelinquishFileMembershipContext : The current user relinquishes their membership
-// in the designated file.
+// RelinquishFileMembershipContext : The current user relinquishes their
+// membership in the designated file.
 func (dbx *apiImpl) RelinquishFileMembershipContext(ctx context.Context, arg *RelinquishFileMembershipArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1740,10 +1742,10 @@ type RelinquishFolderMembershipAPIError struct {
 }
 
 // RelinquishFolderMembershipContext : The current user relinquishes their
-// membership in the designated shared folder and will no longer have access
-// to the folder.  A folder owner cannot relinquish membership in their own
-// folder. This will run synchronously if leave_a_copy is false, and
-// asynchronously if leave_a_copy is true.
+// membership in the designated shared folder and will no longer have access to
+// the folder.  A folder owner cannot relinquish membership in their own folder.
+// This will run synchronously if leave_a_copy is false, and asynchronously if
+// leave_a_copy is true.
 func (dbx *apiImpl) RelinquishFolderMembershipContext(ctx context.Context, arg *RelinquishFolderMembershipArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1876,8 +1878,8 @@ type RemoveFolderMemberAPIError struct {
 	EndpointError *RemoveFolderMemberError `json:"error"`
 }
 
-// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update policy
-// allows) of a shared folder to remove another member.
+// RemoveFolderMemberContext : Allows an owner or editor (if the ACL update
+// policy allows) of a shared folder to remove another member.
 func (dbx *apiImpl) RemoveFolderMemberContext(ctx context.Context, arg *RemoveFolderMemberArg) (res *async.LaunchResultBase, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1920,11 +1922,11 @@ type RevokeSharedLinkAPIError struct {
 	EndpointError *RevokeSharedLinkError `json:"error"`
 }
 
-// RevokeSharedLinkContext : Revoke a shared link. Note that even after revoking a
-// shared link to a file, the file may be accessible if there are shared
-// links leading to any of the file parent folders. To list all shared links
-// that enable access to a specific file, you can use the list_shared_links
-// with the file as the ListSharedLinksArg.path argument.
+// RevokeSharedLinkContext : Revoke a shared link. Note that even after revoking
+// a shared link to a file, the file may be accessible if there are shared links
+// leading to any of the file parent folders. To list all shared links that
+// enable access to a specific file, you can use the list_shared_links with the
+// file as the ListSharedLinksArg.path argument.
 func (dbx *apiImpl) RevokeSharedLinkContext(ctx context.Context, arg *RevokeSharedLinkArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1964,10 +1966,10 @@ type SetAccessInheritanceAPIError struct {
 }
 
 // SetAccessInheritanceContext : Change the inheritance policy of an existing
-// Shared Folder. Only permitted for shared folders in a shared team root.
-// If a `ShareFolderLaunch.async_job_id` is returned, you'll need to call
-// `checkShareJobStatus` until the action completes to get the metadata for
-// the folder.
+// Shared Folder. Only permitted for shared folders in a shared team root. If a
+// `ShareFolderLaunch.async_job_id` is returned, you'll need to call
+// `checkShareJobStatus` until the action completes to get the metadata for the
+// folder.
 func (dbx *apiImpl) SetAccessInheritanceContext(ctx context.Context, arg *SetAccessInheritanceArg) (res *ShareFolderLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2011,11 +2013,11 @@ type ShareFolderAPIError struct {
 }
 
 // ShareFolderContext : Share a folder with collaborators. Most sharing will be
-// completed synchronously. Large folders will be completed asynchronously.
-// To make testing the async case repeatable, set
-// `ShareFolderArg.force_async`. If a `ShareFolderLaunch.async_job_id` is
-// returned, you'll need to call `checkShareJobStatus` until the action
-// completes to get the metadata for the folder.
+// completed synchronously. Large folders will be completed asynchronously. To
+// make testing the async case repeatable, set `ShareFolderArg.force_async`. If
+// a `ShareFolderLaunch.async_job_id` is returned, you'll need to call
+// `checkShareJobStatus` until the action completes to get the metadata for the
+// folder.
 func (dbx *apiImpl) ShareFolderContext(ctx context.Context, arg *ShareFolderArg) (res *ShareFolderLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2058,8 +2060,8 @@ type TransferFolderAPIError struct {
 	EndpointError *TransferFolderError `json:"error"`
 }
 
-// TransferFolderContext : Transfer ownership of a shared folder to a member of the
-// shared folder. User must have `AccessLevel.owner` access to the shared
+// TransferFolderContext : Transfer ownership of a shared folder to a member of
+// the shared folder. User must have `AccessLevel.owner` access to the shared
 // folder to perform a transfer.
 func (dbx *apiImpl) TransferFolderContext(ctx context.Context, arg *TransferFolderArg) (err error) {
 	req := dropbox.Request{
@@ -2099,8 +2101,8 @@ type UnmountFolderAPIError struct {
 	EndpointError *UnmountFolderError `json:"error"`
 }
 
-// UnmountFolderContext : The current user unmounts the designated folder. They can
-// re-mount the folder at a later time using `mountFolder`.
+// UnmountFolderContext : The current user unmounts the designated folder. They
+// can re-mount the folder at a later time using `mountFolder`.
 func (dbx *apiImpl) UnmountFolderContext(ctx context.Context, arg *UnmountFolderArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2180,10 +2182,9 @@ type UnshareFolderAPIError struct {
 }
 
 // UnshareFolderContext : Allows a shared folder owner to unshare the folder.
-// Unshare will not work in following cases: The shared folder contains
-// shared folders OR the shared folder is inside another shared folder.
-// You'll need to call `checkJobStatus` to determine if the action has
-// completed successfully.
+// Unshare will not work in following cases: The shared folder contains shared
+// folders OR the shared folder is inside another shared folder. You'll need to
+// call `checkJobStatus` to determine if the action has completed successfully.
 func (dbx *apiImpl) UnshareFolderContext(ctx context.Context, arg *UnshareFolderArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2357,8 +2358,8 @@ type UpdateFolderPolicyAPIError struct {
 }
 
 // UpdateFolderPolicyContext : Update the sharing policies for a shared folder.
-// User must have `AccessLevel.owner` access to the shared folder to update
-// its policies.
+// User must have `AccessLevel.owner` access to the shared folder to update its
+// policies.
 func (dbx *apiImpl) UpdateFolderPolicyContext(ctx context.Context, arg *UpdateFolderPolicyArg) (res *SharedFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/sharing/types.go
+++ b/v6/dropbox/sharing/types.go
@@ -94,8 +94,6 @@ type AddFileMemberArgs struct {
 	// AddMessageAsComment : If the custom message should be added as a comment
 	// on the file. Only meant for Paper files.
 	AddMessageAsComment bool `json:"add_message_as_comment"`
-	// FpSealedResult : The FingerprintJS Sealed Client Result value
-	FpSealedResult string `json:"fp_sealed_result,omitempty"`
 }
 
 // NewAddFileMemberArgs returns a new AddFileMemberArgs instance
@@ -166,8 +164,6 @@ type AddFolderMemberArg struct {
 	// CustomMessage : Optional message to display to added members in their
 	// invitation.
 	CustomMessage string `json:"custom_message,omitempty"`
-	// FpSealedResult : The FingerprintJS Sealed Client Result value
-	FpSealedResult string `json:"fp_sealed_result,omitempty"`
 }
 
 // NewAddFolderMemberArg returns a new AddFolderMemberArg instance

--- a/v6/dropbox/team/client.go
+++ b/v6/dropbox/team/client.go
@@ -434,23 +434,25 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// DevicesListMemberDevicesContext : List all device sessions of a team's member.
+	// DevicesListMemberDevicesContext : List all device sessions of a team's
+	// member.
 	DevicesListMemberDevicesContext(ctx context.Context, arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error)
 	// DevicesListMembersDevicesContext : List all device sessions of a team.
 	// Permission : Team member file access.
 	DevicesListMembersDevicesContext(ctx context.Context, arg *ListMembersDevicesArg) (res *ListMembersDevicesResult, err error)
-	// DevicesListTeamDevicesContext : List all device sessions of a team. Permission :
-	// Team member file access.
+	// DevicesListTeamDevicesContext : List all device sessions of a team.
+	// Permission : Team member file access.
 	// Deprecated:
 	DevicesListTeamDevicesContext(ctx context.Context, arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error)
-	// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's member.
+	// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's
+	// member.
 	DevicesRevokeDeviceSessionContext(ctx context.Context, arg *RevokeDeviceSessionArg) (err error)
-	// DevicesRevokeDeviceSessionBatchContext : Revoke a list of device sessions of
-	// team members.
+	// DevicesRevokeDeviceSessionBatchContext : Revoke a list of device sessions
+	// of team members.
 	DevicesRevokeDeviceSessionBatchContext(ctx context.Context, arg *RevokeDeviceSessionBatchArg) (res *RevokeDeviceSessionBatchResult, err error)
-	// FeaturesGetValuesContext : Get the values for one or more features. This route
-	// allows you to check your account's capability for what feature you can
-	// access or what value you have for certain features. Permission : Team
+	// FeaturesGetValuesContext : Get the values for one or more features. This
+	// route allows you to check your account's capability for what feature you
+	// can access or what value you have for certain features. Permission : Team
 	// information.
 	FeaturesGetValuesContext(ctx context.Context, arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error)
 	// GetInfoContext : Retrieves information about a team.
@@ -458,13 +460,13 @@ type ContextClient interface {
 	// GroupsCreateContext : Creates a new, empty group, with a requested name.
 	// Permission : Team member management.
 	GroupsCreateContext(ctx context.Context, arg *GroupCreateArg) (res *GroupFullInfo, err error)
-	// GroupsDeleteContext : Deletes a group. The group is deleted immediately. However
-	// the revoking of group-owned resources may take additional time. Use the
-	// `groupsJobStatusGet` to determine whether this process has completed.
-	// Permission : Team member management.
+	// GroupsDeleteContext : Deletes a group. The group is deleted immediately.
+	// However the revoking of group-owned resources may take additional time.
+	// Use the `groupsJobStatusGet` to determine whether this process has
+	// completed. Permission : Team member management.
 	GroupsDeleteContext(ctx context.Context, arg *GroupSelector) (res *async.LaunchEmptyResult, err error)
-	// GroupsGetInfoContext : Retrieves information about one or more groups. Note that
-	// the optional field `GroupFullInfo.members` is not returned for
+	// GroupsGetInfoContext : Retrieves information about one or more groups.
+	// Note that the optional field `GroupFullInfo.members` is not returned for
 	// system-managed groups. Permission : Team Information.
 	GroupsGetInfoContext(ctx context.Context, arg *GroupsSelector) (res []*GroupsGetInfoItem, err error)
 	// GroupsJobStatusGetContext : Once an async_job_id is returned from
@@ -472,10 +474,12 @@ type ContextClient interface {
 	// method to poll the status of granting/revoking group members' access to
 	// group-owned resources. Permission : Team member management.
 	GroupsJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
-	// GroupsListContext : Lists groups on a team. Permission : Team Information.
+	// GroupsListContext : Lists groups on a team. Permission : Team
+	// Information.
 	GroupsListContext(ctx context.Context, arg *GroupsListArg) (res *GroupsListResult, err error)
-	// GroupsListContinueContext : Once a cursor has been retrieved from `groupsList`,
-	// use this to paginate through all groups. Permission : Team Information.
+	// GroupsListContinueContext : Once a cursor has been retrieved from
+	// `groupsList`, use this to paginate through all groups. Permission : Team
+	// Information.
 	GroupsListContinueContext(ctx context.Context, arg *GroupsListContinueArg) (res *GroupsListResult, err error)
 	// GroupsMembersAddContext : Adds members to a group. The members are added
 	// immediately. However the granting of group-owned resources may take
@@ -489,115 +493,118 @@ type ContextClient interface {
 	// `groupsMembersList`, use this to paginate through all members of the
 	// group. Permission : Team information.
 	GroupsMembersListContinueContext(ctx context.Context, arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error)
-	// GroupsMembersRemoveContext : Removes members from a group. The members are
-	// removed immediately. However the revoking of group-owned resources may
-	// take additional time. Use the `groupsJobStatusGet` to determine whether
-	// this process has completed. This method permits removing the only owner
-	// of a group, even in cases where this is not possible via the web client.
-	// Permission : Team member management.
+	// GroupsMembersRemoveContext : Removes members from a group. The members
+	// are removed immediately. However the revoking of group-owned resources
+	// may take additional time. Use the `groupsJobStatusGet` to determine
+	// whether this process has completed. This method permits removing the only
+	// owner of a group, even in cases where this is not possible via the web
+	// client. Permission : Team member management.
 	GroupsMembersRemoveContext(ctx context.Context, arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error)
-	// GroupsMembersSetAccessTypeContext : Sets a member's access type in a group.
-	// Permission : Team member management.
+	// GroupsMembersSetAccessTypeContext : Sets a member's access type in a
+	// group. Permission : Team member management.
 	GroupsMembersSetAccessTypeContext(ctx context.Context, arg *GroupMembersSetAccessTypeArg) (res []*GroupsGetInfoItem, err error)
-	// GroupsUpdateContext : Updates a group's name and/or external ID. Permission :
-	// Team member management.
+	// GroupsUpdateContext : Updates a group's name and/or external ID.
+	// Permission : Team member management.
 	GroupsUpdateContext(ctx context.Context, arg *GroupUpdateArgs) (res *GroupFullInfo, err error)
-	// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note: Legal Holds
+	// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note:
+	// Legal Holds is a paid add-on. Not all teams have the feature. Permission
+	// : Team member file access.
+	LegalHoldsCreatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error)
+	// LegalHoldsGetPolicyContext : Gets a legal hold by Id. Note: Legal Holds
 	// is a paid add-on. Not all teams have the feature. Permission : Team
 	// member file access.
-	LegalHoldsCreatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error)
-	// LegalHoldsGetPolicyContext : Gets a legal hold by Id. Note: Legal Holds is a
-	// paid add-on. Not all teams have the feature. Permission : Team member
-	// file access.
 	LegalHoldsGetPolicyContext(ctx context.Context, arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error)
-	// LegalHoldsListHeldRevisionsContext : List the file metadata that's under the
-	// hold. Note: Legal Holds is a paid add-on. Not all teams have the feature.
-	// Permission : Team member file access.
+	// LegalHoldsListHeldRevisionsContext : List the file metadata that's under
+	// the hold. Note: Legal Holds is a paid add-on. Not all teams have the
+	// feature. Permission : Team member file access.
 	LegalHoldsListHeldRevisionsContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsArg) (res *LegalHoldsListHeldRevisionResult, err error)
-	// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file metadata
-	// that's under the hold. Note: Legal Holds is a paid add-on. Not all teams
-	// have the feature. Permission : Team member file access.
+	// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file
+	// metadata that's under the hold. Note: Legal Holds is a paid add-on. Not
+	// all teams have the feature. Permission : Team member file access.
 	LegalHoldsListHeldRevisionsContinueContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error)
-	// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal Holds
-	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal
+	// Holds is a paid add-on. Not all teams have the feature. Permission : Team
 	// member file access.
 	LegalHoldsListPoliciesContext(ctx context.Context, arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error)
-	// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal Holds
-	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal
+	// Holds is a paid add-on. Not all teams have the feature. Permission : Team
 	// member file access.
 	LegalHoldsReleasePolicyContext(ctx context.Context, arg *LegalHoldsPolicyReleaseArg) (err error)
-	// LegalHoldsUpdatePolicyContext : Updates a legal hold. Note: Legal Holds is a
-	// paid add-on. Not all teams have the feature. Permission : Team member
-	// file access.
+	// LegalHoldsUpdatePolicyContext : Updates a legal hold. Note: Legal Holds
+	// is a paid add-on. Not all teams have the feature. Permission : Team
+	// member file access.
 	LegalHoldsUpdatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error)
-	// LinkedAppsListMemberLinkedAppsContext : List all linked applications of the team
-	// member. Note, this endpoint does not list any team-linked applications.
-	LinkedAppsListMemberLinkedAppsContext(ctx context.Context, arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error)
-	// LinkedAppsListMembersLinkedAppsContext : List all applications linked to the
-	// team members' accounts. Note, this endpoint does not list any team-linked
+	// LinkedAppsListMemberLinkedAppsContext : List all linked applications of
+	// the team member. Note, this endpoint does not list any team-linked
 	// applications.
+	LinkedAppsListMemberLinkedAppsContext(ctx context.Context, arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error)
+	// LinkedAppsListMembersLinkedAppsContext : List all applications linked to
+	// the team members' accounts. Note, this endpoint does not list any
+	// team-linked applications.
 	LinkedAppsListMembersLinkedAppsContext(ctx context.Context, arg *ListMembersAppsArg) (res *ListMembersAppsResult, err error)
-	// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the team
-	// members' accounts. Note, this endpoint doesn't list any team-linked
+	// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the
+	// team members' accounts. Note, this endpoint doesn't list any team-linked
 	// applications.
 	// Deprecated:
 	LinkedAppsListTeamLinkedAppsContext(ctx context.Context, arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error)
-	// LinkedAppsRevokeLinkedAppContext : Revoke a linked application of the team
-	// member.
+	// LinkedAppsRevokeLinkedAppContext : Revoke a linked application of the
+	// team member.
 	LinkedAppsRevokeLinkedAppContext(ctx context.Context, arg *RevokeLinkedApiAppArg) (err error)
-	// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked applications of
-	// the team members.
+	// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked
+	// applications of the team members.
 	LinkedAppsRevokeLinkedAppBatchContext(ctx context.Context, arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error)
-	// MemberSpaceLimitsExcludedUsersAddContext : Add users to member space limits
-	// excluded users list.
-	MemberSpaceLimitsExcludedUsersAddContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error)
-	// MemberSpaceLimitsExcludedUsersListContext : List member space limits excluded
-	// users.
-	MemberSpaceLimitsExcludedUsersListContext(ctx context.Context, arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error)
-	// MemberSpaceLimitsExcludedUsersListContinueContext : Continue listing member
-	// space limits excluded users.
-	MemberSpaceLimitsExcludedUsersListContinueContext(ctx context.Context, arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error)
-	// MemberSpaceLimitsExcludedUsersRemoveContext : Remove users from member space
+	// MemberSpaceLimitsExcludedUsersAddContext : Add users to member space
 	// limits excluded users list.
+	MemberSpaceLimitsExcludedUsersAddContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error)
+	// MemberSpaceLimitsExcludedUsersListContext : List member space limits
+	// excluded users.
+	MemberSpaceLimitsExcludedUsersListContext(ctx context.Context, arg *ExcludedUsersListArg) (res *ExcludedUsersListResult, err error)
+	// MemberSpaceLimitsExcludedUsersListContinueContext : Continue listing
+	// member space limits excluded users.
+	MemberSpaceLimitsExcludedUsersListContinueContext(ctx context.Context, arg *ExcludedUsersListContinueArg) (res *ExcludedUsersListResult, err error)
+	// MemberSpaceLimitsExcludedUsersRemoveContext : Remove users from member
+	// space limits excluded users list.
 	MemberSpaceLimitsExcludedUsersRemoveContext(ctx context.Context, arg *ExcludedUsersUpdateArg) (res *ExcludedUsersUpdateResult, err error)
-	// MemberSpaceLimitsGetCustomQuotaContext : Get users custom quota. A maximum of
-	// 1000 members can be specified in a single call. Note: to apply a custom
-	// space limit, a team admin needs to set a member space limit for the team
-	// first. (the team admin can check the settings here:
+	// MemberSpaceLimitsGetCustomQuotaContext : Get users custom quota. A
+	// maximum of 1000 members can be specified in a single call. Note: to apply
+	// a custom space limit, a team admin needs to set a member space limit for
+	// the team first. (the team admin can check the settings here:
 	// https://www.dropbox.com/team/admin/settings/space).
 	MemberSpaceLimitsGetCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error)
-	// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A maximum
-	// of 1000 members can be specified in a single call. Note: to apply a
-	// custom space limit, a team admin needs to set a member space limit for
+	// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A
+	// maximum of 1000 members can be specified in a single call. Note: to apply
+	// a custom space limit, a team admin needs to set a member space limit for
 	// the team first. (the team admin can check the settings here:
 	// https://www.dropbox.com/team/admin/settings/space).
 	MemberSpaceLimitsRemoveCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error)
-	// MemberSpaceLimitsSetCustomQuotaContext : Set users custom quota. Custom quota
-	// has to be at least 2GB. A maximum of 1000 members can be specified in a
-	// single call. Note: to apply a custom space limit, a team admin needs to
-	// set a member space limit for the team first. (the team admin can check
+	// MemberSpaceLimitsSetCustomQuotaContext : Set users custom quota. Custom
+	// quota has to be at least 2GB. A maximum of 1000 members can be specified
+	// in a single call. Note: to apply a custom space limit, a team admin needs
+	// to set a member space limit for the team first. (the team admin can check
 	// the settings here: https://www.dropbox.com/team/admin/settings/space).
 	MemberSpaceLimitsSetCustomQuotaContext(ctx context.Context, arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error)
-	// MembersAddContext : Adds members to a team. Permission : Team member management
-	// A maximum of 20 members can be specified in a single call. If no Dropbox
-	// account exists with the email address specified, a new Dropbox account
-	// will be created with the given email address, and that account will be
-	// invited to the team. If a personal Dropbox account exists with the email
-	// address specified in the call, this call will create a placeholder
-	// Dropbox account for the user on the team and send an email inviting the
-	// user to migrate their existing personal account onto the team. Team
-	// member management apps are required to set an initial given_name and
-	// surname for a user to use in the team invitation and for 'Perform as team
-	// member' actions taken on the user before they become 'active'.
+	// MembersAddContext : Adds members to a team. Permission : Team member
+	// management A maximum of 20 members can be specified in a single call. If
+	// no Dropbox account exists with the email address specified, a new Dropbox
+	// account will be created with the given email address, and that account
+	// will be invited to the team. If a personal Dropbox account exists with
+	// the email address specified in the call, this call will create a
+	// placeholder Dropbox account for the user on the team and send an email
+	// inviting the user to migrate their existing personal account onto the
+	// team. Team member management apps are required to set an initial
+	// given_name and surname for a user to use in the team invitation and for
+	// 'Perform as team member' actions taken on the user before they become
+	// 'active'.
 	MembersAddContext(ctx context.Context, arg *MembersAddArg) (res *MembersAddLaunch, err error)
-	// MembersAddV2Context : Adds members to a team. Permission : Team member management
-	// A maximum of 20 members can be specified in a single call. If no Dropbox
-	// account exists with the email address specified, a new Dropbox account
-	// will be created with the given email address, and that account will be
-	// invited to the team. If a personal Dropbox account exists with the email
-	// address specified in the call, this call will create a placeholder
-	// Dropbox account for the user on the team and send an email inviting the
-	// user to migrate their existing personal account onto the team.
+	// MembersAddV2Context : Adds members to a team. Permission : Team member
+	// management A maximum of 20 members can be specified in a single call. If
+	// no Dropbox account exists with the email address specified, a new Dropbox
+	// account will be created with the given email address, and that account
+	// will be invited to the team. If a personal Dropbox account exists with
+	// the email address specified in the call, this call will create a
+	// placeholder Dropbox account for the user on the team and send an email
+	// inviting the user to migrate their existing personal account onto the
+	// team.
 	MembersAddV2Context(ctx context.Context, arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error)
 	// MembersAddJobStatusGetContext : Once an async_job_id is returned from
 	// `membersAdd` , use this to poll the status of the asynchronous request.
@@ -607,20 +614,20 @@ type ContextClient interface {
 	// `membersAdd` , use this to poll the status of the asynchronous request.
 	// Permission : Team member management.
 	MembersAddJobStatusGetV2Context(ctx context.Context, arg *async.PollArg) (res *MembersAddJobStatusV2Result, err error)
-	// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a user
-	// who has been removed from the team. After permanent deletion, those files
-	// will not be available to be transferred to another team member.
+	// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a
+	// user who has been removed from the team. After permanent deletion, those
+	// files will not be available to be transferred to another team member.
 	// Permission : Team member management Exactly one of team_member_id, email,
 	// or external_id must be provided to identify the user account.
 	MembersDeleteFormerMemberFilesContext(ctx context.Context, arg *MembersFormerMemberArg) (err error)
 	// MembersDeleteProfilePhotoContext : Deletes a team member's profile photo.
 	// Permission : Team member management.
 	MembersDeleteProfilePhotoContext(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfo, err error)
-	// MembersDeleteProfilePhotoV2Context : Deletes a team member's profile photo.
-	// Permission : Team member management.
+	// MembersDeleteProfilePhotoV2Context : Deletes a team member's profile
+	// photo. Permission : Team member management.
 	MembersDeleteProfilePhotoV2Context(ctx context.Context, arg *MembersDeleteProfilePhotoArg) (res *TeamMemberInfoV2Result, err error)
-	// MembersGetAvailableTeamMemberRolesContext : Get available TeamMemberRoles for
-	// the connected team. To be used with `membersSetAdminPermissions`.
+	// MembersGetAvailableTeamMemberRolesContext : Get available TeamMemberRoles
+	// for the connected team. To be used with `membersSetAdminPermissions`.
 	// Permission : Team member management.
 	MembersGetAvailableTeamMemberRolesContext(ctx context.Context) (res *MembersGetAvailableTeamMemberRolesResult, err error)
 	// MembersGetInfoContext : Returns information about multiple team members.
@@ -628,14 +635,16 @@ type ContextClient interface {
 	// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
 	// matched to a valid team member.
 	MembersGetInfoContext(ctx context.Context, arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error)
-	// MembersGetInfoV2Context : Returns information about multiple team members.
-	// Permission : Team information This endpoint will return
+	// MembersGetInfoV2Context : Returns information about multiple team
+	// members. Permission : Team information This endpoint will return
 	// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
 	// matched to a valid team member.
 	MembersGetInfoV2Context(ctx context.Context, arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error)
-	// MembersListContext : Lists members of a team. Permission : Team information.
+	// MembersListContext : Lists members of a team. Permission : Team
+	// information.
 	MembersListContext(ctx context.Context, arg *MembersListArg) (res *MembersListResult, err error)
-	// MembersListV2Context : Lists members of a team. Permission : Team information.
+	// MembersListV2Context : Lists members of a team. Permission : Team
+	// information.
 	MembersListV2Context(ctx context.Context, arg *MembersListArg) (res *MembersListV2Result, err error)
 	// MembersListContinueContext : Once a cursor has been retrieved from
 	// `membersList`, use this to paginate through all team members. Permission
@@ -651,18 +660,18 @@ type ContextClient interface {
 	// `membersMoveFormerMemberFilesJobStatusCheck`. Permission : Team member
 	// management.
 	MembersMoveFormerMemberFilesContext(ctx context.Context, arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error)
-	// MembersMoveFormerMemberFilesJobStatusCheckContext : Once an async_job_id is
-	// returned from `membersMoveFormerMemberFiles` , use this to poll the
+	// MembersMoveFormerMemberFilesJobStatusCheckContext : Once an async_job_id
+	// is returned from `membersMoveFormerMemberFiles` , use this to poll the
 	// status of the asynchronous request. Permission : Team member management.
 	MembersMoveFormerMemberFilesJobStatusCheckContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
-	// MembersRecoverContext : Recover a deleted member. Permission : Team member
-	// management Exactly one of team_member_id, email, or external_id must be
-	// provided to identify the user account.
+	// MembersRecoverContext : Recover a deleted member. Permission : Team
+	// member management Exactly one of team_member_id, email, or external_id
+	// must be provided to identify the user account.
 	MembersRecoverContext(ctx context.Context, arg *MembersRecoverArg) (err error)
-	// MembersRemoveContext : Removes a member from a team. Permission : Team member
-	// management Exactly one of team_member_id, email, or external_id must be
-	// provided to identify the user account. Accounts can be recovered via
-	// `membersRecover` for a 7 day period or until the account has been
+	// MembersRemoveContext : Removes a member from a team. Permission : Team
+	// member management Exactly one of team_member_id, email, or external_id
+	// must be provided to identify the user account. Accounts can be recovered
+	// via `membersRecover` for a 7 day period or until the account has been
 	// permanently deleted or transferred to another account (whichever comes
 	// first). Calling `membersAdd` while a user is still recoverable on your
 	// team will return with `MemberAddResult.user_already_on_team`. Accounts
@@ -678,35 +687,35 @@ type ContextClient interface {
 	// `membersRemove` , use this to poll the status of the asynchronous
 	// request. Permission : Team member management.
 	MembersRemoveJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error)
-	// MembersSecondaryEmailsAddContext : Add secondary emails to users. Permission :
-	// Team member management. Emails that are on verified domains will be
-	// verified automatically. For each email address not on a verified domain a
-	// verification email will be sent.
+	// MembersSecondaryEmailsAddContext : Add secondary emails to users.
+	// Permission : Team member management. Emails that are on verified domains
+	// will be verified automatically. For each email address not on a verified
+	// domain a verification email will be sent.
 	MembersSecondaryEmailsAddContext(ctx context.Context, arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error)
 	// MembersSecondaryEmailsDeleteContext : Delete secondary emails from users
 	// Permission : Team member management. Users will be notified of deletions
 	// of verified secondary emails at both the secondary email and their
 	// primary email.
 	MembersSecondaryEmailsDeleteContext(ctx context.Context, arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error)
-	// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary email
-	// verification emails. Permission : Team member management.
+	// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary
+	// email verification emails. Permission : Team member management.
 	MembersSecondaryEmailsResendVerificationEmailsContext(ctx context.Context, arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error)
-	// MembersSendWelcomeEmailContext : Sends welcome email to pending team member.
-	// Permission : Team member management Exactly one of team_member_id, email,
-	// or external_id must be provided to identify the user account. No-op if
-	// team member is not pending.
+	// MembersSendWelcomeEmailContext : Sends welcome email to pending team
+	// member. Permission : Team member management Exactly one of
+	// team_member_id, email, or external_id must be provided to identify the
+	// user account. No-op if team member is not pending.
 	MembersSendWelcomeEmailContext(ctx context.Context, arg *UserSelectorArg) (err error)
 	// MembersSetAdminPermissionsContext : Updates a team member's permissions.
 	// Permission : Team member management.
 	MembersSetAdminPermissionsContext(ctx context.Context, arg *MembersSetPermissionsArg) (res *MembersSetPermissionsResult, err error)
-	// MembersSetAdminPermissionsV2Context : Updates a team member's permissions.
-	// Permission : Team member management.
+	// MembersSetAdminPermissionsV2Context : Updates a team member's
+	// permissions. Permission : Team member management.
 	MembersSetAdminPermissionsV2Context(ctx context.Context, arg *MembersSetPermissions2Arg) (res *MembersSetPermissions2Result, err error)
-	// MembersSetProfileContext : Updates a team member's profile. Permission : Team
-	// member management.
+	// MembersSetProfileContext : Updates a team member's profile. Permission :
+	// Team member management.
 	MembersSetProfileContext(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfo, err error)
-	// MembersSetProfileV2Context : Updates a team member's profile. Permission : Team
-	// member management.
+	// MembersSetProfileV2Context : Updates a team member's profile. Permission
+	// : Team member management.
 	MembersSetProfileV2Context(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error)
 	// MembersSetProfilePhotoContext : Updates a team member's profile photo.
 	// Permission : Team member management.
@@ -714,20 +723,20 @@ type ContextClient interface {
 	// MembersSetProfilePhotoV2Context : Updates a team member's profile photo.
 	// Permission : Team member management.
 	MembersSetProfilePhotoV2Context(ctx context.Context, arg *MembersSetProfilePhotoArg) (res *TeamMemberInfoV2Result, err error)
-	// MembersSuspendContext : Suspend a member from a team. Permission : Team member
-	// management Exactly one of team_member_id, email, or external_id must be
-	// provided to identify the user account.
-	MembersSuspendContext(ctx context.Context, arg *MembersDeactivateArg) (err error)
-	// MembersUnsuspendContext : Unsuspend a member from a team. Permission : Team
+	// MembersSuspendContext : Suspend a member from a team. Permission : Team
 	// member management Exactly one of team_member_id, email, or external_id
 	// must be provided to identify the user account.
+	MembersSuspendContext(ctx context.Context, arg *MembersDeactivateArg) (err error)
+	// MembersUnsuspendContext : Unsuspend a member from a team. Permission :
+	// Team member management Exactly one of team_member_id, email, or
+	// external_id must be provided to identify the user account.
 	MembersUnsuspendContext(ctx context.Context, arg *MembersUnsuspendArg) (err error)
-	// NamespacesListContext : Returns a list of all team-accessible namespaces. This
-	// list includes team folders, shared folders containing team members, team
-	// members' home namespaces, and team members' app folders. Home namespaces
-	// and app folders are always owned by this team or members of the team, but
-	// shared folders may be owned by other users or other teams. Duplicates may
-	// occur in the list.
+	// NamespacesListContext : Returns a list of all team-accessible namespaces.
+	// This list includes team folders, shared folders containing team members,
+	// team members' home namespaces, and team members' app folders. Home
+	// namespaces and app folders are always owned by this team or members of
+	// the team, but shared folders may be owned by other users or other teams.
+	// Duplicates may occur in the list.
 	NamespacesListContext(ctx context.Context, arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error)
 	// NamespacesListContinueContext : Once a cursor has been retrieved from
 	// `namespacesList`, use this to paginate through all team-accessible
@@ -736,8 +745,8 @@ type ContextClient interface {
 	// PropertiesTemplateAddContext : Permission : Team member file access.
 	// Deprecated:
 	PropertiesTemplateAddContext(ctx context.Context, arg *file_properties.AddTemplateArg) (res *file_properties.AddTemplateResult, err error)
-	// PropertiesTemplateGetContext : Permission : Team member file access. The scope
-	// for the route is files.team_metadata.write.
+	// PropertiesTemplateGetContext : Permission : Team member file access. The
+	// scope for the route is files.team_metadata.write.
 	// Deprecated:
 	PropertiesTemplateGetContext(ctx context.Context, arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error)
 	// ReportsGetActivityContext : Retrieves reporting data about a team's user
@@ -752,60 +761,60 @@ type ContextClient interface {
 	// membership. Deprecated: Will be removed on July 1st 2021.
 	// Deprecated:
 	ReportsGetMembershipContext(ctx context.Context, arg *DateRange) (res *GetMembershipReport, err error)
-	// ReportsGetStorageContext : Retrieves reporting data about a team's storage
-	// usage. Deprecated: Will be removed on July 1st 2021.
+	// ReportsGetStorageContext : Retrieves reporting data about a team's
+	// storage usage. Deprecated: Will be removed on July 1st 2021.
 	// Deprecated:
 	ReportsGetStorageContext(ctx context.Context, arg *DateRange) (res *GetStorageReport, err error)
-	// SharingAllowlistAddContext : Endpoint adds Approve List entries. Changes are
-	// effective immediately. Changes are committed in transaction. In case of
-	// single validation error - all entries are rejected. Valid domains
+	// SharingAllowlistAddContext : Endpoint adds Approve List entries. Changes
+	// are effective immediately. Changes are committed in transaction. In case
+	// of single validation error - all entries are rejected. Valid domains
 	// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Added entries cannot
 	// overflow limit of 10000 entries per team. Maximum 100 entries per call is
 	// allowed.
 	SharingAllowlistAddContext(ctx context.Context, arg *SharingAllowlistAddArgs) (res *SharingAllowlistAddResponse, err error)
-	// SharingAllowlistListContext : Lists Approve List entries for given team, from
-	// newest to oldest, returning up to `limit` entries at a time. If there are
-	// more than `limit` entries associated with the current team, more can be
-	// fetched by passing the returned `cursor` to
+	// SharingAllowlistListContext : Lists Approve List entries for given team,
+	// from newest to oldest, returning up to `limit` entries at a time. If
+	// there are more than `limit` entries associated with the current team,
+	// more can be fetched by passing the returned `cursor` to
 	// `sharingAllowlistListContinue`.
 	SharingAllowlistListContext(ctx context.Context, arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error)
-	// SharingAllowlistListContinueContext : Lists entries associated with given team,
-	// starting from a the cursor. See `sharingAllowlistList`.
+	// SharingAllowlistListContinueContext : Lists entries associated with given
+	// team, starting from a the cursor. See `sharingAllowlistList`.
 	SharingAllowlistListContinueContext(ctx context.Context, arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error)
-	// SharingAllowlistRemoveContext : Endpoint removes Approve List entries. Changes
-	// are effective immediately. Changes are committed in transaction. In case
-	// of single validation error - all entries are rejected. Valid domains
-	// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries being
-	// removed have to be present on the list. Maximum 1000 entries per call is
-	// allowed.
+	// SharingAllowlistRemoveContext : Endpoint removes Approve List entries.
+	// Changes are effective immediately. Changes are committed in transaction.
+	// In case of single validation error - all entries are rejected. Valid
+	// domains (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries
+	// being removed have to be present on the list. Maximum 1000 entries per
+	// call is allowed.
 	SharingAllowlistRemoveContext(ctx context.Context, arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error)
-	// TeamFolderActivateContext : Sets an archived team folder's status to active.
-	// Permission : Team member file access.
+	// TeamFolderActivateContext : Sets an archived team folder's status to
+	// active. Permission : Team member file access.
 	TeamFolderActivateContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error)
-	// TeamFolderArchiveContext : Sets an active team folder's status to archived and
-	// removes all folder and file members. This endpoint cannot be used for
-	// teams that have a shared team space. This route will either finish
-	// synchronously, or return a job ID and do the async archive job in
+	// TeamFolderArchiveContext : Sets an active team folder's status to
+	// archived and removes all folder and file members. This endpoint cannot be
+	// used for teams that have a shared team space. This route will either
+	// finish synchronously, or return a job ID and do the async archive job in
 	// background. Please use team_folder/archive/check to check the job status.
 	// Permission : Team member file access.
 	TeamFolderArchiveContext(ctx context.Context, arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error)
-	// TeamFolderArchiveCheckContext : Returns the status of an asynchronous job for
-	// archiving a team folder. The job may show '.tag' as complete, but the
+	// TeamFolderArchiveCheckContext : Returns the status of an asynchronous job
+	// for archiving a team folder. The job may show '.tag' as complete, but the
 	// team folder could still be in the process of archiving (indicated by
 	// `TeamFolderMetadata.status` with 'archive_in_progress'). To confirm that
 	// the team folder is fully archived, check the field
 	// `TeamFolderMetadata.status` in the response for the value 'archived'.
 	// Permission : Team member file access.
 	TeamFolderArchiveCheckContext(ctx context.Context, arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error)
-	// TeamFolderCreateContext : Creates a new, active, team folder with no members.
-	// This endpoint can only be used for teams that do not already have a
-	// shared team space. Permission : Team member file access.
+	// TeamFolderCreateContext : Creates a new, active, team folder with no
+	// members. This endpoint can only be used for teams that do not already
+	// have a shared team space. Permission : Team member file access.
 	TeamFolderCreateContext(ctx context.Context, arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error)
-	// TeamFolderGetInfoContext : Retrieves metadata for team folders. Permission :
-	// Team member file access.
+	// TeamFolderGetInfoContext : Retrieves metadata for team folders.
+	// Permission : Team member file access.
 	TeamFolderGetInfoContext(ctx context.Context, arg *TeamFolderIdListArg) (res []*TeamFolderGetInfoItem, err error)
-	// TeamFolderListContext : Lists all team folders. Permission : Team member file
-	// access.
+	// TeamFolderListContext : Lists all team folders. Permission : Team member
+	// file access.
 	TeamFolderListContext(ctx context.Context, arg *TeamFolderListArg) (res *TeamFolderListResult, err error)
 	// TeamFolderListContinueContext : Once a cursor has been retrieved from
 	// `teamFolderList`, use this to paginate through all team folders.
@@ -815,18 +824,18 @@ type ContextClient interface {
 	// folder. This endpoint cannot be used for teams that have a shared team
 	// space. Permission : Team member file access.
 	TeamFolderPermanentlyDeleteContext(ctx context.Context, arg *TeamFolderIdArg) (err error)
-	// TeamFolderRenameContext : Changes an active team folder's name. Permission :
-	// Team member file access.
+	// TeamFolderRenameContext : Changes an active team folder's name.
+	// Permission : Team member file access.
 	TeamFolderRenameContext(ctx context.Context, arg *TeamFolderRenameArg) (res *TeamFolderMetadata, err error)
-	// TeamFolderRestoreContext : Sets an inactive team folder's status to active.
-	// Permission: Team member file access.
+	// TeamFolderRestoreContext : Sets an inactive team folder's status to
+	// active. Permission: Team member file access.
 	TeamFolderRestoreContext(ctx context.Context, arg *TeamFolderIdArg) (res *TeamFolderMetadata, err error)
-	// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team folder
-	// or its contents.  Use of this endpoint requires that the team has team
-	// selective sync enabled.
+	// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team
+	// folder or its contents.  Use of this endpoint requires that the team has
+	// team selective sync enabled.
 	TeamFolderUpdateSyncSettingsContext(ctx context.Context, arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error)
-	// TokenGetAuthenticatedAdminContext : Returns the member profile of the admin who
-	// generated the team access token used to make the call.
+	// TokenGetAuthenticatedAdminContext : Returns the member profile of the
+	// admin who generated the team access token used to make the call.
 	TokenGetAuthenticatedAdminContext(ctx context.Context) (res *TokenGetAuthenticatedAdminResult, err error)
 }
 
@@ -838,7 +847,8 @@ type DevicesListMemberDevicesAPIError struct {
 	EndpointError *ListMemberDevicesError `json:"error"`
 }
 
-// DevicesListMemberDevicesContext : List all device sessions of a team's member.
+// DevicesListMemberDevicesContext : List all device sessions of a team's
+// member.
 func (dbx *apiImpl) DevicesListMemberDevicesContext(ctx context.Context, arg *ListMemberDevicesArg) (res *ListMemberDevicesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -925,8 +935,8 @@ type DevicesListTeamDevicesAPIError struct {
 	EndpointError *ListTeamDevicesError `json:"error"`
 }
 
-// DevicesListTeamDevicesContext : List all device sessions of a team. Permission :
-// Team member file access.
+// DevicesListTeamDevicesContext : List all device sessions of a team.
+// Permission : Team member file access.
 // Deprecated:
 func (dbx *apiImpl) DevicesListTeamDevicesContext(ctx context.Context, arg *ListTeamDevicesArg) (res *ListTeamDevicesResult, err error) {
 	log.Printf("WARNING: API `DevicesListTeamDevices` is deprecated")
@@ -972,7 +982,8 @@ type DevicesRevokeDeviceSessionAPIError struct {
 	EndpointError *RevokeDeviceSessionError `json:"error"`
 }
 
-// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's member.
+// DevicesRevokeDeviceSessionContext : Revoke a device session of a team's
+// member.
 func (dbx *apiImpl) DevicesRevokeDeviceSessionContext(ctx context.Context, arg *RevokeDeviceSessionArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1055,8 +1066,8 @@ type FeaturesGetValuesAPIError struct {
 	EndpointError *FeaturesGetValuesBatchError `json:"error"`
 }
 
-// FeaturesGetValuesContext : Get the values for one or more features. This route
-// allows you to check your account's capability for what feature you can
+// FeaturesGetValuesContext : Get the values for one or more features. This
+// route allows you to check your account's capability for what feature you can
 // access or what value you have for certain features. Permission : Team
 // information.
 func (dbx *apiImpl) FeaturesGetValuesContext(ctx context.Context, arg *FeaturesGetValuesBatchArg) (res *FeaturesGetValuesBatchResult, err error) {
@@ -1188,9 +1199,9 @@ type GroupsDeleteAPIError struct {
 	EndpointError *GroupDeleteError `json:"error"`
 }
 
-// GroupsDeleteContext : Deletes a group. The group is deleted immediately. However
-// the revoking of group-owned resources may take additional time. Use the
-// `groupsJobStatusGet` to determine whether this process has completed.
+// GroupsDeleteContext : Deletes a group. The group is deleted immediately.
+// However the revoking of group-owned resources may take additional time. Use
+// the `groupsJobStatusGet` to determine whether this process has completed.
 // Permission : Team member management.
 func (dbx *apiImpl) GroupsDeleteContext(ctx context.Context, arg *GroupSelector) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
@@ -1234,8 +1245,8 @@ type GroupsGetInfoAPIError struct {
 	EndpointError *GroupsGetInfoError `json:"error"`
 }
 
-// GroupsGetInfoContext : Retrieves information about one or more groups. Note that
-// the optional field `GroupFullInfo.members` is not returned for
+// GroupsGetInfoContext : Retrieves information about one or more groups. Note
+// that the optional field `GroupFullInfo.members` is not returned for
 // system-managed groups. Permission : Team Information.
 func (dbx *apiImpl) GroupsGetInfoContext(ctx context.Context, arg *GroupsSelector) (res []*GroupsGetInfoItem, err error) {
 	req := dropbox.Request{
@@ -1280,9 +1291,9 @@ type GroupsJobStatusGetAPIError struct {
 }
 
 // GroupsJobStatusGetContext : Once an async_job_id is returned from
-// `groupsDelete`, `groupsMembersAdd` , or `groupsMembersRemove` use this
-// method to poll the status of granting/revoking group members' access to
-// group-owned resources. Permission : Team member management.
+// `groupsDelete`, `groupsMembersAdd` , or `groupsMembersRemove` use this method
+// to poll the status of granting/revoking group members' access to group-owned
+// resources. Permission : Team member management.
 func (dbx *apiImpl) GroupsJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1368,8 +1379,9 @@ type GroupsListContinueAPIError struct {
 	EndpointError *GroupsListContinueError `json:"error"`
 }
 
-// GroupsListContinueContext : Once a cursor has been retrieved from `groupsList`,
-// use this to paginate through all groups. Permission : Team Information.
+// GroupsListContinueContext : Once a cursor has been retrieved from
+// `groupsList`, use this to paginate through all groups. Permission : Team
+// Information.
 func (dbx *apiImpl) GroupsListContinueContext(ctx context.Context, arg *GroupsListContinueArg) (res *GroupsListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1503,8 +1515,8 @@ type GroupsMembersListContinueAPIError struct {
 }
 
 // GroupsMembersListContinueContext : Once a cursor has been retrieved from
-// `groupsMembersList`, use this to paginate through all members of the
-// group. Permission : Team information.
+// `groupsMembersList`, use this to paginate through all members of the group.
+// Permission : Team information.
 func (dbx *apiImpl) GroupsMembersListContinueContext(ctx context.Context, arg *GroupsMembersListContinueArg) (res *GroupsMembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1548,10 +1560,10 @@ type GroupsMembersRemoveAPIError struct {
 }
 
 // GroupsMembersRemoveContext : Removes members from a group. The members are
-// removed immediately. However the revoking of group-owned resources may
-// take additional time. Use the `groupsJobStatusGet` to determine whether
-// this process has completed. This method permits removing the only owner
-// of a group, even in cases where this is not possible via the web client.
+// removed immediately. However the revoking of group-owned resources may take
+// additional time. Use the `groupsJobStatusGet` to determine whether this
+// process has completed. This method permits removing the only owner of a
+// group, even in cases where this is not possible via the web client.
 // Permission : Team member management.
 func (dbx *apiImpl) GroupsMembersRemoveContext(ctx context.Context, arg *GroupMembersRemoveArg) (res *GroupMembersChangeResult, err error) {
 	req := dropbox.Request{
@@ -1683,8 +1695,8 @@ type LegalHoldsCreatePolicyAPIError struct {
 	EndpointError *LegalHoldsPolicyCreateError `json:"error"`
 }
 
-// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note: Legal Holds
-// is a paid add-on. Not all teams have the feature. Permission : Team
+// LegalHoldsCreatePolicyContext : Creates new legal hold policy. Note: Legal
+// Holds is a paid add-on. Not all teams have the feature. Permission : Team
 // member file access.
 func (dbx *apiImpl) LegalHoldsCreatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyCreateArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
@@ -1729,8 +1741,8 @@ type LegalHoldsGetPolicyAPIError struct {
 }
 
 // LegalHoldsGetPolicyContext : Gets a legal hold by Id. Note: Legal Holds is a
-// paid add-on. Not all teams have the feature. Permission : Team member
-// file access.
+// paid add-on. Not all teams have the feature. Permission : Team member file
+// access.
 func (dbx *apiImpl) LegalHoldsGetPolicyContext(ctx context.Context, arg *LegalHoldsGetPolicyArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1818,9 +1830,9 @@ type LegalHoldsListHeldRevisionsContinueAPIError struct {
 	EndpointError *LegalHoldsListHeldRevisionsError `json:"error"`
 }
 
-// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file metadata
-// that's under the hold. Note: Legal Holds is a paid add-on. Not all teams
-// have the feature. Permission : Team member file access.
+// LegalHoldsListHeldRevisionsContinueContext : Continue listing the file
+// metadata that's under the hold. Note: Legal Holds is a paid add-on. Not all
+// teams have the feature. Permission : Team member file access.
 func (dbx *apiImpl) LegalHoldsListHeldRevisionsContinueContext(ctx context.Context, arg *LegalHoldsListHeldRevisionsContinueArg) (res *LegalHoldsListHeldRevisionResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1863,8 +1875,8 @@ type LegalHoldsListPoliciesAPIError struct {
 	EndpointError *LegalHoldsListPoliciesError `json:"error"`
 }
 
-// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal Holds
-// is a paid add-on. Not all teams have the feature. Permission : Team
+// LegalHoldsListPoliciesContext : Lists legal holds on a team. Note: Legal
+// Holds is a paid add-on. Not all teams have the feature. Permission : Team
 // member file access.
 func (dbx *apiImpl) LegalHoldsListPoliciesContext(ctx context.Context, arg *LegalHoldsListPoliciesArg) (res *LegalHoldsListPoliciesResult, err error) {
 	req := dropbox.Request{
@@ -1908,8 +1920,8 @@ type LegalHoldsReleasePolicyAPIError struct {
 	EndpointError *LegalHoldsPolicyReleaseError `json:"error"`
 }
 
-// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal Holds
-// is a paid add-on. Not all teams have the feature. Permission : Team
+// LegalHoldsReleasePolicyContext : Releases a legal hold by Id. Note: Legal
+// Holds is a paid add-on. Not all teams have the feature. Permission : Team
 // member file access.
 func (dbx *apiImpl) LegalHoldsReleasePolicyContext(ctx context.Context, arg *LegalHoldsPolicyReleaseArg) (err error) {
 	req := dropbox.Request{
@@ -1950,8 +1962,8 @@ type LegalHoldsUpdatePolicyAPIError struct {
 }
 
 // LegalHoldsUpdatePolicyContext : Updates a legal hold. Note: Legal Holds is a
-// paid add-on. Not all teams have the feature. Permission : Team member
-// file access.
+// paid add-on. Not all teams have the feature. Permission : Team member file
+// access.
 func (dbx *apiImpl) LegalHoldsUpdatePolicyContext(ctx context.Context, arg *LegalHoldsPolicyUpdateArg) (res *LegalHoldPolicy, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -1994,8 +2006,8 @@ type LinkedAppsListMemberLinkedAppsAPIError struct {
 	EndpointError *ListMemberAppsError `json:"error"`
 }
 
-// LinkedAppsListMemberLinkedAppsContext : List all linked applications of the team
-// member. Note, this endpoint does not list any team-linked applications.
+// LinkedAppsListMemberLinkedAppsContext : List all linked applications of the
+// team member. Note, this endpoint does not list any team-linked applications.
 func (dbx *apiImpl) LinkedAppsListMemberLinkedAppsContext(ctx context.Context, arg *ListMemberAppsArg) (res *ListMemberAppsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2083,8 +2095,8 @@ type LinkedAppsListTeamLinkedAppsAPIError struct {
 	EndpointError *ListTeamAppsError `json:"error"`
 }
 
-// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the team
-// members' accounts. Note, this endpoint doesn't list any team-linked
+// LinkedAppsListTeamLinkedAppsContext : List all applications linked to the
+// team members' accounts. Note, this endpoint doesn't list any team-linked
 // applications.
 // Deprecated:
 func (dbx *apiImpl) LinkedAppsListTeamLinkedAppsContext(ctx context.Context, arg *ListTeamAppsArg) (res *ListTeamAppsResult, err error) {
@@ -2171,8 +2183,8 @@ type LinkedAppsRevokeLinkedAppBatchAPIError struct {
 	EndpointError *RevokeLinkedAppBatchError `json:"error"`
 }
 
-// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked applications of
-// the team members.
+// LinkedAppsRevokeLinkedAppBatchContext : Revoke a list of linked applications
+// of the team members.
 func (dbx *apiImpl) LinkedAppsRevokeLinkedAppBatchContext(ctx context.Context, arg *RevokeLinkedApiAppBatchArg) (res *RevokeLinkedAppBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2392,9 +2404,9 @@ type MemberSpaceLimitsGetCustomQuotaAPIError struct {
 }
 
 // MemberSpaceLimitsGetCustomQuotaContext : Get users custom quota. A maximum of
-// 1000 members can be specified in a single call. Note: to apply a custom
-// space limit, a team admin needs to set a member space limit for the team
-// first. (the team admin can check the settings here:
+// 1000 members can be specified in a single call. Note: to apply a custom space
+// limit, a team admin needs to set a member space limit for the team first.
+// (the team admin can check the settings here:
 // https://www.dropbox.com/team/admin/settings/space).
 func (dbx *apiImpl) MemberSpaceLimitsGetCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*CustomQuotaResult, err error) {
 	req := dropbox.Request{
@@ -2438,10 +2450,10 @@ type MemberSpaceLimitsRemoveCustomQuotaAPIError struct {
 	EndpointError *CustomQuotaError `json:"error"`
 }
 
-// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A maximum
-// of 1000 members can be specified in a single call. Note: to apply a
-// custom space limit, a team admin needs to set a member space limit for
-// the team first. (the team admin can check the settings here:
+// MemberSpaceLimitsRemoveCustomQuotaContext : Remove users custom quota. A
+// maximum of 1000 members can be specified in a single call. Note: to apply a
+// custom space limit, a team admin needs to set a member space limit for the
+// team first. (the team admin can check the settings here:
 // https://www.dropbox.com/team/admin/settings/space).
 func (dbx *apiImpl) MemberSpaceLimitsRemoveCustomQuotaContext(ctx context.Context, arg *CustomQuotaUsersArg) (res []*RemoveCustomQuotaResult, err error) {
 	req := dropbox.Request{
@@ -2487,9 +2499,9 @@ type MemberSpaceLimitsSetCustomQuotaAPIError struct {
 
 // MemberSpaceLimitsSetCustomQuotaContext : Set users custom quota. Custom quota
 // has to be at least 2GB. A maximum of 1000 members can be specified in a
-// single call. Note: to apply a custom space limit, a team admin needs to
-// set a member space limit for the team first. (the team admin can check
-// the settings here: https://www.dropbox.com/team/admin/settings/space).
+// single call. Note: to apply a custom space limit, a team admin needs to set a
+// member space limit for the team first. (the team admin can check the settings
+// here: https://www.dropbox.com/team/admin/settings/space).
 func (dbx *apiImpl) MemberSpaceLimitsSetCustomQuotaContext(ctx context.Context, arg *SetCustomQuotaArg) (res []*CustomQuotaResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2532,17 +2544,17 @@ type MembersAddAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// MembersAddContext : Adds members to a team. Permission : Team member management
-// A maximum of 20 members can be specified in a single call. If no Dropbox
-// account exists with the email address specified, a new Dropbox account
-// will be created with the given email address, and that account will be
-// invited to the team. If a personal Dropbox account exists with the email
-// address specified in the call, this call will create a placeholder
-// Dropbox account for the user on the team and send an email inviting the
-// user to migrate their existing personal account onto the team. Team
-// member management apps are required to set an initial given_name and
-// surname for a user to use in the team invitation and for 'Perform as team
-// member' actions taken on the user before they become 'active'.
+// MembersAddContext : Adds members to a team. Permission : Team member
+// management A maximum of 20 members can be specified in a single call. If no
+// Dropbox account exists with the email address specified, a new Dropbox
+// account will be created with the given email address, and that account will
+// be invited to the team. If a personal Dropbox account exists with the email
+// address specified in the call, this call will create a placeholder Dropbox
+// account for the user on the team and send an email inviting the user to
+// migrate their existing personal account onto the team. Team member management
+// apps are required to set an initial given_name and surname for a user to use
+// in the team invitation and for 'Perform as team member' actions taken on the
+// user before they become 'active'.
 func (dbx *apiImpl) MembersAddContext(ctx context.Context, arg *MembersAddArg) (res *MembersAddLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2585,14 +2597,14 @@ type MembersAddV2APIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// MembersAddV2Context : Adds members to a team. Permission : Team member management
-// A maximum of 20 members can be specified in a single call. If no Dropbox
-// account exists with the email address specified, a new Dropbox account
-// will be created with the given email address, and that account will be
-// invited to the team. If a personal Dropbox account exists with the email
-// address specified in the call, this call will create a placeholder
-// Dropbox account for the user on the team and send an email inviting the
-// user to migrate their existing personal account onto the team.
+// MembersAddV2Context : Adds members to a team. Permission : Team member
+// management A maximum of 20 members can be specified in a single call. If no
+// Dropbox account exists with the email address specified, a new Dropbox
+// account will be created with the given email address, and that account will
+// be invited to the team. If a personal Dropbox account exists with the email
+// address specified in the call, this call will create a placeholder Dropbox
+// account for the user on the team and send an email inviting the user to
+// migrate their existing personal account onto the team.
 func (dbx *apiImpl) MembersAddV2Context(ctx context.Context, arg *MembersAddV2Arg) (res *MembersAddLaunchV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2725,11 +2737,11 @@ type MembersDeleteFormerMemberFilesAPIError struct {
 	EndpointError *MembersDeleteFormerMemberFilesError `json:"error"`
 }
 
-// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a user
-// who has been removed from the team. After permanent deletion, those files
-// will not be available to be transferred to another team member.
-// Permission : Team member management Exactly one of team_member_id, email,
-// or external_id must be provided to identify the user account.
+// MembersDeleteFormerMemberFilesContext : Permanently delete the files of a
+// user who has been removed from the team. After permanent deletion, those
+// files will not be available to be transferred to another team member.
+// Permission : Team member management Exactly one of team_member_id, email, or
+// external_id must be provided to identify the user account.
 func (dbx *apiImpl) MembersDeleteFormerMemberFilesContext(ctx context.Context, arg *MembersFormerMemberArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2857,8 +2869,8 @@ type MembersGetAvailableTeamMemberRolesAPIError struct {
 }
 
 // MembersGetAvailableTeamMemberRolesContext : Get available TeamMemberRoles for
-// the connected team. To be used with `membersSetAdminPermissions`.
-// Permission : Team member management.
+// the connected team. To be used with `membersSetAdminPermissions`. Permission
+// : Team member management.
 func (dbx *apiImpl) MembersGetAvailableTeamMemberRolesContext(ctx context.Context) (res *MembersGetAvailableTeamMemberRolesResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2903,8 +2915,8 @@ type MembersGetInfoAPIError struct {
 
 // MembersGetInfoContext : Returns information about multiple team members.
 // Permission : Team information This endpoint will return
-// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
-// matched to a valid team member.
+// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be matched
+// to a valid team member.
 func (dbx *apiImpl) MembersGetInfoContext(ctx context.Context, arg *MembersGetInfoArgs) (res []*MembersGetInfoItem, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -2949,8 +2961,8 @@ type MembersGetInfoV2APIError struct {
 
 // MembersGetInfoV2Context : Returns information about multiple team members.
 // Permission : Team information This endpoint will return
-// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be
-// matched to a valid team member.
+// `MembersGetInfoItem.id_not_found`, for IDs (or emails) that cannot be matched
+// to a valid team member.
 func (dbx *apiImpl) MembersGetInfoV2Context(ctx context.Context, arg *MembersGetInfoV2Arg) (res *MembersGetInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3036,7 +3048,8 @@ type MembersListV2APIError struct {
 	EndpointError *MembersListError `json:"error"`
 }
 
-// MembersListV2Context : Lists members of a team. Permission : Team information.
+// MembersListV2Context : Lists members of a team. Permission : Team
+// information.
 func (dbx *apiImpl) MembersListV2Context(ctx context.Context, arg *MembersListArg) (res *MembersListV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3080,8 +3093,8 @@ type MembersListContinueAPIError struct {
 }
 
 // MembersListContinueContext : Once a cursor has been retrieved from
-// `membersList`, use this to paginate through all team members. Permission
-// : Team information.
+// `membersList`, use this to paginate through all team members. Permission :
+// Team information.
 func (dbx *apiImpl) MembersListContinueContext(ctx context.Context, arg *MembersListContinueArg) (res *MembersListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3125,8 +3138,8 @@ type MembersListContinueV2APIError struct {
 }
 
 // MembersListContinueV2Context : Once a cursor has been retrieved from
-// `membersList`, use this to paginate through all team members. Permission
-// : Team information.
+// `membersList`, use this to paginate through all team members. Permission :
+// Team information.
 func (dbx *apiImpl) MembersListContinueV2Context(ctx context.Context, arg *MembersListContinueArg) (res *MembersListV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3170,8 +3183,8 @@ type MembersMoveFormerMemberFilesAPIError struct {
 }
 
 // MembersMoveFormerMemberFilesContext : Moves removed member's files to a
-// different member. This endpoint initiates an asynchronous job. To obtain
-// the final result of the job, the client should periodically poll
+// different member. This endpoint initiates an asynchronous job. To obtain the
+// final result of the job, the client should periodically poll
 // `membersMoveFormerMemberFilesJobStatusCheck`. Permission : Team member
 // management.
 func (dbx *apiImpl) MembersMoveFormerMemberFilesContext(ctx context.Context, arg *MembersDataTransferArg) (res *async.LaunchEmptyResult, err error) {
@@ -3217,8 +3230,8 @@ type MembersMoveFormerMemberFilesJobStatusCheckAPIError struct {
 }
 
 // MembersMoveFormerMemberFilesJobStatusCheckContext : Once an async_job_id is
-// returned from `membersMoveFormerMemberFiles` , use this to poll the
-// status of the asynchronous request. Permission : Team member management.
+// returned from `membersMoveFormerMemberFiles` , use this to poll the status of
+// the asynchronous request. Permission : Team member management.
 func (dbx *apiImpl) MembersMoveFormerMemberFilesJobStatusCheckContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3305,17 +3318,16 @@ type MembersRemoveAPIError struct {
 // MembersRemoveContext : Removes a member from a team. Permission : Team member
 // management Exactly one of team_member_id, email, or external_id must be
 // provided to identify the user account. Accounts can be recovered via
-// `membersRecover` for a 7 day period or until the account has been
-// permanently deleted or transferred to another account (whichever comes
-// first). Calling `membersAdd` while a user is still recoverable on your
-// team will return with `MemberAddResult.user_already_on_team`. Accounts
-// can have their files transferred via the admin console for a limited
-// time, based on the version history length associated with the team (180
-// days for most teams). Accounts can have their stacks transferred through
-// the admin console. This only transfers stacks that they have created.
-// This endpoint may initiate an asynchronous job. To obtain the final
-// result of the job, the client should periodically poll
-// `membersRemoveJobStatusGet`.
+// `membersRecover` for a 7 day period or until the account has been permanently
+// deleted or transferred to another account (whichever comes first). Calling
+// `membersAdd` while a user is still recoverable on your team will return with
+// `MemberAddResult.user_already_on_team`. Accounts can have their files
+// transferred via the admin console for a limited time, based on the version
+// history length associated with the team (180 days for most teams). Accounts
+// can have their stacks transferred through the admin console. This only
+// transfers stacks that they have created. This endpoint may initiate an
+// asynchronous job. To obtain the final result of the job, the client should
+// periodically poll `membersRemoveJobStatusGet`.
 func (dbx *apiImpl) MembersRemoveContext(ctx context.Context, arg *MembersRemoveArg) (res *async.LaunchEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3359,8 +3371,8 @@ type MembersRemoveJobStatusGetAPIError struct {
 }
 
 // MembersRemoveJobStatusGetContext : Once an async_job_id is returned from
-// `membersRemove` , use this to poll the status of the asynchronous
-// request. Permission : Team member management.
+// `membersRemove` , use this to poll the status of the asynchronous request.
+// Permission : Team member management.
 func (dbx *apiImpl) MembersRemoveJobStatusGetContext(ctx context.Context, arg *async.PollArg) (res *async.PollEmptyResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3403,8 +3415,8 @@ type MembersSecondaryEmailsAddAPIError struct {
 	EndpointError *AddSecondaryEmailsError `json:"error"`
 }
 
-// MembersSecondaryEmailsAddContext : Add secondary emails to users. Permission :
-// Team member management. Emails that are on verified domains will be
+// MembersSecondaryEmailsAddContext : Add secondary emails to users. Permission
+// : Team member management. Emails that are on verified domains will be
 // verified automatically. For each email address not on a verified domain a
 // verification email will be sent.
 func (dbx *apiImpl) MembersSecondaryEmailsAddContext(ctx context.Context, arg *AddSecondaryEmailsArg) (res *AddSecondaryEmailsResult, err error) {
@@ -3450,9 +3462,9 @@ type MembersSecondaryEmailsDeleteAPIError struct {
 }
 
 // MembersSecondaryEmailsDeleteContext : Delete secondary emails from users
-// Permission : Team member management. Users will be notified of deletions
-// of verified secondary emails at both the secondary email and their
-// primary email.
+// Permission : Team member management. Users will be notified of deletions of
+// verified secondary emails at both the secondary email and their primary
+// email.
 func (dbx *apiImpl) MembersSecondaryEmailsDeleteContext(ctx context.Context, arg *DeleteSecondaryEmailsArg) (res *DeleteSecondaryEmailsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3495,8 +3507,8 @@ type MembersSecondaryEmailsResendVerificationEmailsAPIError struct {
 	EndpointError struct{} `json:"error"`
 }
 
-// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary email
-// verification emails. Permission : Team member management.
+// MembersSecondaryEmailsResendVerificationEmailsContext : Resend secondary
+// email verification emails. Permission : Team member management.
 func (dbx *apiImpl) MembersSecondaryEmailsResendVerificationEmailsContext(ctx context.Context, arg *ResendVerificationEmailArg) (res *ResendVerificationEmailResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3540,9 +3552,9 @@ type MembersSendWelcomeEmailAPIError struct {
 }
 
 // MembersSendWelcomeEmailContext : Sends welcome email to pending team member.
-// Permission : Team member management Exactly one of team_member_id, email,
-// or external_id must be provided to identify the user account. No-op if
-// team member is not pending.
+// Permission : Team member management Exactly one of team_member_id, email, or
+// external_id must be provided to identify the user account. No-op if team
+// member is not pending.
 func (dbx *apiImpl) MembersSendWelcomeEmailContext(ctx context.Context, arg *UserSelectorArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3713,8 +3725,8 @@ type MembersSetProfileV2APIError struct {
 	EndpointError *MembersSetProfileError `json:"error"`
 }
 
-// MembersSetProfileV2Context : Updates a team member's profile. Permission : Team
-// member management.
+// MembersSetProfileV2Context : Updates a team member's profile. Permission :
+// Team member management.
 func (dbx *apiImpl) MembersSetProfileV2Context(ctx context.Context, arg *MembersSetProfileArg) (res *TeamMemberInfoV2Result, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3845,9 +3857,9 @@ type MembersSuspendAPIError struct {
 	EndpointError *MembersSuspendError `json:"error"`
 }
 
-// MembersSuspendContext : Suspend a member from a team. Permission : Team member
-// management Exactly one of team_member_id, email, or external_id must be
-// provided to identify the user account.
+// MembersSuspendContext : Suspend a member from a team. Permission : Team
+// member management Exactly one of team_member_id, email, or external_id must
+// be provided to identify the user account.
 func (dbx *apiImpl) MembersSuspendContext(ctx context.Context, arg *MembersDeactivateArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3887,8 +3899,8 @@ type MembersUnsuspendAPIError struct {
 }
 
 // MembersUnsuspendContext : Unsuspend a member from a team. Permission : Team
-// member management Exactly one of team_member_id, email, or external_id
-// must be provided to identify the user account.
+// member management Exactly one of team_member_id, email, or external_id must
+// be provided to identify the user account.
 func (dbx *apiImpl) MembersUnsuspendContext(ctx context.Context, arg *MembersUnsuspendArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -3927,12 +3939,12 @@ type NamespacesListAPIError struct {
 	EndpointError *TeamNamespacesListError `json:"error"`
 }
 
-// NamespacesListContext : Returns a list of all team-accessible namespaces. This
-// list includes team folders, shared folders containing team members, team
-// members' home namespaces, and team members' app folders. Home namespaces
-// and app folders are always owned by this team or members of the team, but
-// shared folders may be owned by other users or other teams. Duplicates may
-// occur in the list.
+// NamespacesListContext : Returns a list of all team-accessible namespaces.
+// This list includes team folders, shared folders containing team members, team
+// members' home namespaces, and team members' app folders. Home namespaces and
+// app folders are always owned by this team or members of the team, but shared
+// folders may be owned by other users or other teams. Duplicates may occur in
+// the list.
 func (dbx *apiImpl) NamespacesListContext(ctx context.Context, arg *TeamNamespacesListArg) (res *TeamNamespacesListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4066,8 +4078,8 @@ type PropertiesTemplateGetAPIError struct {
 	EndpointError *file_properties.TemplateError `json:"error"`
 }
 
-// PropertiesTemplateGetContext : Permission : Team member file access. The scope
-// for the route is files.team_metadata.write.
+// PropertiesTemplateGetContext : Permission : Team member file access. The
+// scope for the route is files.team_metadata.write.
 // Deprecated:
 func (dbx *apiImpl) PropertiesTemplateGetContext(ctx context.Context, arg *file_properties.GetTemplateArg) (res *file_properties.GetTemplateResult, err error) {
 	log.Printf("WARNING: API `PropertiesTemplateGet` is deprecated")
@@ -4352,8 +4364,7 @@ type SharingAllowlistListAPIError struct {
 // SharingAllowlistListContext : Lists Approve List entries for given team, from
 // newest to oldest, returning up to `limit` entries at a time. If there are
 // more than `limit` entries associated with the current team, more can be
-// fetched by passing the returned `cursor` to
-// `sharingAllowlistListContinue`.
+// fetched by passing the returned `cursor` to `sharingAllowlistListContinue`.
 func (dbx *apiImpl) SharingAllowlistListContext(ctx context.Context, arg *SharingAllowlistListArg) (res *SharingAllowlistListResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4396,8 +4407,8 @@ type SharingAllowlistListContinueAPIError struct {
 	EndpointError *SharingAllowlistListContinueError `json:"error"`
 }
 
-// SharingAllowlistListContinueContext : Lists entries associated with given team,
-// starting from a the cursor. See `sharingAllowlistList`.
+// SharingAllowlistListContinueContext : Lists entries associated with given
+// team, starting from a the cursor. See `sharingAllowlistList`.
 func (dbx *apiImpl) SharingAllowlistListContinueContext(ctx context.Context, arg *SharingAllowlistListContinueArg) (res *SharingAllowlistListResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4440,12 +4451,11 @@ type SharingAllowlistRemoveAPIError struct {
 	EndpointError *SharingAllowlistRemoveError `json:"error"`
 }
 
-// SharingAllowlistRemoveContext : Endpoint removes Approve List entries. Changes
-// are effective immediately. Changes are committed in transaction. In case
-// of single validation error - all entries are rejected. Valid domains
-// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries being
-// removed have to be present on the list. Maximum 1000 entries per call is
-// allowed.
+// SharingAllowlistRemoveContext : Endpoint removes Approve List entries.
+// Changes are effective immediately. Changes are committed in transaction. In
+// case of single validation error - all entries are rejected. Valid domains
+// (RFC-1034/5) and emails (RFC-5322/822) are accepted. Entries being removed
+// have to be present on the list. Maximum 1000 entries per call is allowed.
 func (dbx *apiImpl) SharingAllowlistRemoveContext(ctx context.Context, arg *SharingAllowlistRemoveArgs) (res *SharingAllowlistRemoveResponse, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4532,12 +4542,12 @@ type TeamFolderArchiveAPIError struct {
 	EndpointError *TeamFolderArchiveError `json:"error"`
 }
 
-// TeamFolderArchiveContext : Sets an active team folder's status to archived and
-// removes all folder and file members. This endpoint cannot be used for
+// TeamFolderArchiveContext : Sets an active team folder's status to archived
+// and removes all folder and file members. This endpoint cannot be used for
 // teams that have a shared team space. This route will either finish
-// synchronously, or return a job ID and do the async archive job in
-// background. Please use team_folder/archive/check to check the job status.
-// Permission : Team member file access.
+// synchronously, or return a job ID and do the async archive job in background.
+// Please use team_folder/archive/check to check the job status. Permission :
+// Team member file access.
 func (dbx *apiImpl) TeamFolderArchiveContext(ctx context.Context, arg *TeamFolderArchiveArg) (res *TeamFolderArchiveLaunch, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4581,12 +4591,11 @@ type TeamFolderArchiveCheckAPIError struct {
 }
 
 // TeamFolderArchiveCheckContext : Returns the status of an asynchronous job for
-// archiving a team folder. The job may show '.tag' as complete, but the
-// team folder could still be in the process of archiving (indicated by
-// `TeamFolderMetadata.status` with 'archive_in_progress'). To confirm that
-// the team folder is fully archived, check the field
-// `TeamFolderMetadata.status` in the response for the value 'archived'.
-// Permission : Team member file access.
+// archiving a team folder. The job may show '.tag' as complete, but the team
+// folder could still be in the process of archiving (indicated by
+// `TeamFolderMetadata.status` with 'archive_in_progress'). To confirm that the
+// team folder is fully archived, check the field `TeamFolderMetadata.status` in
+// the response for the value 'archived'. Permission : Team member file access.
 func (dbx *apiImpl) TeamFolderArchiveCheckContext(ctx context.Context, arg *async.PollArg) (res *TeamFolderArchiveJobStatus, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4630,8 +4639,8 @@ type TeamFolderCreateAPIError struct {
 }
 
 // TeamFolderCreateContext : Creates a new, active, team folder with no members.
-// This endpoint can only be used for teams that do not already have a
-// shared team space. Permission : Team member file access.
+// This endpoint can only be used for teams that do not already have a shared
+// team space. Permission : Team member file access.
 func (dbx *apiImpl) TeamFolderCreateContext(ctx context.Context, arg *TeamFolderCreateArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4763,8 +4772,8 @@ type TeamFolderListContinueAPIError struct {
 }
 
 // TeamFolderListContinueContext : Once a cursor has been retrieved from
-// `teamFolderList`, use this to paginate through all team folders.
-// Permission : Team member file access.
+// `teamFolderList`, use this to paginate through all team folders. Permission :
+// Team member file access.
 func (dbx *apiImpl) TeamFolderListContinueContext(ctx context.Context, arg *TeamFolderListContinueArg) (res *TeamFolderListResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4808,8 +4817,8 @@ type TeamFolderPermanentlyDeleteAPIError struct {
 }
 
 // TeamFolderPermanentlyDeleteContext : Permanently deletes an archived team
-// folder. This endpoint cannot be used for teams that have a shared team
-// space. Permission : Team member file access.
+// folder. This endpoint cannot be used for teams that have a shared team space.
+// Permission : Team member file access.
 func (dbx *apiImpl) TeamFolderPermanentlyDeleteContext(ctx context.Context, arg *TeamFolderIdArg) (err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -4936,8 +4945,8 @@ type TeamFolderUpdateSyncSettingsAPIError struct {
 	EndpointError *TeamFolderUpdateSyncSettingsError `json:"error"`
 }
 
-// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team folder
-// or its contents.  Use of this endpoint requires that the team has team
+// TeamFolderUpdateSyncSettingsContext : Updates the sync settings on a team
+// folder or its contents.  Use of this endpoint requires that the team has team
 // selective sync enabled.
 func (dbx *apiImpl) TeamFolderUpdateSyncSettingsContext(ctx context.Context, arg *TeamFolderUpdateSyncSettingsArg) (res *TeamFolderMetadata, err error) {
 	req := dropbox.Request{
@@ -4981,8 +4990,8 @@ type TokenGetAuthenticatedAdminAPIError struct {
 	EndpointError *TokenGetAuthenticatedAdminError `json:"error"`
 }
 
-// TokenGetAuthenticatedAdminContext : Returns the member profile of the admin who
-// generated the team access token used to make the call.
+// TokenGetAuthenticatedAdminContext : Returns the member profile of the admin
+// who generated the team access token used to make the call.
 func (dbx *apiImpl) TokenGetAuthenticatedAdminContext(ctx context.Context) (res *TokenGetAuthenticatedAdminResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/team/types.go
+++ b/v6/dropbox/team/types.go
@@ -5136,11 +5136,12 @@ type TeamFolderCreateError struct {
 
 // Valid tag values for TeamFolderCreateError
 const (
-	TeamFolderCreateErrorInvalidFolderName     = "invalid_folder_name"
-	TeamFolderCreateErrorFolderNameAlreadyUsed = "folder_name_already_used"
-	TeamFolderCreateErrorFolderNameReserved    = "folder_name_reserved"
-	TeamFolderCreateErrorSyncSettingsError     = "sync_settings_error"
-	TeamFolderCreateErrorOther                 = "other"
+	TeamFolderCreateErrorInvalidFolderName        = "invalid_folder_name"
+	TeamFolderCreateErrorFolderNameAlreadyUsed    = "folder_name_already_used"
+	TeamFolderCreateErrorFolderNameReserved       = "folder_name_reserved"
+	TeamFolderCreateErrorSyncSettingsError        = "sync_settings_error"
+	TeamFolderCreateErrorFolderCountLimitExceeded = "folder_count_limit_exceeded"
+	TeamFolderCreateErrorOther                    = "other"
 )
 
 // UnmarshalJSON deserializes into a TeamFolderCreateError instance

--- a/v6/dropbox/team_log/client.go
+++ b/v6/dropbox/team_log/client.go
@@ -62,8 +62,9 @@ type ContextClient interface {
 	// </developers/documentation/http/teams#team-features-get_values> to check
 	// for this feature. Permission : Team Auditing.
 	GetEventsContext(ctx context.Context, arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error)
-	// GetEventsContinueContext : Once a cursor has been retrieved from `getEvents`,
-	// use this to paginate through all events. Permission : Team Auditing.
+	// GetEventsContinueContext : Once a cursor has been retrieved from
+	// `getEvents`, use this to paginate through all events. Permission : Team
+	// Auditing.
 	GetEventsContinueContext(ctx context.Context, arg *GetTeamEventsContinueArg) (res *GetTeamEventsResult, err error)
 }
 
@@ -76,15 +77,15 @@ type GetEventsAPIError struct {
 }
 
 // GetEventsContext : Retrieves team events. If the result's
-// `GetTeamEventsResult.has_more` field is true, call `getEventsContinue`
-// with the returned cursor to retrieve more entries. If end_time is not
-// specified in your request, you may use the returned cursor to poll
-// `getEventsContinue` for new events. Many attributes note 'may be missing
-// due to historical data gap'. Note that the file_operations category and &
-// analogous paper events are not available on all Dropbox Business `plans`
-// </business/plans-comparison>. Use `features/get_values`
-// </developers/documentation/http/teams#team-features-get_values> to check
-// for this feature. Permission : Team Auditing.
+// `GetTeamEventsResult.has_more` field is true, call `getEventsContinue` with
+// the returned cursor to retrieve more entries. If end_time is not specified in
+// your request, you may use the returned cursor to poll `getEventsContinue` for
+// new events. Many attributes note 'may be missing due to historical data gap'.
+// Note that the file_operations category and & analogous paper events are not
+// available on all Dropbox Business `plans` </business/plans-comparison>. Use
+// `features/get_values`
+// </developers/documentation/http/teams#team-features-get_values> to check for
+// this feature. Permission : Team Auditing.
 func (dbx *apiImpl) GetEventsContext(ctx context.Context, arg *GetTeamEventsArg) (res *GetTeamEventsResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",

--- a/v6/dropbox/team_log/types.go
+++ b/v6/dropbox/team_log/types.go
@@ -5811,6 +5811,8 @@ type EventDetails struct {
 	FolderOverviewItemPinnedDetails *FolderOverviewItemPinnedDetails `json:"folder_overview_item_pinned_details,omitempty"`
 	// FolderOverviewItemUnpinnedDetails : has no documentation (yet)
 	FolderOverviewItemUnpinnedDetails *FolderOverviewItemUnpinnedDetails `json:"folder_overview_item_unpinned_details,omitempty"`
+	// MediaHubFileDownloadedDetails : has no documentation (yet)
+	MediaHubFileDownloadedDetails *MediaHubFileDownloadedDetails `json:"media_hub_file_downloaded_details,omitempty"`
 	// ObjectLabelAddedDetails : has no documentation (yet)
 	ObjectLabelAddedDetails *ObjectLabelAddedDetails `json:"object_label_added_details,omitempty"`
 	// ObjectLabelRemovedDetails : has no documentation (yet)
@@ -6145,6 +6147,21 @@ type EventDetails struct {
 	FileTransfersTransferSendDetails *FileTransfersTransferSendDetails `json:"file_transfers_transfer_send_details,omitempty"`
 	// FileTransfersTransferViewDetails : has no documentation (yet)
 	FileTransfersTransferViewDetails *FileTransfersTransferViewDetails `json:"file_transfers_transfer_view_details,omitempty"`
+	// MediaHubProjectTeamAddDetails : has no documentation (yet)
+	MediaHubProjectTeamAddDetails *MediaHubProjectTeamAddDetails `json:"media_hub_project_team_add_details,omitempty"`
+	// MediaHubProjectTeamDeleteDetails : has no documentation (yet)
+	MediaHubProjectTeamDeleteDetails *MediaHubProjectTeamDeleteDetails `json:"media_hub_project_team_delete_details,omitempty"`
+	// MediaHubProjectTeamRoleChangedDetails : has no documentation (yet)
+	MediaHubProjectTeamRoleChangedDetails *MediaHubProjectTeamRoleChangedDetails `json:"media_hub_project_team_role_changed_details,omitempty"`
+	// MediaHubSharedLinkAudienceChangedDetails : has no documentation (yet)
+	MediaHubSharedLinkAudienceChangedDetails *MediaHubSharedLinkAudienceChangedDetails `json:"media_hub_shared_link_audience_changed_details,omitempty"`
+	// MediaHubSharedLinkCreatedDetails : has no documentation (yet)
+	MediaHubSharedLinkCreatedDetails *MediaHubSharedLinkCreatedDetails `json:"media_hub_shared_link_created_details,omitempty"`
+	// MediaHubSharedLinkDownloadSettingChangedDetails : has no documentation
+	// (yet)
+	MediaHubSharedLinkDownloadSettingChangedDetails *MediaHubSharedLinkDownloadSettingChangedDetails `json:"media_hub_shared_link_download_setting_changed_details,omitempty"`
+	// MediaHubSharedLinkRevokedDetails : has no documentation (yet)
+	MediaHubSharedLinkRevokedDetails *MediaHubSharedLinkRevokedDetails `json:"media_hub_shared_link_revoked_details,omitempty"`
 	// NoteAclInviteOnlyDetails : has no documentation (yet)
 	NoteAclInviteOnlyDetails *NoteAclInviteOnlyDetails `json:"note_acl_invite_only_details,omitempty"`
 	// NoteAclLinkDetails : has no documentation (yet)
@@ -6525,6 +6542,12 @@ type EventDetails struct {
 	IntegrationPolicyChangedDetails *IntegrationPolicyChangedDetails `json:"integration_policy_changed_details,omitempty"`
 	// InviteAcceptanceEmailPolicyChangedDetails : has no documentation (yet)
 	InviteAcceptanceEmailPolicyChangedDetails *InviteAcceptanceEmailPolicyChangedDetails `json:"invite_acceptance_email_policy_changed_details,omitempty"`
+	// MediaHubAddingPeoplePolicyChangedDetails : has no documentation (yet)
+	MediaHubAddingPeoplePolicyChangedDetails *MediaHubAddingPeoplePolicyChangedDetails `json:"media_hub_adding_people_policy_changed_details,omitempty"`
+	// MediaHubDownloadPolicyChangedDetails : has no documentation (yet)
+	MediaHubDownloadPolicyChangedDetails *MediaHubDownloadPolicyChangedDetails `json:"media_hub_download_policy_changed_details,omitempty"`
+	// MediaHubLinkSharingPolicyChangedDetails : has no documentation (yet)
+	MediaHubLinkSharingPolicyChangedDetails *MediaHubLinkSharingPolicyChangedDetails `json:"media_hub_link_sharing_policy_changed_details,omitempty"`
 	// MemberRequestsChangePolicyDetails : has no documentation (yet)
 	MemberRequestsChangePolicyDetails *MemberRequestsChangePolicyDetails `json:"member_requests_change_policy_details,omitempty"`
 	// MemberSendInvitePolicyChangedDetails : has no documentation (yet)
@@ -6543,6 +6566,8 @@ type EventDetails struct {
 	MicrosoftLoginChangePolicyDetails *MicrosoftLoginChangePolicyDetails `json:"microsoft_login_change_policy_details,omitempty"`
 	// MicrosoftOfficeAddinChangePolicyDetails : has no documentation (yet)
 	MicrosoftOfficeAddinChangePolicyDetails *MicrosoftOfficeAddinChangePolicyDetails `json:"microsoft_office_addin_change_policy_details,omitempty"`
+	// MultiTeamIdentityPolicyChangedDetails : has no documentation (yet)
+	MultiTeamIdentityPolicyChangedDetails *MultiTeamIdentityPolicyChangedDetails `json:"multi_team_identity_policy_changed_details,omitempty"`
 	// NetworkControlChangePolicyDetails : has no documentation (yet)
 	NetworkControlChangePolicyDetails *NetworkControlChangePolicyDetails `json:"network_control_change_policy_details,omitempty"`
 	// PaperChangeDeploymentPolicyDetails : has no documentation (yet)
@@ -6913,6 +6938,7 @@ const (
 	EventDetailsFolderOverviewDescriptionChangedDetails              = "folder_overview_description_changed_details"
 	EventDetailsFolderOverviewItemPinnedDetails                      = "folder_overview_item_pinned_details"
 	EventDetailsFolderOverviewItemUnpinnedDetails                    = "folder_overview_item_unpinned_details"
+	EventDetailsMediaHubFileDownloadedDetails                        = "media_hub_file_downloaded_details"
 	EventDetailsObjectLabelAddedDetails                              = "object_label_added_details"
 	EventDetailsObjectLabelRemovedDetails                            = "object_label_removed_details"
 	EventDetailsObjectLabelUpdatedValueDetails                       = "object_label_updated_value_details"
@@ -7079,6 +7105,13 @@ const (
 	EventDetailsFileTransfersTransferDownloadDetails                 = "file_transfers_transfer_download_details"
 	EventDetailsFileTransfersTransferSendDetails                     = "file_transfers_transfer_send_details"
 	EventDetailsFileTransfersTransferViewDetails                     = "file_transfers_transfer_view_details"
+	EventDetailsMediaHubProjectTeamAddDetails                        = "media_hub_project_team_add_details"
+	EventDetailsMediaHubProjectTeamDeleteDetails                     = "media_hub_project_team_delete_details"
+	EventDetailsMediaHubProjectTeamRoleChangedDetails                = "media_hub_project_team_role_changed_details"
+	EventDetailsMediaHubSharedLinkAudienceChangedDetails             = "media_hub_shared_link_audience_changed_details"
+	EventDetailsMediaHubSharedLinkCreatedDetails                     = "media_hub_shared_link_created_details"
+	EventDetailsMediaHubSharedLinkDownloadSettingChangedDetails      = "media_hub_shared_link_download_setting_changed_details"
+	EventDetailsMediaHubSharedLinkRevokedDetails                     = "media_hub_shared_link_revoked_details"
 	EventDetailsNoteAclInviteOnlyDetails                             = "note_acl_invite_only_details"
 	EventDetailsNoteAclLinkDetails                                   = "note_acl_link_details"
 	EventDetailsNoteAclTeamLinkDetails                               = "note_acl_team_link_details"
@@ -7265,6 +7298,9 @@ const (
 	EventDetailsGroupUserManagementChangePolicyDetails               = "group_user_management_change_policy_details"
 	EventDetailsIntegrationPolicyChangedDetails                      = "integration_policy_changed_details"
 	EventDetailsInviteAcceptanceEmailPolicyChangedDetails            = "invite_acceptance_email_policy_changed_details"
+	EventDetailsMediaHubAddingPeoplePolicyChangedDetails             = "media_hub_adding_people_policy_changed_details"
+	EventDetailsMediaHubDownloadPolicyChangedDetails                 = "media_hub_download_policy_changed_details"
+	EventDetailsMediaHubLinkSharingPolicyChangedDetails              = "media_hub_link_sharing_policy_changed_details"
 	EventDetailsMemberRequestsChangePolicyDetails                    = "member_requests_change_policy_details"
 	EventDetailsMemberSendInvitePolicyChangedDetails                 = "member_send_invite_policy_changed_details"
 	EventDetailsMemberSpaceLimitsAddExceptionDetails                 = "member_space_limits_add_exception_details"
@@ -7274,6 +7310,7 @@ const (
 	EventDetailsMemberSuggestionsChangePolicyDetails                 = "member_suggestions_change_policy_details"
 	EventDetailsMicrosoftLoginChangePolicyDetails                    = "microsoft_login_change_policy_details"
 	EventDetailsMicrosoftOfficeAddinChangePolicyDetails              = "microsoft_office_addin_change_policy_details"
+	EventDetailsMultiTeamIdentityPolicyChangedDetails                = "multi_team_identity_policy_changed_details"
 	EventDetailsNetworkControlChangePolicyDetails                    = "network_control_change_policy_details"
 	EventDetailsPaperChangeDeploymentPolicyDetails                   = "paper_change_deployment_policy_details"
 	EventDetailsPaperChangeMemberLinkPolicyDetails                   = "paper_change_member_link_policy_details"
@@ -8119,6 +8156,11 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 			return err
 		}
 
+	case "media_hub_file_downloaded_details":
+		if err = json.Unmarshal(body, &u.MediaHubFileDownloadedDetails); err != nil {
+			return err
+		}
+
 	case "object_label_added_details":
 		if err = json.Unmarshal(body, &u.ObjectLabelAddedDetails); err != nil {
 			return err
@@ -8946,6 +8988,41 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 
 	case "file_transfers_transfer_view_details":
 		if err = json.Unmarshal(body, &u.FileTransfersTransferViewDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_add_details":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamAddDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_delete_details":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamDeleteDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_role_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamRoleChangedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_audience_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkAudienceChangedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_created_details":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkCreatedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_download_setting_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkDownloadSettingChangedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_revoked_details":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkRevokedDetails); err != nil {
 			return err
 		}
 
@@ -9879,6 +9956,21 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 			return err
 		}
 
+	case "media_hub_adding_people_policy_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubAddingPeoplePolicyChangedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_download_policy_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubDownloadPolicyChangedDetails); err != nil {
+			return err
+		}
+
+	case "media_hub_link_sharing_policy_changed_details":
+		if err = json.Unmarshal(body, &u.MediaHubLinkSharingPolicyChangedDetails); err != nil {
+			return err
+		}
+
 	case "member_requests_change_policy_details":
 		if err = json.Unmarshal(body, &u.MemberRequestsChangePolicyDetails); err != nil {
 			return err
@@ -9921,6 +10013,11 @@ func (u *EventDetails) UnmarshalJSON(body []byte) error {
 
 	case "microsoft_office_addin_change_policy_details":
 		if err = json.Unmarshal(body, &u.MicrosoftOfficeAddinChangePolicyDetails); err != nil {
+			return err
+		}
+
+	case "multi_team_identity_policy_changed_details":
+		if err = json.Unmarshal(body, &u.MultiTeamIdentityPolicyChangedDetails); err != nil {
 			return err
 		}
 
@@ -10788,6 +10885,8 @@ type EventType struct {
 	// FolderOverviewItemUnpinned : (file_operations) Unpinned item from folder
 	// overview
 	FolderOverviewItemUnpinned *FolderOverviewItemUnpinnedType `json:"folder_overview_item_unpinned,omitempty"`
+	// MediaHubFileDownloaded : (file_operations) Downloaded files in Media Hub
+	MediaHubFileDownloaded *MediaHubFileDownloadedType `json:"media_hub_file_downloaded,omitempty"`
 	// ObjectLabelAdded : (file_operations) Added a label
 	ObjectLabelAdded *ObjectLabelAddedType `json:"object_label_added,omitempty"`
 	// ObjectLabelRemoved : (file_operations) Removed a label
@@ -11183,6 +11282,24 @@ type EventType struct {
 	FileTransfersTransferSend *FileTransfersTransferSendType `json:"file_transfers_transfer_send,omitempty"`
 	// FileTransfersTransferView : (sharing) Viewed transfer
 	FileTransfersTransferView *FileTransfersTransferViewType `json:"file_transfers_transfer_view,omitempty"`
+	// MediaHubProjectTeamAdd : (sharing) Added member to Media Hub project
+	MediaHubProjectTeamAdd *MediaHubProjectTeamAddType `json:"media_hub_project_team_add,omitempty"`
+	// MediaHubProjectTeamDelete : (sharing) Removed member from Media Hub
+	// project
+	MediaHubProjectTeamDelete *MediaHubProjectTeamDeleteType `json:"media_hub_project_team_delete,omitempty"`
+	// MediaHubProjectTeamRoleChanged : (sharing) Changed member role in Media
+	// Hub project
+	MediaHubProjectTeamRoleChanged *MediaHubProjectTeamRoleChangedType `json:"media_hub_project_team_role_changed,omitempty"`
+	// MediaHubSharedLinkAudienceChanged : (sharing) Changed Media Hub shared
+	// link audience
+	MediaHubSharedLinkAudienceChanged *MediaHubSharedLinkAudienceChangedType `json:"media_hub_shared_link_audience_changed,omitempty"`
+	// MediaHubSharedLinkCreated : (sharing) Created Media Hub shared link
+	MediaHubSharedLinkCreated *MediaHubSharedLinkCreatedType `json:"media_hub_shared_link_created,omitempty"`
+	// MediaHubSharedLinkDownloadSettingChanged : (sharing) Changed Media Hub
+	// shared link download setting
+	MediaHubSharedLinkDownloadSettingChanged *MediaHubSharedLinkDownloadSettingChangedType `json:"media_hub_shared_link_download_setting_changed,omitempty"`
+	// MediaHubSharedLinkRevoked : (sharing) Revoked Media Hub shared link
+	MediaHubSharedLinkRevoked *MediaHubSharedLinkRevokedType `json:"media_hub_shared_link_revoked,omitempty"`
 	// NoteAclInviteOnly : (sharing) Changed Paper doc to invite-only
 	// (deprecated, no longer logged)
 	NoteAclInviteOnly *NoteAclInviteOnlyType `json:"note_acl_invite_only,omitempty"`
@@ -11665,6 +11782,15 @@ type EventType struct {
 	// InviteAcceptanceEmailPolicyChanged : (team_policies) Changed invite
 	// accept email policy for team
 	InviteAcceptanceEmailPolicyChanged *InviteAcceptanceEmailPolicyChangedType `json:"invite_acceptance_email_policy_changed,omitempty"`
+	// MediaHubAddingPeoplePolicyChanged : (team_policies) Changed the policy
+	// for adding people to Media Hub content
+	MediaHubAddingPeoplePolicyChanged *MediaHubAddingPeoplePolicyChangedType `json:"media_hub_adding_people_policy_changed,omitempty"`
+	// MediaHubDownloadPolicyChanged : (team_policies) Changed the policy for
+	// downloading Media Hub content
+	MediaHubDownloadPolicyChanged *MediaHubDownloadPolicyChangedType `json:"media_hub_download_policy_changed,omitempty"`
+	// MediaHubLinkSharingPolicyChanged : (team_policies) Changed the policy for
+	// sharing Media Hub content
+	MediaHubLinkSharingPolicyChanged *MediaHubLinkSharingPolicyChangedType `json:"media_hub_link_sharing_policy_changed,omitempty"`
 	// MemberRequestsChangePolicy : (team_policies) Changed whether users can
 	// find team when not invited
 	MemberRequestsChangePolicy *MemberRequestsChangePolicyType `json:"member_requests_change_policy,omitempty"`
@@ -11692,6 +11818,9 @@ type EventType struct {
 	// MicrosoftOfficeAddinChangePolicy : (team_policies) Enabled/disabled
 	// Microsoft Office add-in
 	MicrosoftOfficeAddinChangePolicy *MicrosoftOfficeAddinChangePolicyType `json:"microsoft_office_addin_change_policy,omitempty"`
+	// MultiTeamIdentityPolicyChanged : (team_policies) Changed multi-team
+	// identity policy for team
+	MultiTeamIdentityPolicyChanged *MultiTeamIdentityPolicyChangedType `json:"multi_team_identity_policy_changed,omitempty"`
 	// NetworkControlChangePolicy : (team_policies) Enabled/disabled network
 	// control
 	NetworkControlChangePolicy *NetworkControlChangePolicyType `json:"network_control_change_policy,omitempty"`
@@ -12134,6 +12263,7 @@ const (
 	EventTypeFolderOverviewDescriptionChanged              = "folder_overview_description_changed"
 	EventTypeFolderOverviewItemPinned                      = "folder_overview_item_pinned"
 	EventTypeFolderOverviewItemUnpinned                    = "folder_overview_item_unpinned"
+	EventTypeMediaHubFileDownloaded                        = "media_hub_file_downloaded"
 	EventTypeObjectLabelAdded                              = "object_label_added"
 	EventTypeObjectLabelRemoved                            = "object_label_removed"
 	EventTypeObjectLabelUpdatedValue                       = "object_label_updated_value"
@@ -12300,6 +12430,13 @@ const (
 	EventTypeFileTransfersTransferDownload                 = "file_transfers_transfer_download"
 	EventTypeFileTransfersTransferSend                     = "file_transfers_transfer_send"
 	EventTypeFileTransfersTransferView                     = "file_transfers_transfer_view"
+	EventTypeMediaHubProjectTeamAdd                        = "media_hub_project_team_add"
+	EventTypeMediaHubProjectTeamDelete                     = "media_hub_project_team_delete"
+	EventTypeMediaHubProjectTeamRoleChanged                = "media_hub_project_team_role_changed"
+	EventTypeMediaHubSharedLinkAudienceChanged             = "media_hub_shared_link_audience_changed"
+	EventTypeMediaHubSharedLinkCreated                     = "media_hub_shared_link_created"
+	EventTypeMediaHubSharedLinkDownloadSettingChanged      = "media_hub_shared_link_download_setting_changed"
+	EventTypeMediaHubSharedLinkRevoked                     = "media_hub_shared_link_revoked"
 	EventTypeNoteAclInviteOnly                             = "note_acl_invite_only"
 	EventTypeNoteAclLink                                   = "note_acl_link"
 	EventTypeNoteAclTeamLink                               = "note_acl_team_link"
@@ -12486,6 +12623,9 @@ const (
 	EventTypeGroupUserManagementChangePolicy               = "group_user_management_change_policy"
 	EventTypeIntegrationPolicyChanged                      = "integration_policy_changed"
 	EventTypeInviteAcceptanceEmailPolicyChanged            = "invite_acceptance_email_policy_changed"
+	EventTypeMediaHubAddingPeoplePolicyChanged             = "media_hub_adding_people_policy_changed"
+	EventTypeMediaHubDownloadPolicyChanged                 = "media_hub_download_policy_changed"
+	EventTypeMediaHubLinkSharingPolicyChanged              = "media_hub_link_sharing_policy_changed"
 	EventTypeMemberRequestsChangePolicy                    = "member_requests_change_policy"
 	EventTypeMemberSendInvitePolicyChanged                 = "member_send_invite_policy_changed"
 	EventTypeMemberSpaceLimitsAddException                 = "member_space_limits_add_exception"
@@ -12495,6 +12635,7 @@ const (
 	EventTypeMemberSuggestionsChangePolicy                 = "member_suggestions_change_policy"
 	EventTypeMicrosoftLoginChangePolicy                    = "microsoft_login_change_policy"
 	EventTypeMicrosoftOfficeAddinChangePolicy              = "microsoft_office_addin_change_policy"
+	EventTypeMultiTeamIdentityPolicyChanged                = "multi_team_identity_policy_changed"
 	EventTypeNetworkControlChangePolicy                    = "network_control_change_policy"
 	EventTypePaperChangeDeploymentPolicy                   = "paper_change_deployment_policy"
 	EventTypePaperChangeMemberLinkPolicy                   = "paper_change_member_link_policy"
@@ -13339,6 +13480,11 @@ func (u *EventType) UnmarshalJSON(body []byte) error {
 			return err
 		}
 
+	case "media_hub_file_downloaded":
+		if err = json.Unmarshal(body, &u.MediaHubFileDownloaded); err != nil {
+			return err
+		}
+
 	case "object_label_added":
 		if err = json.Unmarshal(body, &u.ObjectLabelAdded); err != nil {
 			return err
@@ -14166,6 +14312,41 @@ func (u *EventType) UnmarshalJSON(body []byte) error {
 
 	case "file_transfers_transfer_view":
 		if err = json.Unmarshal(body, &u.FileTransfersTransferView); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_add":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamAdd); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_delete":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamDelete); err != nil {
+			return err
+		}
+
+	case "media_hub_project_team_role_changed":
+		if err = json.Unmarshal(body, &u.MediaHubProjectTeamRoleChanged); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_audience_changed":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkAudienceChanged); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_created":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkCreated); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_download_setting_changed":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkDownloadSettingChanged); err != nil {
+			return err
+		}
+
+	case "media_hub_shared_link_revoked":
+		if err = json.Unmarshal(body, &u.MediaHubSharedLinkRevoked); err != nil {
 			return err
 		}
 
@@ -15099,6 +15280,21 @@ func (u *EventType) UnmarshalJSON(body []byte) error {
 			return err
 		}
 
+	case "media_hub_adding_people_policy_changed":
+		if err = json.Unmarshal(body, &u.MediaHubAddingPeoplePolicyChanged); err != nil {
+			return err
+		}
+
+	case "media_hub_download_policy_changed":
+		if err = json.Unmarshal(body, &u.MediaHubDownloadPolicyChanged); err != nil {
+			return err
+		}
+
+	case "media_hub_link_sharing_policy_changed":
+		if err = json.Unmarshal(body, &u.MediaHubLinkSharingPolicyChanged); err != nil {
+			return err
+		}
+
 	case "member_requests_change_policy":
 		if err = json.Unmarshal(body, &u.MemberRequestsChangePolicy); err != nil {
 			return err
@@ -15141,6 +15337,11 @@ func (u *EventType) UnmarshalJSON(body []byte) error {
 
 	case "microsoft_office_addin_change_policy":
 		if err = json.Unmarshal(body, &u.MicrosoftOfficeAddinChangePolicy); err != nil {
+			return err
+		}
+
+	case "multi_team_identity_policy_changed":
+		if err = json.Unmarshal(body, &u.MultiTeamIdentityPolicyChanged); err != nil {
 			return err
 		}
 
@@ -15796,6 +15997,7 @@ const (
 	EventTypeArgFolderOverviewDescriptionChanged              = "folder_overview_description_changed"
 	EventTypeArgFolderOverviewItemPinned                      = "folder_overview_item_pinned"
 	EventTypeArgFolderOverviewItemUnpinned                    = "folder_overview_item_unpinned"
+	EventTypeArgMediaHubFileDownloaded                        = "media_hub_file_downloaded"
 	EventTypeArgObjectLabelAdded                              = "object_label_added"
 	EventTypeArgObjectLabelRemoved                            = "object_label_removed"
 	EventTypeArgObjectLabelUpdatedValue                       = "object_label_updated_value"
@@ -15962,6 +16164,13 @@ const (
 	EventTypeArgFileTransfersTransferDownload                 = "file_transfers_transfer_download"
 	EventTypeArgFileTransfersTransferSend                     = "file_transfers_transfer_send"
 	EventTypeArgFileTransfersTransferView                     = "file_transfers_transfer_view"
+	EventTypeArgMediaHubProjectTeamAdd                        = "media_hub_project_team_add"
+	EventTypeArgMediaHubProjectTeamDelete                     = "media_hub_project_team_delete"
+	EventTypeArgMediaHubProjectTeamRoleChanged                = "media_hub_project_team_role_changed"
+	EventTypeArgMediaHubSharedLinkAudienceChanged             = "media_hub_shared_link_audience_changed"
+	EventTypeArgMediaHubSharedLinkCreated                     = "media_hub_shared_link_created"
+	EventTypeArgMediaHubSharedLinkDownloadSettingChanged      = "media_hub_shared_link_download_setting_changed"
+	EventTypeArgMediaHubSharedLinkRevoked                     = "media_hub_shared_link_revoked"
 	EventTypeArgNoteAclInviteOnly                             = "note_acl_invite_only"
 	EventTypeArgNoteAclLink                                   = "note_acl_link"
 	EventTypeArgNoteAclTeamLink                               = "note_acl_team_link"
@@ -16148,6 +16357,9 @@ const (
 	EventTypeArgGroupUserManagementChangePolicy               = "group_user_management_change_policy"
 	EventTypeArgIntegrationPolicyChanged                      = "integration_policy_changed"
 	EventTypeArgInviteAcceptanceEmailPolicyChanged            = "invite_acceptance_email_policy_changed"
+	EventTypeArgMediaHubAddingPeoplePolicyChanged             = "media_hub_adding_people_policy_changed"
+	EventTypeArgMediaHubDownloadPolicyChanged                 = "media_hub_download_policy_changed"
+	EventTypeArgMediaHubLinkSharingPolicyChanged              = "media_hub_link_sharing_policy_changed"
 	EventTypeArgMemberRequestsChangePolicy                    = "member_requests_change_policy"
 	EventTypeArgMemberSendInvitePolicyChanged                 = "member_send_invite_policy_changed"
 	EventTypeArgMemberSpaceLimitsAddException                 = "member_space_limits_add_exception"
@@ -16157,6 +16369,7 @@ const (
 	EventTypeArgMemberSuggestionsChangePolicy                 = "member_suggestions_change_policy"
 	EventTypeArgMicrosoftLoginChangePolicy                    = "microsoft_login_change_policy"
 	EventTypeArgMicrosoftOfficeAddinChangePolicy              = "microsoft_office_addin_change_policy"
+	EventTypeArgMultiTeamIdentityPolicyChanged                = "multi_team_identity_policy_changed"
 	EventTypeArgNetworkControlChangePolicy                    = "network_control_change_policy"
 	EventTypeArgPaperChangeDeploymentPolicy                   = "paper_change_deployment_policy"
 	EventTypeArgPaperChangeMemberLinkPolicy                   = "paper_change_member_link_policy"
@@ -20125,6 +20338,406 @@ func NewMalwareExclusionState(ExcludedFileHashesCount int64) *MalwareExclusionSt
 	return s
 }
 
+// MediaHubAddingPeoplePolicy : Policy for deciding who can be added to Media
+// Hub content
+type MediaHubAddingPeoplePolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubAddingPeoplePolicy
+const (
+	MediaHubAddingPeoplePolicyAnyone   = "anyone"
+	MediaHubAddingPeoplePolicyTeamOnly = "team_only"
+	MediaHubAddingPeoplePolicyOther    = "other"
+)
+
+// MediaHubAddingPeoplePolicyChangedDetails : Changed the policy for adding
+// people to Media Hub content.
+type MediaHubAddingPeoplePolicyChangedDetails struct {
+	// NewValue : To.
+	NewValue *MediaHubAddingPeoplePolicy `json:"new_value"`
+	// PreviousValue : From.
+	PreviousValue *MediaHubAddingPeoplePolicy `json:"previous_value"`
+}
+
+// NewMediaHubAddingPeoplePolicyChangedDetails returns a new MediaHubAddingPeoplePolicyChangedDetails instance
+func NewMediaHubAddingPeoplePolicyChangedDetails(NewValue *MediaHubAddingPeoplePolicy, PreviousValue *MediaHubAddingPeoplePolicy) *MediaHubAddingPeoplePolicyChangedDetails {
+	s := new(MediaHubAddingPeoplePolicyChangedDetails)
+	s.NewValue = NewValue
+	s.PreviousValue = PreviousValue
+	return s
+}
+
+// MediaHubAddingPeoplePolicyChangedType : has no documentation (yet)
+type MediaHubAddingPeoplePolicyChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubAddingPeoplePolicyChangedType returns a new MediaHubAddingPeoplePolicyChangedType instance
+func NewMediaHubAddingPeoplePolicyChangedType(Description string) *MediaHubAddingPeoplePolicyChangedType {
+	s := new(MediaHubAddingPeoplePolicyChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubDownloadPolicy : Policy for deciding whether Media Hub content can be
+// downloaded
+type MediaHubDownloadPolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubDownloadPolicy
+const (
+	MediaHubDownloadPolicyDisabled = "disabled"
+	MediaHubDownloadPolicyEnabled  = "enabled"
+	MediaHubDownloadPolicyOther    = "other"
+)
+
+// MediaHubDownloadPolicyChangedDetails : Changed the policy for downloading
+// Media Hub content.
+type MediaHubDownloadPolicyChangedDetails struct {
+	// NewValue : To.
+	NewValue *MediaHubDownloadPolicy `json:"new_value"`
+	// PreviousValue : From.
+	PreviousValue *MediaHubDownloadPolicy `json:"previous_value"`
+}
+
+// NewMediaHubDownloadPolicyChangedDetails returns a new MediaHubDownloadPolicyChangedDetails instance
+func NewMediaHubDownloadPolicyChangedDetails(NewValue *MediaHubDownloadPolicy, PreviousValue *MediaHubDownloadPolicy) *MediaHubDownloadPolicyChangedDetails {
+	s := new(MediaHubDownloadPolicyChangedDetails)
+	s.NewValue = NewValue
+	s.PreviousValue = PreviousValue
+	return s
+}
+
+// MediaHubDownloadPolicyChangedType : has no documentation (yet)
+type MediaHubDownloadPolicyChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubDownloadPolicyChangedType returns a new MediaHubDownloadPolicyChangedType instance
+func NewMediaHubDownloadPolicyChangedType(Description string) *MediaHubDownloadPolicyChangedType {
+	s := new(MediaHubDownloadPolicyChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubFileDownloadedDetails : Downloaded files in Media Hub.
+type MediaHubFileDownloadedDetails struct {
+}
+
+// NewMediaHubFileDownloadedDetails returns a new MediaHubFileDownloadedDetails instance
+func NewMediaHubFileDownloadedDetails() *MediaHubFileDownloadedDetails {
+	s := new(MediaHubFileDownloadedDetails)
+	return s
+}
+
+// MediaHubFileDownloadedType : has no documentation (yet)
+type MediaHubFileDownloadedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubFileDownloadedType returns a new MediaHubFileDownloadedType instance
+func NewMediaHubFileDownloadedType(Description string) *MediaHubFileDownloadedType {
+	s := new(MediaHubFileDownloadedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubLinkSharingPolicy : Policy for deciding who Media Hub content can be
+// shared with through links
+type MediaHubLinkSharingPolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubLinkSharingPolicy
+const (
+	MediaHubLinkSharingPolicyNoOne    = "no_one"
+	MediaHubLinkSharingPolicyPublic   = "public"
+	MediaHubLinkSharingPolicyTeamOnly = "team_only"
+	MediaHubLinkSharingPolicyOther    = "other"
+)
+
+// MediaHubLinkSharingPolicyChangedDetails : Changed the policy for sharing
+// Media Hub content.
+type MediaHubLinkSharingPolicyChangedDetails struct {
+	// NewValue : To.
+	NewValue *MediaHubLinkSharingPolicy `json:"new_value"`
+	// PreviousValue : From.
+	PreviousValue *MediaHubLinkSharingPolicy `json:"previous_value"`
+}
+
+// NewMediaHubLinkSharingPolicyChangedDetails returns a new MediaHubLinkSharingPolicyChangedDetails instance
+func NewMediaHubLinkSharingPolicyChangedDetails(NewValue *MediaHubLinkSharingPolicy, PreviousValue *MediaHubLinkSharingPolicy) *MediaHubLinkSharingPolicyChangedDetails {
+	s := new(MediaHubLinkSharingPolicyChangedDetails)
+	s.NewValue = NewValue
+	s.PreviousValue = PreviousValue
+	return s
+}
+
+// MediaHubLinkSharingPolicyChangedType : has no documentation (yet)
+type MediaHubLinkSharingPolicyChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubLinkSharingPolicyChangedType returns a new MediaHubLinkSharingPolicyChangedType instance
+func NewMediaHubLinkSharingPolicyChangedType(Description string) *MediaHubLinkSharingPolicyChangedType {
+	s := new(MediaHubLinkSharingPolicyChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubProjectRole : Media Hub project role
+type MediaHubProjectRole struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubProjectRole
+const (
+	MediaHubProjectRoleEditor   = "editor"
+	MediaHubProjectRoleOwner    = "owner"
+	MediaHubProjectRoleReviewer = "reviewer"
+	MediaHubProjectRoleOther    = "other"
+)
+
+// MediaHubProjectTeamAddDetails : Added member to Media Hub project.
+type MediaHubProjectTeamAddDetails struct {
+}
+
+// NewMediaHubProjectTeamAddDetails returns a new MediaHubProjectTeamAddDetails instance
+func NewMediaHubProjectTeamAddDetails() *MediaHubProjectTeamAddDetails {
+	s := new(MediaHubProjectTeamAddDetails)
+	return s
+}
+
+// MediaHubProjectTeamAddType : has no documentation (yet)
+type MediaHubProjectTeamAddType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubProjectTeamAddType returns a new MediaHubProjectTeamAddType instance
+func NewMediaHubProjectTeamAddType(Description string) *MediaHubProjectTeamAddType {
+	s := new(MediaHubProjectTeamAddType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubProjectTeamDeleteDetails : Removed member from Media Hub project.
+type MediaHubProjectTeamDeleteDetails struct {
+}
+
+// NewMediaHubProjectTeamDeleteDetails returns a new MediaHubProjectTeamDeleteDetails instance
+func NewMediaHubProjectTeamDeleteDetails() *MediaHubProjectTeamDeleteDetails {
+	s := new(MediaHubProjectTeamDeleteDetails)
+	return s
+}
+
+// MediaHubProjectTeamDeleteType : has no documentation (yet)
+type MediaHubProjectTeamDeleteType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubProjectTeamDeleteType returns a new MediaHubProjectTeamDeleteType instance
+func NewMediaHubProjectTeamDeleteType(Description string) *MediaHubProjectTeamDeleteType {
+	s := new(MediaHubProjectTeamDeleteType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubProjectTeamRoleChangedDetails : Changed member role in Media Hub
+// project.
+type MediaHubProjectTeamRoleChangedDetails struct {
+	// PreviousRole : Previous Media Hub project role.
+	PreviousRole *MediaHubProjectRole `json:"previous_role"`
+	// NewRole : New Media Hub project role.
+	NewRole *MediaHubProjectRole `json:"new_role"`
+}
+
+// NewMediaHubProjectTeamRoleChangedDetails returns a new MediaHubProjectTeamRoleChangedDetails instance
+func NewMediaHubProjectTeamRoleChangedDetails(PreviousRole *MediaHubProjectRole, NewRole *MediaHubProjectRole) *MediaHubProjectTeamRoleChangedDetails {
+	s := new(MediaHubProjectTeamRoleChangedDetails)
+	s.PreviousRole = PreviousRole
+	s.NewRole = NewRole
+	return s
+}
+
+// MediaHubProjectTeamRoleChangedType : has no documentation (yet)
+type MediaHubProjectTeamRoleChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubProjectTeamRoleChangedType returns a new MediaHubProjectTeamRoleChangedType instance
+func NewMediaHubProjectTeamRoleChangedType(Description string) *MediaHubProjectTeamRoleChangedType {
+	s := new(MediaHubProjectTeamRoleChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubSharedLinkAudience : Media Hub shared link audience
+type MediaHubSharedLinkAudience struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubSharedLinkAudience
+const (
+	MediaHubSharedLinkAudienceNoOne    = "no_one"
+	MediaHubSharedLinkAudiencePublic   = "public"
+	MediaHubSharedLinkAudienceTeamOnly = "team_only"
+	MediaHubSharedLinkAudienceOther    = "other"
+)
+
+// MediaHubSharedLinkAudienceChangedDetails : Changed Media Hub shared link
+// audience.
+type MediaHubSharedLinkAudienceChangedDetails struct {
+	// TargetType : Media Hub shared link target type.
+	TargetType *MediaHubSharedLinkTargetType `json:"target_type"`
+	// PreviousValue : Previous Media Hub shared link audience.
+	PreviousValue *MediaHubSharedLinkAudience `json:"previous_value"`
+	// NewValue : New Media Hub shared link audience.
+	NewValue *MediaHubSharedLinkAudience `json:"new_value"`
+}
+
+// NewMediaHubSharedLinkAudienceChangedDetails returns a new MediaHubSharedLinkAudienceChangedDetails instance
+func NewMediaHubSharedLinkAudienceChangedDetails(TargetType *MediaHubSharedLinkTargetType, PreviousValue *MediaHubSharedLinkAudience, NewValue *MediaHubSharedLinkAudience) *MediaHubSharedLinkAudienceChangedDetails {
+	s := new(MediaHubSharedLinkAudienceChangedDetails)
+	s.TargetType = TargetType
+	s.PreviousValue = PreviousValue
+	s.NewValue = NewValue
+	return s
+}
+
+// MediaHubSharedLinkAudienceChangedType : has no documentation (yet)
+type MediaHubSharedLinkAudienceChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubSharedLinkAudienceChangedType returns a new MediaHubSharedLinkAudienceChangedType instance
+func NewMediaHubSharedLinkAudienceChangedType(Description string) *MediaHubSharedLinkAudienceChangedType {
+	s := new(MediaHubSharedLinkAudienceChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubSharedLinkCreatedDetails : Created Media Hub shared link.
+type MediaHubSharedLinkCreatedDetails struct {
+	// TargetType : Media Hub shared link target type.
+	TargetType *MediaHubSharedLinkTargetType `json:"target_type"`
+	// Audience : Media Hub shared link audience.
+	Audience *MediaHubSharedLinkAudience `json:"audience"`
+}
+
+// NewMediaHubSharedLinkCreatedDetails returns a new MediaHubSharedLinkCreatedDetails instance
+func NewMediaHubSharedLinkCreatedDetails(TargetType *MediaHubSharedLinkTargetType, Audience *MediaHubSharedLinkAudience) *MediaHubSharedLinkCreatedDetails {
+	s := new(MediaHubSharedLinkCreatedDetails)
+	s.TargetType = TargetType
+	s.Audience = Audience
+	return s
+}
+
+// MediaHubSharedLinkCreatedType : has no documentation (yet)
+type MediaHubSharedLinkCreatedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubSharedLinkCreatedType returns a new MediaHubSharedLinkCreatedType instance
+func NewMediaHubSharedLinkCreatedType(Description string) *MediaHubSharedLinkCreatedType {
+	s := new(MediaHubSharedLinkCreatedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubSharedLinkDownloadSetting : Media Hub shared link download setting
+type MediaHubSharedLinkDownloadSetting struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubSharedLinkDownloadSetting
+const (
+	MediaHubSharedLinkDownloadSettingDisabled = "disabled"
+	MediaHubSharedLinkDownloadSettingEnabled  = "enabled"
+	MediaHubSharedLinkDownloadSettingOther    = "other"
+)
+
+// MediaHubSharedLinkDownloadSettingChangedDetails : Changed Media Hub shared
+// link download setting.
+type MediaHubSharedLinkDownloadSettingChangedDetails struct {
+	// TargetType : Media Hub shared link target type.
+	TargetType *MediaHubSharedLinkTargetType `json:"target_type"`
+	// PreviousValue : Previous Media Hub shared link download setting.
+	PreviousValue *MediaHubSharedLinkDownloadSetting `json:"previous_value"`
+	// NewValue : New Media Hub shared link download setting.
+	NewValue *MediaHubSharedLinkDownloadSetting `json:"new_value"`
+}
+
+// NewMediaHubSharedLinkDownloadSettingChangedDetails returns a new MediaHubSharedLinkDownloadSettingChangedDetails instance
+func NewMediaHubSharedLinkDownloadSettingChangedDetails(TargetType *MediaHubSharedLinkTargetType, PreviousValue *MediaHubSharedLinkDownloadSetting, NewValue *MediaHubSharedLinkDownloadSetting) *MediaHubSharedLinkDownloadSettingChangedDetails {
+	s := new(MediaHubSharedLinkDownloadSettingChangedDetails)
+	s.TargetType = TargetType
+	s.PreviousValue = PreviousValue
+	s.NewValue = NewValue
+	return s
+}
+
+// MediaHubSharedLinkDownloadSettingChangedType : has no documentation (yet)
+type MediaHubSharedLinkDownloadSettingChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubSharedLinkDownloadSettingChangedType returns a new MediaHubSharedLinkDownloadSettingChangedType instance
+func NewMediaHubSharedLinkDownloadSettingChangedType(Description string) *MediaHubSharedLinkDownloadSettingChangedType {
+	s := new(MediaHubSharedLinkDownloadSettingChangedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubSharedLinkRevokedDetails : Revoked Media Hub shared link.
+type MediaHubSharedLinkRevokedDetails struct {
+	// TargetType : Media Hub shared link target type.
+	TargetType *MediaHubSharedLinkTargetType `json:"target_type"`
+}
+
+// NewMediaHubSharedLinkRevokedDetails returns a new MediaHubSharedLinkRevokedDetails instance
+func NewMediaHubSharedLinkRevokedDetails(TargetType *MediaHubSharedLinkTargetType) *MediaHubSharedLinkRevokedDetails {
+	s := new(MediaHubSharedLinkRevokedDetails)
+	s.TargetType = TargetType
+	return s
+}
+
+// MediaHubSharedLinkRevokedType : has no documentation (yet)
+type MediaHubSharedLinkRevokedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMediaHubSharedLinkRevokedType returns a new MediaHubSharedLinkRevokedType instance
+func NewMediaHubSharedLinkRevokedType(Description string) *MediaHubSharedLinkRevokedType {
+	s := new(MediaHubSharedLinkRevokedType)
+	s.Description = Description
+	return s
+}
+
+// MediaHubSharedLinkTargetType : Media Hub shared link target type
+type MediaHubSharedLinkTargetType struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MediaHubSharedLinkTargetType
+const (
+	MediaHubSharedLinkTargetTypeBundle  = "bundle"
+	MediaHubSharedLinkTargetTypeProject = "project"
+	MediaHubSharedLinkTargetTypeOther   = "other"
+)
+
 // MemberAccessDetailsCreateReportDetails : Created member access report.
 type MemberAccessDetailsCreateReportDetails struct {
 }
@@ -21139,6 +21752,49 @@ type MobileSessionLogInfo struct {
 // NewMobileSessionLogInfo returns a new MobileSessionLogInfo instance
 func NewMobileSessionLogInfo() *MobileSessionLogInfo {
 	s := new(MobileSessionLogInfo)
+	return s
+}
+
+// MultiTeamIdentityPolicy : Multi-team identity policy
+type MultiTeamIdentityPolicy struct {
+	dropbox.Tagged
+}
+
+// Valid tag values for MultiTeamIdentityPolicy
+const (
+	MultiTeamIdentityPolicyDefault  = "default"
+	MultiTeamIdentityPolicyDisabled = "disabled"
+	MultiTeamIdentityPolicyEnabled  = "enabled"
+	MultiTeamIdentityPolicyOther    = "other"
+)
+
+// MultiTeamIdentityPolicyChangedDetails : Changed multi-team identity policy
+// for team.
+type MultiTeamIdentityPolicyChangedDetails struct {
+	// NewValue : New multi-team identity policy.
+	NewValue *MultiTeamIdentityPolicy `json:"new_value"`
+	// PreviousValue : Previous multi-team identity policy. Might be missing due
+	// to historical data gap.
+	PreviousValue *MultiTeamIdentityPolicy `json:"previous_value,omitempty"`
+}
+
+// NewMultiTeamIdentityPolicyChangedDetails returns a new MultiTeamIdentityPolicyChangedDetails instance
+func NewMultiTeamIdentityPolicyChangedDetails(NewValue *MultiTeamIdentityPolicy) *MultiTeamIdentityPolicyChangedDetails {
+	s := new(MultiTeamIdentityPolicyChangedDetails)
+	s.NewValue = NewValue
+	return s
+}
+
+// MultiTeamIdentityPolicyChangedType : has no documentation (yet)
+type MultiTeamIdentityPolicyChangedType struct {
+	// Description : has no documentation (yet)
+	Description string `json:"description"`
+}
+
+// NewMultiTeamIdentityPolicyChangedType returns a new MultiTeamIdentityPolicyChangedType instance
+func NewMultiTeamIdentityPolicyChangedType(Description string) *MultiTeamIdentityPolicyChangedType {
+	s := new(MultiTeamIdentityPolicyChangedType)
+	s.Description = Description
 	return s
 }
 

--- a/v6/dropbox/users/client.go
+++ b/v6/dropbox/users/client.go
@@ -50,18 +50,19 @@ type Client interface {
 // ContextClient interface describes all routes in this namespace with context support
 type ContextClient interface {
 	Client
-	// FeaturesGetValuesContext : Get a list of feature values that may be configured
-	// for the current account.
+	// FeaturesGetValuesContext : Get a list of feature values that may be
+	// configured for the current account.
 	FeaturesGetValuesContext(ctx context.Context, arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error)
 	// GetAccountContext : Get information about a user's account.
 	GetAccountContext(ctx context.Context, arg *GetAccountArg) (res *BasicAccount, err error)
-	// GetAccountBatchContext : Get information about multiple user accounts. At most
-	// 300 accounts may be queried per request.
+	// GetAccountBatchContext : Get information about multiple user accounts. At
+	// most 300 accounts may be queried per request.
 	GetAccountBatchContext(ctx context.Context, arg *GetAccountBatchArg) (res []*BasicAccount, err error)
-	// GetCurrentAccountContext : Get information about the current user's account.
-	GetCurrentAccountContext(ctx context.Context) (res *FullAccount, err error)
-	// GetSpaceUsageContext : Get the space usage information for the current user's
+	// GetCurrentAccountContext : Get information about the current user's
 	// account.
+	GetCurrentAccountContext(ctx context.Context) (res *FullAccount, err error)
+	// GetSpaceUsageContext : Get the space usage information for the current
+	// user's account.
 	GetSpaceUsageContext(ctx context.Context) (res *SpaceUsage, err error)
 }
 
@@ -73,8 +74,8 @@ type FeaturesGetValuesAPIError struct {
 	EndpointError *UserFeaturesGetValuesBatchError `json:"error"`
 }
 
-// FeaturesGetValuesContext : Get a list of feature values that may be configured
-// for the current account.
+// FeaturesGetValuesContext : Get a list of feature values that may be
+// configured for the current account.
 func (dbx *apiImpl) FeaturesGetValuesContext(ctx context.Context, arg *UserFeaturesGetValuesBatchArg) (res *UserFeaturesGetValuesBatchResult, err error) {
 	req := dropbox.Request{
 		Host:         "api",
@@ -160,8 +161,8 @@ type GetAccountBatchAPIError struct {
 	EndpointError *GetAccountBatchError `json:"error"`
 }
 
-// GetAccountBatchContext : Get information about multiple user accounts. At most
-// 300 accounts may be queried per request.
+// GetAccountBatchContext : Get information about multiple user accounts. At
+// most 300 accounts may be queried per request.
 func (dbx *apiImpl) GetAccountBatchContext(ctx context.Context, arg *GetAccountBatchArg) (res []*BasicAccount, err error) {
 	req := dropbox.Request{
 		Host:         "api",


### PR DESCRIPTION
## Summary

Two related changes bundled in one branch:

### 1. Generator + spec regeneration
- Update the Go generator to **export inline Stone composite types** (e.g. `riviera.MetadataUnion`).
- **Omit caller-restricted fields** from generated public types, matching the Python SDK's serialization.
- Pin the API spec submodule to `7e5f668` and regenerate the whole SDK.
- Document the Stone v3.5.2 requirement in `generator/README.md`.

### 2. Live-API integration tests
A new `integration`-tagged test package (`v6/dropbox/integration/`) that exercises the real Dropbox API with scoped **refresh-token** credentials, mirroring the [dropbox-sdk-python integration suite](https://github.com/dropbox/dropbox-sdk-python/commit/0ab9517e5bd6650efd7020d00c9d42b52f42e9be):

- **User:** create and delete a folder round-trip.
- **Team:** list members, and — acting as a member (`AsMemberID`, the Go analogue of `DropboxTeam.as_user`) — create and delete a folder.

Credentials come from `SCOPED_USER_*` / `SCOPED_TEAM_*` env vars (or a JSON file via `DROPBOX_SDK_SECRETS_FILE`). Missing creds **skip** rather than fail. The `integration` build tag keeps these out of the default `go test ./...`.