### PR TITLE
Add spec_update workflow for automated API spec updates

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -1,0 +1,153 @@
+name: Spec Update
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [spec_update]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-go-unofficial-repo
+          aws-region: us-west-2
+
+      - name: Fetch GitHub App credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            SDK_UPDATER,sdk-updater-github-app
+          parse-json-secrets: true
+
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ env.SDK_UPDATER_CLIENT_ID }}
+          private-key: ${{ env.SDK_UPDATER_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+      - name: Setup Python environment
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYY_MM_DD
+          utcOffset: "-08:00"
+      - name: Install Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install stone==3.5.2
+          go install golang.org/x/tools/cmd/goimports@latest
+      - name: Update Modules
+        run: |
+          git submodule init
+          git submodule update --remote --recursive
+      - name: Generate Branch Name
+        id: git-branch
+        env:
+          FORMATTED_TIME: ${{ steps.current-time.outputs.formattedTime }}
+        run: |
+          echo "branch=spec_update_${FORMATTED_TIME}" >> "$GITHUB_OUTPUT"
+      - name: Generate Num Diffs
+        id: git-diff-num
+        run: |
+          cd generator/
+          diffs=$(git diff --submodule dropbox-api-spec | grep ">" | wc -l)
+          echo "Number of Spec diffs: $diffs"
+          echo "num-diff=$diffs" >> "$GITHUB_OUTPUT"
+          cd ..
+      - name: Generate Diff
+        id: git-diff
+        env:
+          NUM_DIFF: ${{ steps.git-diff-num.outputs.num-diff }}
+        run: |
+          cd generator/dropbox-api-spec
+          gitdiff=$(git log -n "$NUM_DIFF" --pretty="format:%n %H %n%n %b")
+          commit="Automated Spec Update $gitdiff"
+          while true; do
+            delimiter="SPEC_UPDATE_EOF_$(python -c 'import uuid; print(uuid.uuid4())')"
+            if ! grep -Fxq "$delimiter" <<< "$commit"; then
+              break
+            fi
+          done
+          {
+            printf 'commit<<%s\n' "$delimiter"
+            printf '%s\n' "$commit"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+          cd ../..
+      - name: Get current SDK version
+        id: sdk-version
+        run: |
+          version=$(grep -oP 'sdkVersion\s*=\s*"\K[^"]+' v6/dropbox/sdk.go)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Generate New Routes
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+        run: |
+          cd generator
+          ./generate-sdk.sh "$SDK_VERSION"
+          cd ..
+
+      - name: Close Old Pull Requests
+        id: close-old-prs
+        if: steps.git-diff-num.outputs.num-diff != 0
+        run: |
+          closed=""
+          while read -r pr_num; do
+            echo "Closing old PR #$pr_num"
+            gh pr close "$pr_num" --delete-branch
+            closed="${closed:+$closed,}$pr_num"
+          done < <(gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number')
+          echo "closed=$closed" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v8
+        if: steps.git-diff-num.outputs.num-diff != 0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: |
+            ${{ steps.git-diff.outputs.commit}}
+          branch: ${{ steps.git-branch.outputs.branch }}
+          delete-branch: true
+          title: 'Automated Spec Update - ${{ steps.current-time.outputs.formattedTime }}'
+          body: |
+            ${{ steps.git-diff.outputs.commit}}
+          base: 'main'
+          labels: |
+            automated-spec-update
+          draft: false
+
+      - name: Comment on closed PRs
+        if: steps.create-pr.outputs.pull-request-number && steps.close-old-prs.outputs.closed
+        run: |
+          IFS=',' read -ra prs <<< "${{ steps.close-old-prs.outputs.closed }}"
+          for pr_num in "${prs[@]}"; do
+            gh pr comment "$pr_num" --body "Superseded by #${{ steps.create-pr.outputs.pull-request-number }}"
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # - name: Enable Pull Request Automerge
+      #   if: steps.create-pr.outputs.pull-request-number
+      #   run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add a new `spec_update.yml` GitHub Actions workflow matching the pattern used in dropbox-sdk-python
- Uses OIDC + GitHub App token (`sdk-updater-github-app`) via AWS Secrets Manager
- Updates the `generator/dropbox-api-spec` submodule, reads the current `sdkVersion` from `v6/dropbox/sdk.go`, and runs `generate-sdk.sh` to regenerate routes
- Closes superseded spec update PRs with a comment linking to the replacement
- Adds `automated-spec-update` label for filtering/tracking
- Triggered via `workflow_dispatch` or `repository_dispatch` (type: `spec_update`)

## Test plan
- [ ] Verify the IAM role `oidc-github-dropbox-dropbox-sdk-go-unofficial-repo` exists in AWS
- [ ] Verify the `sdk-updater-github-app` secret is accessible from this repo's OIDC role
- [ ] Trigger via `workflow_dispatch` and confirm generation succeeds (stone + goimports installed correctly)
- [ ] Confirm old PRs get closed and commented when a new spec update runs
- [ ] Verify the multiline commit message renders correctly in the PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)