### PR TITLE
Fix spec-update automerge: use --squash instead of --merge

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -148,6 +148,6 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The branch now requires linear history (via ruleset), so `gh pr merge --merge --auto` is rejected with `GraphQL: Merge method merge commits are not allowed`, failing the Enable Pull Request Automerge step. Switches to `--squash`.