### PR TITLE
files: add helpers for HTTP range downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,39 @@ Here's an example:
     fmt.Printf("Name: %v", resp.Name)
   }
 ```
+### Downloading a byte range
+
+Use `files.SetRange` to download from a byte offset to the end of a file:
+
+```go
+arg := files.NewDownloadArg("/large-file.bin")
+if err := files.SetRange(arg, 1024); err != nil {
+    return err
+}
+
+_, content, err := client.DownloadContext(ctx, arg)
+if err != nil {
+    return err
+}
+defer content.Close()
+```
+
+Use `files.SetRangeLength` to download a fixed number of bytes:
+
+```go
+arg := files.NewDownloadArg("/large-file.bin")
+if err := files.SetRangeLength(arg, 1024, 4096); err != nil {
+    return err
+}
+
+_, content, err := client.DownloadContext(ctx, arg)
+if err != nil {
+    return err
+}
+defer content.Close()
+```
+
+`SetRange` is useful for continuing an interrupted download from the number of bytes already written.
 
 ### Retrying API calls
 
@@ -413,7 +446,7 @@ As described in the [API docs](https://www.dropbox.com/developers/documentation/
 
 To use the Team API, you will need to create a Dropbox Business App. The OAuth token from this app will _only_ work for the Team API.
 
-Please read the [API docs](https://www.dropbox.com/developers/documentation/http/teams) carefully to appropriate secure your apps and tokens when using the Team API.
+Please read the [API docs](https://www.dropbox.com/developers/documentation/http/teams) carefully to appropriately secure your apps and tokens when using the Team API.
 
 ## Testing
 

--- a/v6/dropbox/files/helpers.go
+++ b/v6/dropbox/files/helpers.go
@@ -1,0 +1,52 @@
+package files
+
+import (
+	"fmt"
+)
+
+// SetRange configures arg to download bytes starting at offset until the end
+// of the file. It sets the HTTP Range header to "bytes=<offset>-".
+func SetRange(arg *DownloadArg, offset int64) error {
+	if arg == nil {
+		return fmt.Errorf("download argument is nil")
+	}
+
+	if offset < 0 {
+		return fmt.Errorf("range offset must be non-negative")
+	}
+
+	if arg.ExtraHeaders == nil {
+		arg.ExtraHeaders = map[string]string{}
+	}
+
+	arg.ExtraHeaders["Range"] = fmt.Sprintf("bytes=%d-", offset)
+	return nil
+}
+
+// SetRangeLength configures arg to download length bytes starting at offset.
+// It sets the HTTP Range header to "bytes=<offset>-<end>".
+func SetRangeLength(arg *DownloadArg, offset int64, length int64) error {
+	if arg == nil {
+		return fmt.Errorf("download argument is nil")
+	}
+
+	if offset < 0 {
+		return fmt.Errorf("range offset must be non-negative")
+	}
+
+	if length <= 0 {
+		return fmt.Errorf("range length must be positive")
+	}
+
+	end := offset + length - 1
+	if end < offset {
+		return fmt.Errorf("range end overflow")
+	}
+
+	if arg.ExtraHeaders == nil {
+		arg.ExtraHeaders = make(map[string]string)
+	}
+
+	arg.ExtraHeaders["Range"] = fmt.Sprintf("bytes=%d-%d", offset, end)
+	return nil
+}

--- a/v6/dropbox/files/helpers_test.go
+++ b/v6/dropbox/files/helpers_test.go
@@ -1,0 +1,150 @@
+package files
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSetRangeLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        *DownloadArg
+		offset     int64
+		length     int64
+		wantHeader string
+		wantErr    bool
+	}{
+		{
+			name:       "sets range header",
+			arg:        NewDownloadArg("/file.bin"),
+			offset:     100,
+			length:     50,
+			wantHeader: "bytes=100-149",
+		},
+		{
+			name:       "preserves existing headers",
+			arg:        &DownloadArg{ExtraHeaders: map[string]string{"If-None-Match": "etag"}},
+			offset:     0,
+			length:     1,
+			wantHeader: "bytes=0-0",
+		},
+		{
+			name:    "nil argument",
+			arg:     nil,
+			offset:  0,
+			length:  1,
+			wantErr: true,
+		},
+		{
+			name:    "negative offset",
+			arg:     NewDownloadArg("/file.bin"),
+			offset:  -1,
+			length:  1,
+			wantErr: true,
+		},
+		{
+			name:    "zero length",
+			arg:     NewDownloadArg("/file.bin"),
+			offset:  0,
+			length:  0,
+			wantErr: true,
+		},
+		{
+			name:    "negative length",
+			arg:     NewDownloadArg("/file.bin"),
+			offset:  0,
+			length:  -1,
+			wantErr: true,
+		},
+		{
+			name:    "range overflow",
+			arg:     NewDownloadArg("/file.bin"),
+			offset:  math.MaxInt64,
+			length:  2,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetRangeLength(tt.arg, tt.offset, tt.length)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("SetRangeLength() expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetRangeLength() error = %v", err)
+			}
+			if got := tt.arg.ExtraHeaders["Range"]; got != tt.wantHeader {
+				t.Errorf("Range header = %q, want %q", got, tt.wantHeader)
+			}
+		})
+
+	}
+}
+
+func TestSetRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		arg        *DownloadArg
+		offset     int64
+		wantHeader string
+		wantErr    bool
+	}{
+		{
+			name:       "sets range header",
+			arg:        NewDownloadArg("/file.bin"),
+			offset:     100,
+			wantHeader: "bytes=100-",
+		},
+		{
+			name:       "sets range from zero",
+			arg:        NewDownloadArg("/file.bin"),
+			offset:     0,
+			wantHeader: "bytes=0-",
+		},
+		{
+			name: "preserves existing headers",
+			arg: &DownloadArg{
+				ExtraHeaders: map[string]string{
+					"If-None-Match": "etag",
+				},
+			},
+			offset:     100,
+			wantHeader: "bytes=100-",
+		},
+		{
+			name:    "nil argument",
+			arg:     nil,
+			offset:  0,
+			wantErr: true,
+		},
+		{
+			name:    "negative offset",
+			arg:     NewDownloadArg("/file.bin"),
+			offset:  -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetRange(tt.arg, tt.offset)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("SetRange() expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SetRange() error = %v", err)
+			}
+			if got := tt.arg.ExtraHeaders["Range"]; got != tt.wantHeader {
+				t.Errorf("Range header = %q, want %q", got, tt.wantHeader)
+			}
+			if got := tt.arg.ExtraHeaders["If-None-Match"]; tt.name == "preserves existing headers" && got != "etag" {
+				t.Errorf("existing header changed: got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds helper functions for configuring byte-range downloads without modifying generated SDK types.

## Changes

- add `files.SetRange` for downloading from an offset to the end of a file
- add `files.SetRangeLength` for downloading a fixed byte range
- add unit tests for valid ranges, invalid inputs, header preservation, and overflow
- add README usage examples

## Example

```go
arg := files.NewDownloadArg("/large-file.bin")
if err := files.SetRange(arg, existingSize); err != nil {
	return err
}

metadata, content, err := client.DownloadContext(ctx, arg)
```