### PR TITLE
Add reliable file download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For most applications, you should just import the relevant namespace(s) only. Th
 
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash`
+* `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/filedownload`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/oauth`
 * `github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/openid`
@@ -261,6 +262,62 @@ defer content.Close()
 ```
 
 `SetRange` is useful for continuing an interrupted download from the number of bytes already written.
+
+### Resumable file downloads
+
+Use the `filedownload` helper when downloading a Dropbox file to local storage.
+It writes to `localPath + ".part"` first, resumes from that partial file after
+read errors, validates the final size, verifies Dropbox `content_hash` metadata
+when present, and renames the partial file only after validation succeeds:
+
+```go
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/filedownload"
+import "github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+
+client := files.NewContext(config)
+downloader := filedownload.New(client)
+
+result, err := downloader.DownloadFile(ctx, "/large-file.bin", "large-file.bin")
+if err != nil {
+    return err
+}
+
+fmt.Printf(
+    "downloaded %s (%d bytes), resumed from byte %d\n",
+    result.Metadata.Name,
+    result.Metadata.Size,
+    result.ResumedFrom,
+)
+```
+
+Progress callbacks receive cumulative bytes written, the expected total size
+when known, and the byte offset used for resume:
+
+```go
+downloader := filedownload.New(
+    client,
+    filedownload.WithProgress(func(progress filedownload.Progress) {
+        fmt.Printf("%d/%d bytes\n", progress.BytesWritten, progress.TotalBytes)
+    }),
+)
+```
+
+For fresh downloads, opt in to parallel ranged requests with
+`WithParallelDownloads`. Existing `.part` files continue serially from the saved
+offset so retries preserve already-written bytes:
+
+```go
+downloader := filedownload.New(
+    client,
+    filedownload.WithParallelDownloads(4),
+)
+
+_, err := downloader.DownloadFile(ctx, "/large-file.bin", "large-file.bin")
+```
+
+If a retry sees a different file revision than the previous attempt, the
+download fails and discards the stale partial file instead of appending bytes
+from different revisions.
 
 ### Retrying API calls
 

--- a/v6/dropbox/filedownload/downloader.go
+++ b/v6/dropbox/filedownload/downloader.go
@@ -153,6 +153,7 @@ func (d *Downloader) downloadFileAttempt(
 	}
 
 	if err := f.Close(); err != nil {
+		_ = os.Remove(partPath)
 		return nil, err
 	}
 

--- a/v6/dropbox/filedownload/downloader.go
+++ b/v6/dropbox/filedownload/downloader.go
@@ -220,9 +220,20 @@ func (d *Downloader) downloadFileParallel(
 
 	progress := d.newProgress(0, total, 0)
 	if total > 0 {
-		if _, err := io.Copy(&writeAtWriter{f: f}, progress.reader(body)); err != nil {
+		n, err := io.Copy(
+			&writeAtWriter{f: f},
+			progress.reader(body),
+		)
+		if err != nil {
 			_ = f.Close()
 			return nil, err
+		}
+		if n != 1 {
+			_ = f.Close()
+			return nil, fmt.Errorf(
+				"incomplete initial range: got %d bytes, expected 1",
+				n,
+			)
 		}
 	}
 	if err := f.Close(); err != nil {
@@ -321,8 +332,19 @@ func (d *Downloader) downloadRange(
 		return err
 	}
 
-	_, err = io.Copy(&writeAtWriter{f: f, offset: r.offset}, progress.reader(body))
-	return err
+	n, err := io.Copy(&writeAtWriter{f: f, offset: r.offset}, progress.reader(body))
+	if err != nil {
+		return err
+	}
+	if n != r.length {
+		return fmt.Errorf(
+			"incomplete range at offset %d: got %d bytes, expected %d",
+			r.offset,
+			n,
+			r.length,
+		)
+	}
+	return nil
 }
 
 func (d *Downloader) DownloadFile(

--- a/v6/dropbox/filedownload/downloader.go
+++ b/v6/dropbox/filedownload/downloader.go
@@ -241,6 +241,7 @@ func (d *Downloader) downloadFileParallel(
 		}
 	}
 	if err := f.Close(); err != nil {
+		_ = os.Remove(partPath)
 		return nil, err
 	}
 

--- a/v6/dropbox/filedownload/downloader.go
+++ b/v6/dropbox/filedownload/downloader.go
@@ -1,0 +1,539 @@
+package filedownload
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sync"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+// Client is the subset of files.Client required by Downloader.
+type Client interface {
+	DownloadContext(
+		ctx context.Context,
+		arg *files.DownloadArg,
+	) (*files.FileMetadata, io.ReadCloser, error)
+}
+
+// Progress describes download progress.
+type Progress struct {
+	BytesWritten int64
+	TotalBytes   int64
+	ResumedFrom  int64
+}
+
+// ProgressFunc receives download progress updates.
+type ProgressFunc func(Progress)
+
+// Option configures a Downloader.
+type Option func(*Downloader)
+
+// WithMaxAttempts configures how many times DownloadFile retries.
+func WithMaxAttempts(maxAttempts int) Option {
+	return func(d *Downloader) {
+		if maxAttempts > 0 {
+			d.maxAttempts = maxAttempts
+		}
+	}
+}
+
+// WithProgress configures a callback for download progress updates.
+func WithProgress(progress ProgressFunc) Option {
+	return func(d *Downloader) {
+		d.progress = progress
+	}
+}
+
+// WithParallelDownloads configures how many ranged downloads to run at once
+// for fresh downloads. Resumed downloads continue serially from the part file.
+func WithParallelDownloads(parallelDownloads int) Option {
+	return func(d *Downloader) {
+		if parallelDownloads > 1 {
+			d.parallelDownloads = parallelDownloads
+		}
+	}
+}
+
+// Downloader downloads Dropbox files to local storage.
+type Downloader struct {
+	client            Client
+	maxAttempts       int
+	parallelDownloads int
+	progress          ProgressFunc
+}
+
+// New returns a Downloader that uses client.
+func New(client Client, opts ...Option) *Downloader {
+	d := &Downloader{
+		client:            client,
+		maxAttempts:       3,
+		parallelDownloads: 1,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// Result describes a completed file download.
+type Result struct {
+	Metadata    *files.FileMetadata
+	ResumedFrom int64
+}
+
+func (d *Downloader) downloadFileAttempt(
+	ctx context.Context,
+	remotePath string,
+	localPath string,
+	expectedRev string,
+) (*Result, error) {
+	partPath := localPath + ".part"
+
+	offset, err := partFileSize(partPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if offset == 0 && d.parallelDownloads > 1 {
+		return d.downloadFileParallel(ctx, remotePath, localPath, partPath, expectedRev)
+	}
+
+	f, err := os.OpenFile(
+		partPath,
+		os.O_CREATE|os.O_WRONLY,
+		0o644,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	arg := files.NewDownloadArg(remotePath)
+	if offset > 0 {
+		if err := files.SetRange(arg, offset); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+	}
+
+	metadata, body, err := d.client.DownloadContext(ctx, arg)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if body == nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("download response body is nil")
+	}
+	defer body.Close()
+
+	if err := validateRevision(expectedRev, metadata); err != nil {
+		_ = f.Close()
+		_ = os.Remove(partPath)
+		return nil, err
+	}
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	progress := d.newProgress(offset, metadataSize(metadata), offset)
+	if _, err := io.Copy(f, progress.reader(body)); err != nil {
+		_ = f.Close()
+		return &Result{
+			Metadata:    metadata,
+			ResumedFrom: offset,
+		}, err
+	}
+
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	if err := validatePartFile(partPath, metadata); err != nil {
+		_ = os.Remove(partPath)
+		return nil, err
+	}
+
+	if err := os.Rename(partPath, localPath); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Metadata:    metadata,
+		ResumedFrom: offset,
+	}, nil
+}
+
+func (d *Downloader) downloadFileParallel(
+	ctx context.Context,
+	remotePath string,
+	localPath string,
+	partPath string,
+	expectedRev string,
+) (*Result, error) {
+	arg := files.NewDownloadArg(remotePath)
+	if err := files.SetRangeLength(arg, 0, 1); err != nil {
+		return nil, err
+	}
+
+	metadata, body, err := d.client.DownloadContext(ctx, arg)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, fmt.Errorf("download response body is nil")
+	}
+	defer body.Close()
+
+	if err := validateRevision(expectedRev, metadata); err != nil {
+		_ = os.Remove(partPath)
+		return nil, err
+	}
+
+	if metadata == nil {
+		return nil, fmt.Errorf("download metadata is nil")
+	}
+	if metadata.Size > math.MaxInt64 {
+		return nil, fmt.Errorf("download too large: %d bytes", metadata.Size)
+	}
+
+	total := int64(metadata.Size)
+	f, err := os.OpenFile(
+		partPath,
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC,
+		0o644,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Truncate(total); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	progress := d.newProgress(0, total, 0)
+	if total > 0 {
+		if _, err := io.Copy(&writeAtWriter{f: f}, progress.reader(body)); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	if total > 1 {
+		if err := d.downloadParallelRanges(ctx, remotePath, partPath, metadata, progress); err != nil {
+			_ = os.Remove(partPath)
+			return nil, err
+		}
+	}
+
+	if err := validatePartFile(partPath, metadata); err != nil {
+		_ = os.Remove(partPath)
+		return nil, err
+	}
+
+	if err := os.Rename(partPath, localPath); err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Metadata:    metadata,
+		ResumedFrom: 0,
+	}, nil
+}
+
+func (d *Downloader) downloadParallelRanges(
+	ctx context.Context,
+	remotePath string,
+	partPath string,
+	metadata *files.FileMetadata,
+	progress *progressTracker,
+) error {
+	f, err := os.OpenFile(partPath, os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	total := int64(metadata.Size)
+	ranges := splitRanges(1, total-1, d.parallelDownloads)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errs := make(chan error, len(ranges))
+	var wg sync.WaitGroup
+	for _, r := range ranges {
+		r := r
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := d.downloadRange(ctx, remotePath, f, r, metadata.Rev, progress)
+			if err != nil {
+				cancel()
+			}
+			errs <- err
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			cancel()
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Downloader) downloadRange(
+	ctx context.Context,
+	remotePath string,
+	f *os.File,
+	r byteRange,
+	expectedRev string,
+	progress *progressTracker,
+) error {
+	arg := files.NewDownloadArg(remotePath)
+	if err := files.SetRangeLength(arg, r.offset, r.length); err != nil {
+		return err
+	}
+
+	metadata, body, err := d.client.DownloadContext(ctx, arg)
+	if err != nil {
+		return err
+	}
+	if body == nil {
+		return fmt.Errorf("download response body is nil")
+	}
+	defer body.Close()
+
+	if err := validateRevision(expectedRev, metadata); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(&writeAtWriter{f: f, offset: r.offset}, progress.reader(body))
+	return err
+}
+
+func (d *Downloader) DownloadFile(
+	ctx context.Context,
+	remotePath string,
+	localPath string,
+) (*Result, error) {
+	var (
+		lastErr     error
+		expectedRev string
+	)
+
+	for attempt := 0; attempt < d.maxAttempts; attempt++ {
+		result, err := d.downloadFileAttempt(
+			ctx,
+			remotePath,
+			localPath,
+			expectedRev,
+		)
+
+		if result != nil && result.Metadata != nil && expectedRev == "" {
+			expectedRev = result.Metadata.Rev
+		}
+
+		if err == nil {
+			return result, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		var changed *remoteFileChangedError
+		if errors.As(err, &changed) {
+			return nil, err
+		}
+
+		lastErr = err
+	}
+
+	return nil, lastErr
+}
+
+type progressTracker struct {
+	mu          sync.Mutex
+	written     int64
+	total       int64
+	resumedFrom int64
+	progress    ProgressFunc
+}
+
+func (d *Downloader) newProgress(written int64, total int64, resumedFrom int64) *progressTracker {
+	return &progressTracker{
+		written:     written,
+		total:       total,
+		resumedFrom: resumedFrom,
+		progress:    d.progress,
+	}
+}
+
+func (p *progressTracker) reader(r io.Reader) io.Reader {
+	return &progressReader{reader: r, progress: p}
+}
+
+func (p *progressTracker) add(n int) {
+	if n <= 0 || p.progress == nil {
+		return
+	}
+
+	p.mu.Lock()
+	p.written += int64(n)
+	progress := Progress{
+		BytesWritten: p.written,
+		TotalBytes:   p.total,
+		ResumedFrom:  p.resumedFrom,
+	}
+	p.progress(progress)
+	p.mu.Unlock()
+}
+
+type progressReader struct {
+	reader   io.Reader
+	progress *progressTracker
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.progress.add(n)
+	return n, err
+}
+
+type writeAtWriter struct {
+	f      *os.File
+	offset int64
+}
+
+func (w *writeAtWriter) Write(p []byte) (int, error) {
+	n, err := w.f.WriteAt(p, w.offset)
+	w.offset += int64(n)
+	return n, err
+}
+
+type byteRange struct {
+	offset int64
+	length int64
+}
+
+func splitRanges(offset int64, length int64, parts int) []byteRange {
+	if length <= 0 {
+		return nil
+	}
+	if parts <= 1 {
+		return []byteRange{{offset: offset, length: length}}
+	}
+	if int64(parts) > length {
+		parts = int(length)
+	}
+
+	ranges := make([]byteRange, 0, parts)
+	partSize := length / int64(parts)
+	remainder := length % int64(parts)
+	for i := 0; i < parts; i++ {
+		size := partSize
+		if int64(i) < remainder {
+			size++
+		}
+		ranges = append(ranges, byteRange{offset: offset, length: size})
+		offset += size
+	}
+	return ranges
+}
+
+func validateRevision(expectedRev string, metadata *files.FileMetadata) error {
+	if expectedRev == "" || metadata == nil || metadata.Rev == "" {
+		return nil
+	}
+	if metadata.Rev != expectedRev {
+		return &remoteFileChangedError{got: metadata.Rev, expected: expectedRev}
+	}
+	return nil
+}
+
+type remoteFileChangedError struct {
+	got      string
+	expected string
+}
+
+func (e *remoteFileChangedError) Error() string {
+	return fmt.Sprintf(
+		"remote file changed during retry: got rev %q, expected %q",
+		e.got,
+		e.expected,
+	)
+}
+
+func validatePartFile(partPath string, metadata *files.FileMetadata) error {
+	if metadata == nil {
+		return nil
+	}
+
+	stat, err := os.Stat(partPath)
+	if err != nil {
+		return err
+	}
+
+	if uint64(stat.Size()) != metadata.Size {
+		return fmt.Errorf(
+			"incomplete download: got %d bytes, expected %d",
+			stat.Size(),
+			metadata.Size,
+		)
+	}
+
+	if metadata.ContentHash == "" {
+		return nil
+	}
+
+	f, err := os.Open(partPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	hash, err := contenthash.Compute(f)
+	if err != nil {
+		return err
+	}
+	if hash != metadata.ContentHash {
+		return fmt.Errorf(
+			"content hash mismatch: got %q, expected %q",
+			hash,
+			metadata.ContentHash,
+		)
+	}
+	return nil
+}
+
+func partFileSize(partPath string) (int64, error) {
+	stat, err := os.Stat(partPath)
+	if err == nil {
+		return stat.Size(), nil
+	}
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+	return 0, err
+}
+
+func metadataSize(metadata *files.FileMetadata) int64 {
+	if metadata == nil {
+		return 0
+	}
+	return int64(metadata.Size)
+}

--- a/v6/dropbox/filedownload/downloader.go
+++ b/v6/dropbox/filedownload/downloader.go
@@ -215,6 +215,7 @@ func (d *Downloader) downloadFileParallel(
 	}
 	if err := f.Truncate(total); err != nil {
 		_ = f.Close()
+		_ = os.Remove(partPath)
 		return nil, err
 	}
 
@@ -226,10 +227,12 @@ func (d *Downloader) downloadFileParallel(
 		)
 		if err != nil {
 			_ = f.Close()
+			_ = os.Remove(partPath)
 			return nil, err
 		}
 		if n != 1 {
 			_ = f.Close()
+			_ = os.Remove(partPath)
 			return nil, fmt.Errorf(
 				"incomplete initial range: got %d bytes, expected 1",
 				n,

--- a/v6/dropbox/filedownload/downloader_test.go
+++ b/v6/dropbox/filedownload/downloader_test.go
@@ -1,0 +1,636 @@
+package filedownload
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/contenthash"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+type fakeClient struct {
+	download func(
+		context.Context,
+		*files.DownloadArg,
+	) (*files.FileMetadata, io.ReadCloser, error)
+}
+
+func (f *fakeClient) DownloadContext(
+	ctx context.Context,
+	arg *files.DownloadArg,
+) (*files.FileMetadata, io.ReadCloser, error) {
+	return f.download(ctx, arg)
+}
+
+type failingReader struct {
+	data []byte
+	err  error
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, r.err
+	}
+
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func testMetadata(size uint64) *files.FileMetadata {
+	return &files.FileMetadata{
+		Metadata: *files.NewMetadata("file.bin"),
+		Rev:      "rev1",
+		Size:     size,
+	}
+}
+
+func testMetadataWithRev(size uint64, rev string) *files.FileMetadata {
+	metadata := testMetadata(size)
+	metadata.Rev = rev
+	return metadata
+}
+
+func testMetadataWithHash(t *testing.T, payload string) *files.FileMetadata {
+	t.Helper()
+
+	hash, err := contenthash.Compute(strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metadata := testMetadata(uint64(len(payload)))
+	metadata.ContentHash = hash
+	return metadata
+}
+
+func TestDownloadFileResumesFromPartFile(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+
+	if err := os.WriteFile(partPath, []byte("hello "), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			if got := arg.ExtraHeaders["Range"]; got != "bytes=6-" {
+				t.Fatalf("Range header = %q, want %q", got, "bytes=6-")
+			}
+
+			return testMetadata(11), io.NopCloser(strings.NewReader("world")), nil
+		},
+	}
+
+	d := New(client)
+
+	result, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "hello world"; got != want {
+		t.Fatalf("file contents = %q, want %q", got, want)
+	}
+
+	if result.ResumedFrom != 6 {
+		t.Fatalf("ResumedFrom = %d, want 6", result.ResumedFrom)
+	}
+
+	if _, err := os.Stat(partPath); !os.IsNotExist(err) {
+		t.Fatalf("part file still exists: %v", err)
+	}
+}
+
+func TestDownloadFileFresh(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			if got := arg.ExtraHeaders["Range"]; got != "" {
+				t.Fatalf("Range header = %q, want empty", got)
+			}
+
+			return testMetadata(5),
+				io.NopCloser(strings.NewReader("hello")),
+				nil
+		},
+	}
+
+	d := New(client)
+
+	result, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "hello"; got != want {
+		t.Fatalf("file contents = %q, want %q", got, want)
+	}
+
+	if result.ResumedFrom != 0 {
+		t.Fatalf("ResumedFrom = %d, want 0", result.ResumedFrom)
+	}
+
+	if _, err := os.Stat(localPath + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("part file still exists: %v", err)
+	}
+}
+
+func TestDownloadFilePreservesPartFileOnReadError(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			return testMetadata(7),
+				io.NopCloser(&failingReader{
+					data: []byte("partial"),
+					err:  errors.New("connection reset"),
+				}),
+				nil
+		},
+	}
+
+	d := New(client)
+
+	_, err := d.downloadFileAttempt(
+		context.Background(),
+		"/file.bin",
+		localPath,
+		"",
+	)
+	if err == nil {
+		t.Fatal("DownloadFile() expected an error")
+	}
+
+	data, readErr := os.ReadFile(partPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+
+	if got, want := string(data), "partial"; got != want {
+		t.Fatalf("part file contents = %q, want %q", got, want)
+	}
+
+	if _, statErr := os.Stat(localPath); !os.IsNotExist(statErr) {
+		t.Fatalf("final file unexpectedly exists: %v", statErr)
+	}
+}
+
+func TestDownloadFileRetriesAndResumes(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+
+	calls := 0
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+
+			switch calls {
+			case 1:
+				if got := arg.ExtraHeaders["Range"]; got != "" {
+					t.Fatalf("first Range header = %q, want empty", got)
+				}
+
+				return testMetadata(11),
+					io.NopCloser(&failingReader{
+						data: []byte("hello "),
+						err:  errors.New("connection reset"),
+					}),
+					nil
+
+			case 2:
+				if got := arg.ExtraHeaders["Range"]; got != "bytes=6-" {
+					t.Fatalf("second Range header = %q, want %q", got, "bytes=6-")
+				}
+
+				return testMetadata(11),
+					io.NopCloser(strings.NewReader("world")),
+					nil
+
+			default:
+				t.Fatalf("unexpected download call %d", calls)
+				return nil, nil, nil
+			}
+		},
+	}
+
+	d := New(client)
+
+	result, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "hello world"; got != want {
+		t.Fatalf("file contents = %q, want %q", got, want)
+	}
+
+	if calls != 2 {
+		t.Fatalf("download calls = %d, want 2", calls)
+	}
+
+	if result.ResumedFrom != 6 {
+		t.Fatalf("ResumedFrom = %d, want 6", result.ResumedFrom)
+	}
+}
+
+func TestDownloadFileStopsOnContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+			cancel()
+
+			return nil, nil, ctx.Err()
+		},
+	}
+
+	d := New(client)
+
+	_, err := d.DownloadFile(ctx, "/file.bin", localPath)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DownloadFile() error = %v, want context.Canceled", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("download calls = %d, want 1", calls)
+	}
+}
+
+func TestDownloadFileStopsAfterMaxAttempts(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+
+	calls := 0
+	wantErr := errors.New("connection reset")
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+
+			return testMetadata(0),
+				io.NopCloser(&failingReader{
+					err: wantErr,
+				}),
+				nil
+		},
+	}
+
+	d := New(client)
+
+	_, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err == nil {
+		t.Fatal("DownloadFile() expected an error")
+	}
+
+	if calls != d.maxAttempts {
+		t.Fatalf(
+			"download calls = %d, want %d",
+			calls,
+			d.maxAttempts,
+		)
+	}
+}
+
+func TestDownloadFileStopsWhenRemoteFileChangesDuringRetry(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+
+	calls := 0
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			calls++
+
+			switch calls {
+			case 1:
+				return testMetadataWithRev(11, "rev1"),
+					io.NopCloser(&failingReader{
+						data: []byte("hello "),
+						err:  errors.New("connection reset"),
+					}),
+					nil
+			case 2:
+				return testMetadataWithRev(11, "rev2"),
+					io.NopCloser(strings.NewReader("world")),
+					nil
+			default:
+				t.Fatalf("unexpected download call %d", calls)
+				return nil, nil, nil
+			}
+		},
+	}
+
+	d := New(client)
+
+	_, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err == nil || !strings.Contains(err.Error(), "remote file changed") {
+		t.Fatalf("DownloadFile() error = %v, want remote changed error", err)
+	}
+
+	if _, statErr := os.Stat(partPath); !os.IsNotExist(statErr) {
+		t.Fatalf("part file still exists: %v", statErr)
+	}
+}
+
+func TestDownloadFileValidatesTotalSize(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			return testMetadata(10),
+				io.NopCloser(strings.NewReader("short")),
+				nil
+		},
+	}
+
+	d := New(client, WithMaxAttempts(1))
+
+	_, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err == nil || !strings.Contains(err.Error(), "incomplete download") {
+		t.Fatalf("DownloadFile() error = %v, want incomplete download error", err)
+	}
+	if _, statErr := os.Stat(partPath); !os.IsNotExist(statErr) {
+		t.Fatalf("part file still exists: %v", statErr)
+	}
+}
+
+func TestDownloadFileValidatesContentHash(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			metadata := testMetadata(5)
+			metadata.ContentHash = "not-the-right-hash"
+			return metadata, io.NopCloser(strings.NewReader("hello")), nil
+		},
+	}
+
+	d := New(client, WithMaxAttempts(1))
+
+	_, err := d.DownloadFile(
+		context.Background(),
+		"/file.bin",
+		localPath,
+	)
+	if err == nil || !strings.Contains(err.Error(), "content hash mismatch") {
+		t.Fatalf("DownloadFile() error = %v, want hash mismatch error", err)
+	}
+	if _, statErr := os.Stat(partPath); !os.IsNotExist(statErr) {
+		t.Fatalf("part file still exists: %v", statErr)
+	}
+}
+
+func TestDownloadFileAcceptsContentHash(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			return testMetadataWithHash(t, "hello"),
+				io.NopCloser(strings.NewReader("hello")),
+				nil
+		},
+	}
+
+	d := New(client)
+
+	if _, err := d.DownloadFile(context.Background(), "/file.bin", localPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDownloadFileReportsProgress(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	var updates []Progress
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			return testMetadata(11),
+				io.NopCloser(strings.NewReader("hello world")),
+				nil
+		},
+	}
+
+	d := New(client, WithProgress(func(progress Progress) {
+		updates = append(updates, progress)
+	}))
+
+	if _, err := d.DownloadFile(context.Background(), "/file.bin", localPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(updates) == 0 {
+		t.Fatal("progress callback was not called")
+	}
+
+	last := updates[len(updates)-1]
+	if last.BytesWritten != 11 || last.TotalBytes != 11 || last.ResumedFrom != 0 {
+		t.Fatalf("last progress = %+v, want 11/11 from 0", last)
+	}
+}
+
+func TestDownloadFileParallelDownloadsRanges(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	payload := "hello world"
+	var mu sync.Mutex
+	var ranges []string
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			header := arg.ExtraHeaders["Range"]
+			mu.Lock()
+			ranges = append(ranges, header)
+			mu.Unlock()
+
+			start, end := parseRangeHeader(t, header)
+			return testMetadataWithHash(t, payload),
+				io.NopCloser(strings.NewReader(payload[start : end+1])),
+				nil
+		},
+	}
+
+	d := New(client, WithParallelDownloads(3))
+
+	if _, err := d.DownloadFile(context.Background(), "/file.bin", localPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != payload {
+		t.Fatalf("file contents = %q, want %q", got, payload)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Strings(ranges)
+	wantRanges := []string{
+		"bytes=0-0",
+		"bytes=1-4",
+		"bytes=5-7",
+		"bytes=8-10",
+	}
+	sort.Strings(wantRanges)
+	if strings.Join(ranges, ",") != strings.Join(wantRanges, ",") {
+		t.Fatalf("ranges = %v, want %v", ranges, wantRanges)
+	}
+}
+
+func TestDownloadFileParallelRemovesPartFileOnRangeError(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "file.bin")
+	partPath := localPath + ".part"
+	payload := "hello world"
+
+	client := &fakeClient{
+		download: func(
+			ctx context.Context,
+			arg *files.DownloadArg,
+		) (*files.FileMetadata, io.ReadCloser, error) {
+			header := arg.ExtraHeaders["Range"]
+			if header == "bytes=0-0" {
+				return testMetadataWithHash(t, payload),
+					io.NopCloser(strings.NewReader(payload[:1])),
+					nil
+			}
+			return nil, nil, errors.New("range failed")
+		},
+	}
+
+	d := New(client, WithMaxAttempts(1), WithParallelDownloads(3))
+
+	_, err := d.DownloadFile(context.Background(), "/file.bin", localPath)
+	if err == nil {
+		t.Fatal("DownloadFile() expected an error")
+	}
+
+	if _, statErr := os.Stat(partPath); !os.IsNotExist(statErr) {
+		t.Fatalf("part file still exists: %v", statErr)
+	}
+}
+
+func parseRangeHeader(t *testing.T, header string) (int, int) {
+	t.Helper()
+
+	const prefix = "bytes="
+	if !strings.HasPrefix(header, prefix) {
+		t.Fatalf("Range header = %q, want bytes range", header)
+	}
+
+	parts := strings.Split(strings.TrimPrefix(header, prefix), "-")
+	if len(parts) != 2 {
+		t.Fatalf("Range header = %q, want start-end", header)
+	}
+
+	start, err := strconv.Atoi(parts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	end, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return start, end
+}

--- a/v6/dropbox/integration/downloader_test.go
+++ b/v6/dropbox/integration/downloader_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) Dropbox, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/filedownload"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+)
+
+func TestUserDownloadFile(t *testing.T) {
+	ctx := context.Background()
+	client := files.NewContext(userConfig(t))
+	remotePath := fmt.Sprintf("/sdk-integration-download-%d.txt", time.Now().UnixNano())
+	payload := "hello from the filedownload integration test\n"
+	uploadIntegrationFile(t, ctx, client, remotePath, payload)
+	defer deleteIntegrationPath(t, client, remotePath)
+
+	localPath := filepath.Join(t.TempDir(), "download.txt")
+	result, err := filedownload.New(client).DownloadFile(ctx, remotePath, localPath)
+	if err != nil {
+		t.Fatalf("DownloadFile(%q): %v", remotePath, err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != payload {
+		t.Fatalf("downloaded content = %q, want %q", got, payload)
+	}
+	if result.Metadata == nil {
+		t.Fatal("DownloadFile() metadata is nil")
+	}
+	if result.Metadata.PathDisplay != remotePath {
+		t.Fatalf("metadata path = %q, want %q", result.Metadata.PathDisplay, remotePath)
+	}
+	if result.Metadata.Size != uint64(len(payload)) {
+		t.Fatalf("metadata size = %d, want %d", result.Metadata.Size, len(payload))
+	}
+}
+
+func TestUserDownloadFileResumesFromPartFile(t *testing.T) {
+	ctx := context.Background()
+	client := files.NewContext(userConfig(t))
+	remotePath := fmt.Sprintf("/sdk-integration-download-resume-%d.txt", time.Now().UnixNano())
+	prefix := "already downloaded "
+	suffix := "and fetched with a range request\n"
+	payload := prefix + suffix
+	uploadIntegrationFile(t, ctx, client, remotePath, payload)
+	defer deleteIntegrationPath(t, client, remotePath)
+
+	localPath := filepath.Join(t.TempDir(), "download.txt")
+	if err := os.WriteFile(localPath+".part", []byte(prefix), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := filedownload.New(client).DownloadFile(ctx, remotePath, localPath)
+	if err != nil {
+		t.Fatalf("DownloadFile(%q): %v", remotePath, err)
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != payload {
+		t.Fatalf("downloaded content = %q, want %q", got, payload)
+	}
+	if result.ResumedFrom != int64(len(prefix)) {
+		t.Fatalf("ResumedFrom = %d, want %d", result.ResumedFrom, len(prefix))
+	}
+	if _, err := os.Stat(localPath + ".part"); !os.IsNotExist(err) {
+		t.Fatalf("part file still exists: %v", err)
+	}
+}
+
+func uploadIntegrationFile(
+	t *testing.T,
+	ctx context.Context,
+	client files.ContextClient,
+	path string,
+	payload string,
+) {
+	t.Helper()
+
+	arg := files.NewUploadArg(path)
+	if _, err := client.UploadContext(ctx, arg, strings.NewReader(payload)); err != nil {
+		t.Fatalf("UploadContext(%q): %v", path, err)
+	}
+}
+
+func deleteIntegrationPath(t *testing.T, client files.Client, path string) {
+	t.Helper()
+
+	if _, err := client.DeleteV2(files.NewDeleteArg(path)); err != nil {
+		t.Errorf("cleanup DeleteV2(%q): %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `dropbox/filedownload` helper for resumable local file downloads.
- Support retry resume from `.part` files with range requests.
- Add size validation, Dropbox `content_hash` verification, progress callbacks, and opt-in parallel ranged downloads.
- Add unit, race, README, and live integration coverage for downloader behavior.
