### PR TITLE
fix filetransfer downloader retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ summarized from the repository history.
   (folder create/delete round-trips) authenticated with scoped refresh tokens,
   plus an Integration GitHub Actions workflow.
 
+### Fixed
+
+- Retried all network errors during `dropbox/filetransfer` downloads and
+  honored rate-limit `retry_after` delays.
+
 ### Removed
 
 - Removed the earlier `dropbox/filedownload` helper in favor of

--- a/v6/dropbox/filetransfer/download.go
+++ b/v6/dropbox/filetransfer/download.go
@@ -197,14 +197,14 @@ func (d *Downloader) downloadSequential(
 				return fail(err)
 			}
 			lastErr = err
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, err); err != nil {
 				return fail(err)
 			}
 			continue
 		}
 		if body == nil {
 			lastErr = errors.New("download response body is nil")
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, lastErr); err != nil {
 				return fail(err)
 			}
 			continue
@@ -256,7 +256,7 @@ func (d *Downloader) downloadSequential(
 			if !retryable {
 				return fail(copyErr)
 			}
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, copyErr); err != nil {
 				return fail(err)
 			}
 			continue
@@ -267,7 +267,7 @@ func (d *Downloader) downloadSequential(
 				committed,
 				info.Size,
 			)
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, lastErr); err != nil {
 				return fail(err)
 			}
 			continue
@@ -393,14 +393,14 @@ func (d *Downloader) prepareParallelDownload(
 				return nil, DownloadInfo{}, 0, err
 			}
 			lastErr = err
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, err); err != nil {
 				return nil, DownloadInfo{}, 0, err
 			}
 			continue
 		}
 		if body == nil {
 			lastErr = errors.New("download response body is nil")
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, lastErr); err != nil {
 				return nil, DownloadInfo{}, 0, err
 			}
 			continue
@@ -447,7 +447,7 @@ func (d *Downloader) prepareParallelDownload(
 			return nil, DownloadInfo{}, 0, copyErr
 		}
 		lastErr = copyErr
-		if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+		if err := waitForRetry(ctx, attempt, maxAttempts, copyErr); err != nil {
 			return nil, DownloadInfo{}, 0, err
 		}
 	}
@@ -496,14 +496,14 @@ func (d *Downloader) downloadRange(
 				return err
 			}
 			lastErr = err
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, err); err != nil {
 				return err
 			}
 			continue
 		}
 		if body == nil {
 			lastErr = errors.New("download response body is nil")
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, lastErr); err != nil {
 				return err
 			}
 			continue
@@ -537,7 +537,7 @@ func (d *Downloader) downloadRange(
 			return copyErr
 		}
 		lastErr = copyErr
-		if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+		if err := waitForRetry(ctx, attempt, maxAttempts, copyErr); err != nil {
 			return err
 		}
 	}

--- a/v6/dropbox/filetransfer/download_test.go
+++ b/v6/dropbox/filetransfer/download_test.go
@@ -87,6 +87,57 @@ func TestDownloadSequentialRetriesFromCommittedOffset(t *testing.T) {
 	assertDownloadProgress(t, updates, int64(len(data)))
 }
 
+func TestDownloadRetriesNonTimeoutNetworkError(t *testing.T) {
+	data := []byte("retry network error")
+	client := &fakeDownloadClient{
+		data:                data,
+		metadata:            fileMetadata(data),
+		failFirstRequestErr: networkError{},
+	}
+	target := Bytes()
+
+	_, err := NewDownloader(client).Download(
+		context.Background(),
+		"/retry-network-error.bin",
+		target,
+		DownloadOptions{MaxAttempts: 2},
+	)
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if client.calls != 2 {
+		t.Fatalf("download calls = %d, want 2", client.calls)
+	}
+	if got := target.Bytes(); !bytes.Equal(got, data) {
+		t.Fatalf("downloaded bytes = %q, want %q", got, data)
+	}
+}
+
+func TestDownloadRetryStopsWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &fakeDownloadClient{
+		data:        []byte("unused"),
+		metadata:    fileMetadata([]byte("unused")),
+		apiErr:      networkError{},
+		onFirstCall: cancel,
+	}
+
+	_, err := NewDownloader(client).Download(
+		ctx,
+		"/canceled-retry.bin",
+		Bytes(),
+		DownloadOptions{MaxAttempts: 3},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Download() error = %v, want context.Canceled", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("download calls = %d, want 1", client.calls)
+	}
+}
+
 func TestDownloadDoesNotRetryPermanentAPIError(t *testing.T) {
 	client := &fakeDownloadClient{
 		data:     []byte("unused"),
@@ -287,10 +338,12 @@ type fakeDownloadClient struct {
 	metadata *files.FileMetadata
 	ranges   []string
 
-	failFirstAt  int
-	failFirstErr error
-	apiErr       error
-	calls        int
+	failFirstAt         int
+	failFirstErr        error
+	failFirstRequestErr error
+	apiErr              error
+	onFirstCall         func()
+	calls               int
 }
 
 func (c *fakeDownloadClient) DownloadContext(
@@ -301,11 +354,17 @@ func (c *fakeDownloadClient) DownloadContext(
 	defer c.mu.Unlock()
 
 	c.calls++
+	if c.calls == 1 && c.onFirstCall != nil {
+		c.onFirstCall()
+	}
 	rangeHeader := ""
 	if arg != nil && arg.ExtraHeaders != nil {
 		rangeHeader = arg.ExtraHeaders["Range"]
 	}
 	c.ranges = append(c.ranges, rangeHeader)
+	if c.calls == 1 && c.failFirstRequestErr != nil {
+		return nil, nil, c.failFirstRequestErr
+	}
 	if c.apiErr != nil {
 		return nil, nil, c.apiErr
 	}

--- a/v6/dropbox/filetransfer/retry.go
+++ b/v6/dropbox/filetransfer/retry.go
@@ -23,17 +23,13 @@ func waitForRetry(
 	ctx context.Context,
 	attempt int,
 	maxAttempts int,
-	retryErr ...error,
+	retryErr error,
 ) error {
 	if attempt+1 >= maxAttempts {
 		return nil
 	}
 
-	var err error
-	if len(retryErr) > 0 {
-		err = retryErr[0]
-	}
-	delay := retryDelay(err, attempt)
+	delay := retryDelay(retryErr, attempt)
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 

--- a/v6/dropbox/filetransfer/retry.go
+++ b/v6/dropbox/filetransfer/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"math/rand/v2"
 	"net"
 	"time"
@@ -22,9 +23,36 @@ func waitForRetry(
 	ctx context.Context,
 	attempt int,
 	maxAttempts int,
+	retryErr ...error,
 ) error {
 	if attempt+1 >= maxAttempts {
 		return nil
+	}
+
+	var err error
+	if len(retryErr) > 0 {
+		err = retryErr[0]
+	}
+	delay := retryDelay(err, attempt)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func retryDelay(err error, attempt int) time.Duration {
+	if rateLimitErr := rateLimitTransferError(err); rateLimitErr != nil &&
+		rateLimitErr.RateLimitError != nil {
+		retryAfter := rateLimitErr.RateLimitError.RetryAfter
+		if retryAfter > uint64(math.MaxInt64/int64(time.Second)) {
+			return time.Duration(math.MaxInt64)
+		}
+		return time.Duration(retryAfter) * time.Second
 	}
 
 	delay := retryBaseDelay
@@ -38,15 +66,21 @@ func waitForRetry(
 	half := delay / 2
 	delay = half + time.Duration(rand.Int64N(int64(half)+1))
 
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
+	return delay
+}
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
+func rateLimitTransferError(err error) *auth.RateLimitAPIError {
+	var rateLimitErr auth.RateLimitAPIError
+	if errors.As(err, &rateLimitErr) {
+		return &rateLimitErr
 	}
+
+	var rateLimitErrPtr *auth.RateLimitAPIError
+	if errors.As(err, &rateLimitErrPtr) {
+		return rateLimitErrPtr
+	}
+
+	return nil
 }
 
 func isRetryableTransferError(err error) bool {
@@ -63,7 +97,7 @@ func isRetryableTransferError(err error) bool {
 	}
 
 	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
+	if errors.As(err, &netErr) {
 		return true
 	}
 
@@ -71,8 +105,7 @@ func isRetryableTransferError(err error) bool {
 	if errors.As(err, &serverErr) {
 		return true
 	}
-	var rateLimitErr auth.RateLimitAPIError
-	if errors.As(err, &rateLimitErr) {
+	if rateLimitTransferError(err) != nil {
 		return true
 	}
 	var internalErr dropbox.SDKInternalError

--- a/v6/dropbox/filetransfer/retry_test.go
+++ b/v6/dropbox/filetransfer/retry_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/auth"
 )
 
 func TestIsRetryableTransferError(t *testing.T) {
@@ -43,6 +45,11 @@ func TestIsRetryableTransferError(t *testing.T) {
 		{
 			name: "network timeout",
 			err:  timeoutError{},
+			want: true,
+		},
+		{
+			name: "network non-timeout",
+			err:  networkError{},
 			want: true,
 		},
 		{
@@ -104,7 +111,7 @@ func TestWaitForRetryLastAttempt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := waitForRetry(ctx, 2, 3); err != nil {
+	if err := waitForRetry(ctx, 2, 3, nil); err != nil {
 		t.Fatalf("waitForRetry() error = %v", err)
 	}
 }
@@ -113,12 +120,56 @@ func TestWaitForRetryCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := waitForRetry(ctx, 0, 3)
+	err := waitForRetry(ctx, 0, 3, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf(
 			"waitForRetry() error = %v, want context.Canceled",
 			err,
 		)
+	}
+}
+
+func TestRetryDelayUsesRateLimitRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "value",
+			err: auth.RateLimitAPIError{
+				RateLimitError: &auth.RateLimitError{RetryAfter: 7},
+			},
+		},
+		{
+			name: "pointer",
+			err: &auth.RateLimitAPIError{
+				RateLimitError: &auth.RateLimitError{RetryAfter: 7},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isRetryableTransferError(tt.err) {
+				t.Fatal("isRetryableTransferError() = false, want true")
+			}
+			if got, want := retryDelay(tt.err, 0), 7*time.Second; got != want {
+				t.Fatalf("retryDelay() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestRetryDelayUsesJitteredExponentialBackoff(t *testing.T) {
+	for attempt, maximum := range map[int]time.Duration{
+		0: retryBaseDelay,
+		1: retryBaseDelay * 2,
+		2: retryBaseDelay * 4,
+	} {
+		delay := retryDelay(errors.New("temporary failure"), attempt)
+		if delay < maximum/2 || delay > maximum {
+			t.Fatalf("retryDelay(attempt %d) = %v, want between %v and %v", attempt, delay, maximum/2, maximum)
+		}
 	}
 }
 
@@ -135,3 +186,9 @@ func (timeoutError) Timeout() bool {
 func (timeoutError) Temporary() bool {
 	return false
 }
+
+type networkError struct{}
+
+func (networkError) Error() string   { return "network error" }
+func (networkError) Timeout() bool   { return false }
+func (networkError) Temporary() bool { return false }

--- a/v6/dropbox/filetransfer/upload.go
+++ b/v6/dropbox/filetransfer/upload.go
@@ -185,7 +185,7 @@ func (u *Uploader) startUploadSessionWithRetry(
 		}
 
 		lastErr = err
-		if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+		if err := waitForRetry(ctx, attempt, maxAttempts, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -488,7 +488,7 @@ func (u *Uploader) appendUploadWithRetry(
 					return nil
 				case offset:
 					lastErr = err
-					if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+					if err := waitForRetry(ctx, attempt, maxAttempts, nil); err != nil {
 						return err
 					}
 					continue
@@ -505,7 +505,7 @@ func (u *Uploader) appendUploadWithRetry(
 				return err
 			}
 			lastErr = err
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, nil); err != nil {
 				return err
 			}
 			continue
@@ -557,7 +557,7 @@ func (u *Uploader) finishUploadWithRetry(
 					)
 				}
 				lastErr = err
-				if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+				if err := waitForRetry(ctx, attempt, maxAttempts, nil); err != nil {
 					return nil, err
 				}
 				continue
@@ -566,7 +566,7 @@ func (u *Uploader) finishUploadWithRetry(
 				return nil, err
 			}
 			lastErr = err
-			if err := waitForRetry(ctx, attempt, maxAttempts); err != nil {
+			if err := waitForRetry(ctx, attempt, maxAttempts, nil); err != nil {
 				return nil, err
 			}
 			continue


### PR DESCRIPTION
## Summary

- retry all network errors encountered by filetransfer downloads
- honor Dropbox rate-limit RetryAfter values for downloader retries
- preserve exponential backoff, jitter, context cancellation, and ranged resume behavior

## Root cause

The downloader retried only timeout-classified network errors and ignored rate-limit retry delays.
